### PR TITLE
change: remove STUB_LOG_ENABLE macro from the library usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,30 @@
+if(NOT DEFINED ESP_TARGET)
+    message(FATAL_ERROR "ESP_TARGET not defined. Please specify -DESP_TARGET=<target>")
+endif()
+
+if(NOT ESP_STUB_LIB)
+    set(ESP_STUB_LIB esp-stub-lib)
+endif()
+
+if(NOT ESP_TARGET_LIB)
+    set(ESP_TARGET_LIB ${ESP_TARGET})
+endif()
 
 set(srcs
     src/log.c
     src/flash.c
 )
 
-add_library(esp-stub-lib STATIC ${srcs})
+add_library(${ESP_STUB_LIB} STATIC ${srcs})
 
-target_include_directories(esp-stub-lib
+target_include_directories(${ESP_STUB_LIB}
     PUBLIC include
     PRIVATE include/esp-stub-lib
 )
 
-add_subdirectory(src/${ESP_TARGET})
+# STUB_COMPILE_DEFS is optional definitions coming from the parent CMakeLists.txt
+target_compile_definitions(${ESP_STUB_LIB} PRIVATE ${STUB_COMPILE_DEFS})
 
-target_link_libraries(esp-stub-lib PUBLIC ${ESP_TARGET})
+add_subdirectory(src/${ESP_TARGET} ${ESP_TARGET_LIB})
+
+target_link_libraries(${ESP_STUB_LIB} PUBLIC ${ESP_TARGET_LIB})

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -38,7 +38,7 @@ if(${ESP_TARGET} STREQUAL "esp8266")
     target_link_options(${PROJECT_NAME} PRIVATE -Wl,--entry=stub_main_esp8266)
 endif()
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE asm=__asm__ STUB_LOG_ENABLE)
+target_compile_definitions(${PROJECT_NAME} PRIVATE asm=__asm__ STUB_LOG_ENABLED)
 
 set(MAP_FILE ${CMAKE_CURRENT_BINARY_DIR}/${APP_NAME}.map)
 target_link_options(${PROJECT_NAME} PRIVATE -Wl,-Map=${MAP_FILE})

--- a/example/stub_main.c
+++ b/example/stub_main.c
@@ -22,11 +22,24 @@ struct stub_cmd_handler {
     int (*handler)(va_list ap);
 };
 
+#ifdef STUB_LOG_ENABLED
+#define STUB_LOG_INIT(uart_num, baudrate) stub_lib_log_init(uart_num, baudrate)
+#define STUB_LOG(fmt, ...) stub_lib_log_printf(fmt, ##__VA_ARGS__)
+#else
+#define STUB_LOG_INIT(uart_num, baudrate)
+#define STUB_LOG(fmt, ...)
+#endif
+
 static  __attribute__((unused)) int handle_test1(va_list ap)
 {
     (void)ap;
 
-    STUB_LIB_LOG("test1\n");
+    STUB_LOG("stub command test:%d\n", 1);
+    STUB_LOG("stub command test:%d\n", -1);
+    STUB_LOG("stub command test:0x%x\n", 0x4080393C);
+    STUB_LOG("stub command test:%s\n", "test");
+    STUB_LOG("stub command test:%c\n", 'A');
+    STUB_LOG("stub command test:%l\n", 10); // not supported
 
     return 0;
 }
@@ -35,7 +48,7 @@ static  __attribute__((unused)) int handle_test2(va_list ap)
 {
     (void)ap;
 
-    STUB_LIB_LOG("test2\n");
+    STUB_LOG("test2\n");
 
     return 0;
 }
@@ -71,14 +84,14 @@ int stub_main(int cmd, ...)
 
     va_start(ap, cmd);
 
-    stub_lib_log_init(0, 115200);
+    STUB_LOG_INIT(0, 115200);
 
     stub_lib_flash_init(&flash_state);
 
     const struct stub_cmd_handler *handler = cmd_handlers;
     while (handler->handler) {
         if (handler->cmd == cmd) {
-            STUB_LIB_LOG("Executing command: %s\n", handler->name);
+            STUB_LOG("Executing command: %s\n", handler->name);
             ret = handler->handler(ap);
             break;
         }
@@ -86,7 +99,7 @@ int stub_main(int cmd, ...)
     }
 
     if (!handler->handler) {
-        STUB_LIB_LOG("Unknown command!\n");
+        STUB_LOG("Unknown command!\n");
     }
 
     va_end(ap);

--- a/src/esp32/CMakeLists.txt
+++ b/src/esp32/CMakeLists.txt
@@ -4,11 +4,11 @@ set(srcs
     src/flash.c
 )
 
-add_library(${ESP_TARGET} STATIC ${srcs})
+add_library(${ESP_TARGET_LIB} STATIC ${srcs})
 
-target_include_directories(${ESP_TARGET}
+target_include_directories(${ESP_TARGET_LIB}
     PUBLIC include
     PRIVATE include/target
 )
 
-target_link_options(${ESP_TARGET} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32.rom.ld)
+target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32.rom.ld)

--- a/src/esp32/include/target/esp_rom_caps.h
+++ b/src/esp32/include/target/esp_rom_caps.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define ESP_ROM_HAS_CRC_LE              (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE              (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_HAS_MZ_CRC32            (1) // ROM has mz_crc32 function
+#define ESP_ROM_HAS_JPEG_DECODE         (1) // ROM has JPEG decode library
+#define ESP_ROM_HAS_UART_BUF_SWITCH     (1) // ROM has exported the uart buffer switch function
+#define ESP_ROM_NEEDS_SWSETUP_WORKAROUND    (1) // ROM uses 32-bit time_t. A workaround is required to prevent printf functions from crashing
+#define ESP_ROM_HAS_NEWLIB              (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT  (1) // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_HAS_NEWLIB_32BIT_TIME   (1) // ROM was compiled with 32 bit time_t
+#define ESP_ROM_HAS_SW_FLOAT            (1) // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (-1) // No USB_SERIAL_JTAG in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC    (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)

--- a/src/esp32c2/CMakeLists.txt
+++ b/src/esp32c2/CMakeLists.txt
@@ -3,11 +3,11 @@ set(srcs
     src/flash.c
 )
 
-add_library(${ESP_TARGET} STATIC ${srcs})
+add_library(${ESP_TARGET_LIB} STATIC ${srcs})
 
-target_include_directories(${ESP_TARGET}
+target_include_directories(${ESP_TARGET_LIB}
     PUBLIC include
     PRIVATE include/target
 )
 
-target_link_options(${ESP_TARGET} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c2.rom.ld)
+target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c2.rom.ld)

--- a/src/esp32c2/include/target/esp_rom_caps.h
+++ b/src/esp32c2/include/target/esp_rom_caps.h
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_RVFPLIB                 (1) // ROM has the rvfplib
+#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER            (1) // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_HAS_HEAP_TLSF               (1) // ROM has the implementation of the tlsf and multi-heap library
+#define ESP_ROM_TLSF_CHECK_PATCH            (1) // ROM does not contain the patch of tlsf_check_pool()
+#define ESP_ROM_MULTI_HEAP_WALK_PATCH       (1) // ROM does not contain the patch of multi_heap_walk()
+#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_MBEDTLS_CRYPTO_LIB      (1) // ROM has the mbedtls crypto algorithm lib
+#define ESP_ROM_HAS_SW_FLOAT                (1) // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (-1) // No USB_SERIAL_JTAG in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
+#define ESP_ROM_HAS_VPRINTF_FUNC            (1) // ROM has ets_vprintf
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_CONSOLE_OUTPUT_SECONDARY    (1) // The console output functions will also output to the USB-serial secondary console
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.

--- a/src/esp32c3/CMakeLists.txt
+++ b/src/esp32c3/CMakeLists.txt
@@ -3,11 +3,11 @@ set(srcs
     src/flash.c
 )
 
-add_library(${ESP_TARGET} STATIC ${srcs})
+add_library(${ESP_TARGET_LIB} STATIC ${srcs})
 
-target_include_directories(${ESP_TARGET}
+target_include_directories(${ESP_TARGET_LIB}
     PUBLIC include
     PRIVATE include/target
 )
 
-target_link_options(${ESP_TARGET} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c3.rom.ld)
+target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c3.rom.ld)

--- a/src/esp32c3/include/target/esp_rom_caps.h
+++ b/src/esp32c3/include/target/esp_rom_caps.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_HAS_MZ_CRC32                (1) // ROM has mz_crc32 function
+#define ESP_ROM_HAS_JPEG_DECODE             (1) // ROM has JPEG decode library
+#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (3) // UART uses USB_SERIAL_JTAG port in ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
+#define ESP_ROM_HAS_ERASE_0_REGION_BUG      (1) // ROM has esp_flash_erase_region(size=0) bug
+#define ESP_ROM_HAS_ENCRYPTED_WRITES_USING_LEGACY_DRV     (1) // `esp_flash_write_encrypted` in ROM has bug.
+#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_NEEDS_SWSETUP_WORKAROUND    (1) // ROM uses 32-bit time_t. A workaround is required to prevent printf functions from crashing
+#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_HAS_ETS_PRINTF_BUG          (1) // ROM has ets_printf bug when disable the ROM log either by eFuse or RTC storage register
+#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_HAS_NEWLIB_32BIT_TIME       (1) // ROM was compiled with 32 bit time_t
+#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_SW_FLOAT                (1) // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
+#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
+#define ESP_ROM_CONSOLE_OUTPUT_SECONDARY    (1) // The console output functions will also output to the USB-serial secondary console
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.

--- a/src/esp32c5/CMakeLists.txt
+++ b/src/esp32c5/CMakeLists.txt
@@ -3,11 +3,11 @@ set(srcs
     src/flash.c
 )
 
-add_library(${ESP_TARGET} STATIC ${srcs})
+add_library(${ESP_TARGET_LIB} STATIC ${srcs})
 
-target_include_directories(${ESP_TARGET}
+target_include_directories(${ESP_TARGET_LIB}
     PUBLIC include
     PRIVATE include/target
 )
 
-target_link_options(${ESP_TARGET} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c5.rom.ld)
+target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c5.rom.ld)

--- a/src/esp32c5/include/target/esp_rom_caps.h
+++ b/src/esp32c5/include/target/esp_rom_caps.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_HAS_JPEG_DECODE             (1) // ROM has JPEG decode library
+#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (3) // UART uses USB_SERIAL_JTAG port in ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_RVFPLIB                 (1) // ROM has the rvfplib
+#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER            (1) // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_HAS_HEAP_TLSF               (1) // ROM has the implementation of the tlsf and multi-heap library
+#define ESP_ROM_TLSF_CHECK_PATCH            (1) // ROM does not contain the patch of tlsf_check_pool()
+#define ESP_ROM_MULTI_HEAP_WALK_PATCH       (1) // ROM does not contain the patch of multi_heap_walk()
+#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_WITHOUT_REGI2C              (1) // ROM has no regi2c APIs       TODO: IDF-10110 need refactor
+#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NORMAL_FORMAT    (1) // ROM has the newlib normal/full version of formatting functions (as opposed to the nano versions)
+#define ESP_ROM_WDT_INIT_PATCH              (1) // ROM version does not configure the clock
+#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
+#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
+#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_CLIC_INT_THRESH_PATCH       (1) // ROM version of esprv_intc_int_set_threshold incorrectly assumes lowest MINTTHRESH is 0x1F, should be 0xF
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.

--- a/src/esp32c6/CMakeLists.txt
+++ b/src/esp32c6/CMakeLists.txt
@@ -3,11 +3,11 @@ set(srcs
     src/flash.c
 )
 
-add_library(${ESP_TARGET} STATIC ${srcs})
+add_library(${ESP_TARGET_LIB} STATIC ${srcs})
 
-target_include_directories(${ESP_TARGET}
+target_include_directories(${ESP_TARGET_LIB}
     PUBLIC include
     PRIVATE include/target
 )
 
-target_link_options(${ESP_TARGET} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c6.rom.ld)
+target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c6.rom.ld)

--- a/src/esp32c6/include/target/esp_rom_caps.h
+++ b/src/esp32c6/include/target/esp_rom_caps.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_HAS_JPEG_DECODE             (1) // ROM has JPEG decode library
+#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (3) // UART uses USB_SERIAL_JTAG port in ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_RVFPLIB                 (1) // ROM has the rvfplib
+#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER            (1) // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_HAS_HEAP_TLSF               (1) // ROM has the implementation of the tlsf and multi-heap library
+#define ESP_ROM_TLSF_CHECK_PATCH            (1) // ROM does not contain the patch of tlsf_check_pool()
+#define ESP_ROM_MULTI_HEAP_WALK_PATCH       (1) // ROM does not contain the patch of multi_heap_walk()
+#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_HAS_REGI2C_BUG              (1) // ROM has the regi2c bug
+#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NORMAL_FORMAT    (1) // ROM has the newlib normal/full version of formatting functions (as opposed to the nano versions)
+#define ESP_ROM_REV0_HAS_NO_ECDSA_INTERFACE (1) // ECO 0 does not have ets_ecdsa_verify symbol, future revision will have it
+#define ESP_ROM_WDT_INIT_PATCH              (1) // ROM version does not configure the clock
+#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_SW_FLOAT                (1) // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
+#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_NO_USB_SERIAL_OUTPUT_API    (1) // ROM does not export the usb-serial-jtag write char function
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.

--- a/src/esp32c61/CMakeLists.txt
+++ b/src/esp32c61/CMakeLists.txt
@@ -3,11 +3,11 @@ set(srcs
     src/flash.c
 )
 
-add_library(${ESP_TARGET} STATIC ${srcs})
+add_library(${ESP_TARGET_LIB} STATIC ${srcs})
 
-target_include_directories(${ESP_TARGET}
+target_include_directories(${ESP_TARGET_LIB}
     PUBLIC include
     PRIVATE include/target
 )
 
-target_link_options(${ESP_TARGET} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c61.rom.ld)
+target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c61.rom.ld)

--- a/src/esp32c61/include/target/esp_rom_caps.h
+++ b/src/esp32c61/include/target/esp_rom_caps.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_HAS_JPEG_DECODE             (1) // ROM has JPEG decode library
+#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (3) // UART uses USB_SERIAL_JTAG port in ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_RVFPLIB                 (1) // ROM has the rvfplib
+#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER            (1) // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_HAS_HEAP_TLSF               (1) // ROM has the implementation of the tlsf and multi-heap library
+#define ESP_ROM_TLSF_CHECK_PATCH            (1) // ROM does not contain the patch of tlsf_check_pool()
+#define ESP_ROM_MULTI_HEAP_WALK_PATCH       (1) // ROM does not contain the patch of multi_heap_walk()
+#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_WITHOUT_REGI2C              (1) // ROM has no regi2c APIs       TODO: IDF-10110 need refactor
+#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_HAS_NEWLIB_NANO_PRINTF_FLOAT_BUG  (1) // ROM has the printf float bug with newlib nano version
+#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
+#define ESP_ROM_WDT_INIT_PATCH              (1) // ROM version does not configure the clock
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_SW_FLOAT                (1) // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_CACHE_WB_INVLD_LOW_RANGE    (1) // ROM `Cache_WriteBack_Addr` and `Cache_Invalidate_Addr` can only access low vaddr parts
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.

--- a/src/esp32h2/CMakeLists.txt
+++ b/src/esp32h2/CMakeLists.txt
@@ -3,11 +3,11 @@ set(srcs
     src/flash.c
 )
 
-add_library(${ESP_TARGET} STATIC ${srcs})
+add_library(${ESP_TARGET_LIB} STATIC ${srcs})
 
-target_include_directories(${ESP_TARGET}
+target_include_directories(${ESP_TARGET_LIB}
     PUBLIC include
     PRIVATE include/target
 )
 
-target_link_options(${ESP_TARGET} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32h2.rom.ld)
+target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32h2.rom.ld)

--- a/src/esp32h2/include/target/esp_rom_caps.h
+++ b/src/esp32h2/include/target/esp_rom_caps.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (3) // UART uses USB_SERIAL_JTAG port in ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER            (1) // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_HAS_HEAP_TLSF               (1) // ROM has the implementation of the tlsf and multi-heap library
+#define ESP_ROM_TLSF_CHECK_PATCH            (1) // ROM does not contain the patch of tlsf_check_pool()
+#define ESP_ROM_MULTI_HEAP_WALK_PATCH       (1) // ROM does not contain the patch of multi_heap_walk()
+#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_WITHOUT_REGI2C              (1) // ROM has no regi2c APIs
+#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano versions of formatting functions
+#define ESP_ROM_HAS_NEWLIB_NANO_PRINTF_FLOAT_BUG  (1) // ROM has the printf float bug with newlib nano version
+#define ESP_ROM_WDT_INIT_PATCH              (1) // ROM version does not configure the clock
+#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_SW_FLOAT                (1) // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
+#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_NO_USB_SERIAL_OUTPUT_API    (1) // ROM does not export the usb-serial-jtag write char function
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.

--- a/src/esp32p4/CMakeLists.txt
+++ b/src/esp32p4/CMakeLists.txt
@@ -3,11 +3,11 @@ set(srcs
     src/flash.c
 )
 
-add_library(${ESP_TARGET} STATIC ${srcs})
+add_library(${ESP_TARGET_LIB} STATIC ${srcs})
 
-target_include_directories(${ESP_TARGET}
+target_include_directories(${ESP_TARGET_LIB}
     PUBLIC include
     PRIVATE include/target
 )
 
-target_link_options(${ESP_TARGET} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32p4.rom.ld)
+target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32p4.rom.ld)

--- a/src/esp32p4/include/target/esp_rom_caps.h
+++ b/src/esp32p4/include/target/esp_rom_caps.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (6) // The serial port ID (UART, USB, ...) of USB_SERIAL_JTAG in the ROM.
+#define ESP_ROM_USB_OTG_NUM                 (5) // The serial port ID (UART, USB, ...) of USB_OTG_CDC in the ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_RVFPLIB                 (1) // ROM has the rvfplib
+#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER            (1) // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
+#define ESP_ROM_WDT_INIT_PATCH              (1) // ROM version does not configure the clock
+#define ESP_ROM_HAS_LP_ROM                  (1) // ROM also has a LP ROM placed in LP memory
+#define ESP_ROM_WITHOUT_REGI2C              (1) // ROM has no regi2c APIs
+#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_HAS_NEWLIB_NANO_PRINTF_FLOAT_BUG  (1) // ROM has the printf float bug with newlib nano version
+#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
+#define ESP_ROM_CLIC_INT_TYPE_PATCH         (1) // ROM api esprv_intc_int_set_type configuring edge type interrupt is invalid
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.

--- a/src/esp32s2/CMakeLists.txt
+++ b/src/esp32s2/CMakeLists.txt
@@ -4,11 +4,11 @@ set(srcs
     src/flash.c
 )
 
-add_library(${ESP_TARGET} STATIC ${srcs})
+add_library(${ESP_TARGET_LIB} STATIC ${srcs})
 
-target_include_directories(${ESP_TARGET}
+target_include_directories(${ESP_TARGET_LIB}
     PUBLIC include
     PRIVATE include/target
 )
 
-target_link_options(${ESP_TARGET} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32s2.rom.ld)
+target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32s2.rom.ld)

--- a/src/esp32s2/include/target/esp_rom_caps.h
+++ b/src/esp32s2/include/target/esp_rom_caps.h
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_MZ_CRC32                (1) // ROM has mz_crc32 function
+#define ESP_ROM_HAS_UART_BUF_SWITCH         (1) // ROM has exported the uart buffer switch function
+#define ESP_ROM_NEEDS_SWSETUP_WORKAROUND    (1) // ROM uses 32-bit time_t. A workaround is required to prevent printf functions from crashing
+#define ESP_ROM_HAS_REGI2C_BUG              (1) // ROM has the regi2c bug
+#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_HAS_NEWLIB_32BIT_TIME       (1) // ROM was compiled with 32 bit time_t
+#define ESP_ROM_USB_OTG_NUM                 (3) // The serial port ID (UART, USB, ...) of USB_OTG CDC in the ROM.
+#define ESP_ROM_HAS_FLASH_COUNT_PAGES_BUG   (1) // ROM api Cache_Count_Flash_Pages will return unexpected value
+#define ESP_ROM_HAS_SW_FLOAT            (1) // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (-1) // No USB_SERIAL_JTAG in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
+#define ESP_ROM_HAS_VPRINTF_FUNC            (1) // ROM has ets_vprintf
+#define ESP_ROM_HAS_OUTPUT_TO_CHANNELS_FUNC (1) // ROM has ets_write_char, alias is esp_rom_output_to_channels
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_CONSOLE_OUTPUT_SECONDARY    (1) // The console output functions will also output to the USB-serial secondary console

--- a/src/esp32s3/CMakeLists.txt
+++ b/src/esp32s3/CMakeLists.txt
@@ -3,11 +3,11 @@ set(srcs
     src/flash.c
 )
 
-add_library(${ESP_TARGET} STATIC ${srcs})
+add_library(${ESP_TARGET_LIB} STATIC ${srcs})
 
-target_include_directories(${ESP_TARGET}
+target_include_directories(${ESP_TARGET_LIB}
     PUBLIC include
     PRIVATE include/target
 )
 
-target_link_options(${ESP_TARGET} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32s3.rom.ld)
+target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32s3.rom.ld)

--- a/src/esp32s3/include/target/esp_rom_caps.h
+++ b/src/esp32s3/include/target/esp_rom_caps.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_HAS_MZ_CRC32                (1) // ROM has mz_crc32 function
+#define ESP_ROM_HAS_JPEG_DECODE             (1) // ROM has JPEG decode library
+#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
+#define ESP_ROM_USB_OTG_NUM                 (3) // The serial port ID (UART, USB, ...) of USB_OTG CDC in the ROM.
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (4) // The serial port ID (UART, USB, ...) of USB_SERIAL_JTAG in the ROM.
+#define ESP_ROM_HAS_ERASE_0_REGION_BUG      (1) // ROM has esp_flash_erase_region(size=0) bug
+#define ESP_ROM_HAS_ENCRYPTED_WRITES_USING_LEGACY_DRV     (1) // `esp_flash_write_encrypted` in ROM has bug.
+#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_NEEDS_SWSETUP_WORKAROUND    (1) // ROM uses 32-bit time_t. A workaround is required to prevent printf functions from crashing
+#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_HAS_ETS_PRINTF_BUG          (1) // ROM has ets_printf bug when disable the ROM log either by eFuse or RTC storage register
+#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_HAS_NEWLIB_32BIT_TIME       (1) // ROM was compiled with 32 bit time_t
+#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_FLASH_COUNT_PAGES_BUG   (1) // ROM api Cache_Count_Flash_Pages will return unexpected value
+#define ESP_ROM_HAS_CACHE_SUSPEND_WAITI_BUG (1) // ROM api Cache_Suspend_I/DCache and Cache_Freeze_I/DCache_Enable does not waiti
+#define ESP_ROM_HAS_CACHE_WRITEBACK_BUG     (1) // ROM api Cache_WriteBack_Addr address or size misalignment may cause cache hit with wrong value.
+#define ESP_ROM_HAS_SW_FLOAT                (1) // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
+#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_CONSOLE_OUTPUT_SECONDARY    (1) // The console output functions will also output to the USB-serial secondary console

--- a/src/esp8266/CMakeLists.txt
+++ b/src/esp8266/CMakeLists.txt
@@ -3,11 +3,11 @@ set(srcs
     src/flash.c
 )
 
-add_library(${ESP_TARGET} STATIC ${srcs})
+add_library(${ESP_TARGET_LIB} STATIC ${srcs})
 
-target_include_directories(${ESP_TARGET}
+target_include_directories(${ESP_TARGET_LIB}
     PUBLIC include
     PRIVATE include/target
 )
 
-target_link_options(${ESP_TARGET} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp8266.rom.ld)
+target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp8266.rom.ld)

--- a/src/esp8266/include/target/esp_rom_caps.h
+++ b/src/esp8266/include/target/esp_rom_caps.h
@@ -6,7 +6,4 @@
 
 #pragma once
 
-#include <stdint.h>
-
-void stub_lib_log_init(uint8_t uart_num, uint32_t baudrate);
-void stub_lib_log_printf(const char *fmt, ...);
+#define ESP_ROM_HAS_VPRINTF_FUNC            (1) // ROM has ets_vprintf

--- a/src/log.c
+++ b/src/log.c
@@ -4,22 +4,73 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 #include <stdint.h>
+#include <stdarg.h>
 
+#include <target/esp_rom_caps.h>
 #include <target/uart.h>
 
 // These functions are defined in the ROM
 extern void ets_install_uart_printf(void);
+extern void ets_printf(const char *fmt, ...);
 
-#ifdef STUB_LOG_ENABLE
 void stub_lib_log_init(uint8_t uart_num, uint32_t baudrate)
 {
     stub_target_uart_init(uart_num, baudrate);
     ets_install_uart_printf();
 }
-#else
-void stub_lib_log_init(uint8_t uart_num, uint32_t baudrate)
+
+// This function is designed to avoid implementing vprintf() to reduce code size.
+// It only supports a subset of format specifiers: %s, %d, %u, %x, %X, %c.
+// It does not support floating point numbers or other advanced features.
+void stub_lib_log_printf(const char *fmt, ...)
 {
-    (void)uart_num;
-    (void)baudrate;
+    char buf[3];
+    va_list args;
+
+    va_start(args, fmt);
+
+    while (*fmt) {
+        if (*fmt != '%') {
+            ets_printf("%c", *fmt++);
+            continue;
+        }
+
+        fmt++;  // Skip the '%'
+
+        switch (*fmt) {
+        case 's': {
+            const char *s = va_arg(args, const char *);
+            ets_printf("%s", s ? s : "(null)");
+        }
+        break;
+        case 'd': {
+            int d = va_arg(args, int);
+            if (d < 0) {
+                ets_printf("-%u", (unsigned int)(-d));
+            } else {
+                ets_printf("%u", (unsigned int)d);
+            }
+        }
+        break;
+        case 'u':
+        case 'x':
+        case 'X':
+            buf[0] = '%';
+            buf[1] = *fmt;
+            buf[2] = '\0';
+            ets_printf(buf, va_arg(args, unsigned int));
+            break;
+        case 'c':
+            ets_printf("%c", va_arg(args, int));
+            break;
+        default:
+            buf[0] = '%';
+            buf[1] = *fmt ? *fmt++ : '\0';
+            buf[2] = '\0';
+            ets_printf("%s", buf);
+            break;
+        }
+        fmt++;
+    }
+    va_end(args);
 }
-#endif


### PR DESCRIPTION
## Description

1. The `STUB_LOG_ENABLE` macro will be enabled from the application and will not be used in the library. Unused functions will not be included in the final binary, so this is okay.
2. `stub_lib_log_printf` is implemented in a simple way to avoid using `ets_vprintf`, which is not defined in the ROM on many targets. Instead of re-implementing it, a simpler approach was chosen.
3. `esp_rom_caps.h` files are added for the future use.
4. Library cmake target names can be configured from the application. This is required by the OpenOCD stub when compiling command-based targets. This approach will also help to pass different compile definitions for each command.
