### PR TITLE
buffer log, compile time dispatched

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,16 +11,30 @@ if(NOT ESP_TARGET_LIB)
 endif()
 
 set(srcs
-    src/log.c
     src/flash.c
 )
+
+if(STUB_LOG_ENABLED IN_LIST STUB_COMPILE_DEFS)
+    list(APPEND srcs src/log_common.c)
+
+    if(STUB_LIB_LOG_UART IN_LIST STUB_COMPILE_DEFS)
+        list(APPEND srcs src/log_uart.c)
+    else()
+        # STUB_LIB_LOG_BUF is by default
+        if(NOT STUB_LIB_LOG_BUF IN_LIST STUB_COMPILE_DEFS)
+            list(APPEND STUB_COMPILE_DEFS STUB_LIB_LOG_BUF)
+        endif()
+        list(APPEND srcs src/log_buf.c)
+    endif()
+endif()
 
 add_library(${ESP_STUB_LIB} STATIC ${srcs})
 
 target_include_directories(${ESP_STUB_LIB}
-    PUBLIC include
+    INTERFACE include
     PRIVATE include/esp-stub-lib
 )
+include_directories(include)
 
 # STUB_COMPILE_DEFS is optional definitions coming from the parent CMakeLists.txt
 target_compile_definitions(${ESP_STUB_LIB} PRIVATE ${STUB_COMPILE_DEFS})

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -38,7 +38,8 @@ if(${ESP_TARGET} STREQUAL "esp8266")
     target_link_options(${PROJECT_NAME} PRIVATE -Wl,--entry=stub_main_esp8266)
 endif()
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE asm=__asm__ STUB_LOG_ENABLED)
+set(STUB_COMPILE_DEFS "STUB_LOG_ENABLED")
+target_compile_definitions(${PROJECT_NAME} PRIVATE asm=__asm__ ${STUB_COMPILE_DEFS})
 
 set(MAP_FILE ${CMAKE_CURRENT_BINARY_DIR}/${APP_NAME}.map)
 target_link_options(${PROJECT_NAME} PRIVATE -Wl,-Map=${MAP_FILE})

--- a/example/stub_main.c
+++ b/example/stub_main.c
@@ -22,14 +22,6 @@ struct stub_cmd_handler {
     int (*handler)(va_list ap);
 };
 
-#ifdef STUB_LOG_ENABLED
-#define STUB_LOG_INIT(uart_num, baudrate) stub_lib_log_init(uart_num, baudrate)
-#define STUB_LOG(fmt, ...) stub_lib_log_printf(fmt, ##__VA_ARGS__)
-#else
-#define STUB_LOG_INIT(uart_num, baudrate)
-#define STUB_LOG(fmt, ...)
-#endif
-
 static  __attribute__((unused)) int handle_test1(va_list ap)
 {
     (void)ap;
@@ -40,6 +32,14 @@ static  __attribute__((unused)) int handle_test1(va_list ap)
     STUB_LOG("stub command test:%s\n", "test");
     STUB_LOG("stub command test:%c\n", 'A');
     STUB_LOG("stub command test:%l\n", 10); // not supported
+
+    STUB_LOGE("stub command test\n");
+    STUB_LOGW("stub command test\n");
+    STUB_LOGI("stub command test\n");
+    STUB_LOGD("stub command test\n");
+    STUB_LOGV("stub command test\n");
+    STUB_LOG_TRACE();
+    STUB_LOG_TRACEF("foo:%u\n", 0x2A);
 
     return 0;
 }
@@ -84,7 +84,7 @@ int stub_main(int cmd, ...)
 
     va_start(ap, cmd);
 
-    STUB_LOG_INIT(0, 115200);
+    STUB_LOG_INIT();
 
     stub_lib_flash_init(&flash_state);
 

--- a/include/esp-stub-lib/log.h
+++ b/include/esp-stub-lib/log.h
@@ -6,15 +6,35 @@
 
 #pragma once
 
-#include <stdint.h>
+#if defined(STUB_LOG_ENABLED)
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void stub_lib_log_init(uint8_t uart_num, uint32_t baudrate);
+void stub_lib_log_init();
 void stub_lib_log_printf(const char *fmt, ...);
 
 #ifdef __cplusplus
 }
 #endif // __cplusplus
+
+#define STUB_LOG_INIT() stub_lib_log_init()
+#define STUB_LOG(fmt, ...) stub_lib_log_printf(fmt, ##__VA_ARGS__)
+
+#else // defined(STUB_LOG_ENABLED)
+
+#define STUB_LOG_INIT() do {} while(0)
+#define STUB_LOG(fmt, ...) do {} while(0)
+
+#endif // defined(STUB_LOG_ENABLED)
+
+#define STUB_LOGE(fmt, ...) STUB_LOG("STUB_E: " fmt, ##__VA_ARGS__)
+#define STUB_LOGW(fmt, ...) STUB_LOG("STUB_W: " fmt, ##__VA_ARGS__)
+#define STUB_LOGI(fmt, ...) STUB_LOG("STUB_I: " fmt, ##__VA_ARGS__)
+#define STUB_LOGD(fmt, ...) STUB_LOG("STUB_D: " fmt, ##__VA_ARGS__)
+#define STUB_LOGV(fmt, ...) STUB_LOG("STUB_V: " fmt, ##__VA_ARGS__)
+// trace only function name
+#define STUB_LOG_TRACE() STUB_LOG("STUB_TRACE %s()\n", __func__)
+// trace with format
+#define STUB_LOG_TRACEF(fmt, ...) STUB_LOG("STUB_TRACE %s(): " fmt, __func__, ##__VA_ARGS__)

--- a/src/log.c
+++ b/src/log.c
@@ -70,7 +70,7 @@ void stub_lib_log_printf(const char *fmt, ...)
             break;
         default:
             buf[0] = '%';
-            buf[1] = *fmt ? *fmt++ : '\0';
+            buf[1] = *fmt;
             buf[2] = '\0';
             ets_printf("%s", buf);
             break;

--- a/src/log_buf.c
+++ b/src/log_buf.c
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#include <log.h>
+
+#include <stdint.h>
+#include <stddef.h>
+
+extern void ets_printf(const char *fmt, ...);
+extern void ets_install_putc1(void (*p)(char c));
+extern void ets_install_putc2(void (*p)(char c));
+
+#if !defined(STUB_LIB_LOG_BUF_SIZE)
+#define STUB_LIB_LOG_BUF_SIZE 4096
+#endif
+
+struct stub_lib_log_buf {
+    uint32_t count;
+    char buf[STUB_LIB_LOG_BUF_SIZE];
+};
+
+static struct stub_lib_log_buf g_stub_lib_log_buf;
+static void stub_lib_log_buf_write_char(char c)
+{
+    g_stub_lib_log_buf.buf[g_stub_lib_log_buf.count] = c;
+    g_stub_lib_log_buf.count = (g_stub_lib_log_buf.count + 1) % STUB_LIB_LOG_BUF_SIZE;
+}
+
+void stub_lib_log_init()
+{
+    ets_install_putc1(stub_lib_log_buf_write_char);
+    ets_install_putc2(NULL);
+}

--- a/src/log_common.c
+++ b/src/log_common.c
@@ -3,26 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
-#include <stdint.h>
+#include <log.h>
+
 #include <stdarg.h>
-#include <stddef.h>
 
-#include <target/esp_rom_caps.h>
-#include <target/uart.h>
-
-// These functions are defined in the ROM
-extern void ets_install_uart_printf(void);
 extern void ets_printf(const char *fmt, ...);
-extern void ets_install_putc1(void (*p)(char c));
-extern void ets_install_putc2(void (*p)(char c));
-
-void stub_lib_log_init(uint8_t uart_num, uint32_t baudrate)
-{
-    stub_target_uart_init(uart_num, baudrate);
-    ets_install_putc1(NULL);
-    ets_install_putc2(NULL);
-    ets_install_uart_printf();
-}
 
 // This function is designed to avoid implementing vprintf() to reduce code size.
 // It only supports a subset of format specifiers: %s, %d, %u, %x, %X, %c.

--- a/src/log_uart.c
+++ b/src/log_uart.c
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#include <log.h>
+
+#include <target/uart.h>
+#include <stddef.h>
+
+extern void ets_install_putc1(void (*p)(char c));
+extern void ets_install_putc2(void (*p)(char c));
+extern void ets_install_uart_printf(void);
+
+void stub_lib_log_init()
+{
+    stub_target_uart_init(0, 115200);
+    ets_install_putc1(NULL);
+    ets_install_putc2(NULL);
+    ets_install_uart_printf();
+}


### PR DESCRIPTION
- moves `STUB_LOG_ENABLED` into esp-stub-lib again -- to have common interface for dispatching log configuration
- allows the compile time log configuration dispatching. Nothing extra in the binary result

- to enable: pass `STUB_LOG_ENABLED` via `STUB_COMPILE_DEFS`
- to switch logger type: pass `STUB_LIB_LOG_BUF` or `STUB_LIB_LOG_UART` via `STUB_COMPILE_DEFS`
- to change the default buffer size: pass `STUB_LIB_LOG_BUF_SIZE=2048` via `STUB_COMPILE_DEFS`

(eg, `set(STUB_COMPILE_DEFS "STUB_LOG_ENABLED;STUB_LIB_LOG_BUF;STUB_LIB_LOG_BUF_SIZE=2048")`)