### PR TITLE
fix(include): Make the headers includable from C++

### DIFF
--- a/include/esp-stub-lib/flash.h
+++ b/include/esp-stub-lib/flash.h
@@ -18,6 +18,10 @@ typedef struct stub_flash_info {
     uint32_t encrypted;
 } stub_lib_flash_info_t;
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 void stub_lib_flash_init(void **state);
 void stub_lib_flash_deinit(const void *state);
 void stub_lib_flash_get_info(stub_lib_flash_info_t *info);
@@ -27,3 +31,7 @@ int stub_lib_flash_erase_area(uint32_t addr, uint32_t size);
 int stub_lib_flash_erase_sector(uint32_t addr);
 int stub_lib_flash_erase_block(uint32_t addr);
 int stub_lib_flash_erase_chip(void);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/include/esp-stub-lib/log.h
+++ b/include/esp-stub-lib/log.h
@@ -8,5 +8,13 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 void stub_lib_log_init(uint8_t uart_num, uint32_t baudrate);
 void stub_lib_log_printf(const char *fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus


### PR DESCRIPTION
This PR updates header files to be compatible with C++ inclusion by adding `extern "C"` guards around function declarations.

Required by https://github.com/espressif/esp-flasher-stub/pull/10.