### PR TITLE
feat: add common directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,23 +10,19 @@ if(NOT ESP_TARGET_LIB)
     set(ESP_TARGET_LIB ${ESP_TARGET})
 endif()
 
+if(NOT ESP_COMMON_LIB)
+    set(ESP_COMMON_LIB common)
+endif()
+
+# Provide common headers to all targets
+include_directories(src/common/include)
+
+add_subdirectory(src/common)
+add_subdirectory(src/${ESP_TARGET} ${ESP_TARGET_LIB})
+
 set(srcs
     src/flash.c
 )
-
-if(STUB_LOG_ENABLED IN_LIST STUB_COMPILE_DEFS)
-    list(APPEND srcs src/log_common.c)
-
-    if(STUB_LIB_LOG_UART IN_LIST STUB_COMPILE_DEFS)
-        list(APPEND srcs src/log_uart.c)
-    else()
-        # STUB_LIB_LOG_BUF is by default
-        if(NOT STUB_LIB_LOG_BUF IN_LIST STUB_COMPILE_DEFS)
-            list(APPEND STUB_COMPILE_DEFS STUB_LIB_LOG_BUF)
-        endif()
-        list(APPEND srcs src/log_buf.c)
-    endif()
-endif()
 
 add_library(${ESP_STUB_LIB} STATIC ${srcs})
 
@@ -34,11 +30,8 @@ target_include_directories(${ESP_STUB_LIB}
     INTERFACE include
     PRIVATE include/esp-stub-lib
 )
-include_directories(include)
 
 # STUB_COMPILE_DEFS is optional definitions coming from the parent CMakeLists.txt
 target_compile_definitions(${ESP_STUB_LIB} PRIVATE ${STUB_COMPILE_DEFS})
 
-add_subdirectory(src/${ESP_TARGET} ${ESP_TARGET_LIB})
-
-target_link_libraries(${ESP_STUB_LIB} PUBLIC ${ESP_TARGET_LIB})
+target_link_libraries(${ESP_STUB_LIB} PUBLIC ${ESP_TARGET_LIB} ${ESP_COMMON_LIB})

--- a/include/esp-stub-lib/log.h
+++ b/include/esp-stub-lib/log.h
@@ -6,35 +6,4 @@
 
 #pragma once
 
-#if defined(STUB_LOG_ENABLED)
-
-#ifdef __cplusplus
-extern "C" {
-#endif // __cplusplus
-
-void stub_lib_log_init();
-void stub_lib_log_printf(const char *fmt, ...);
-
-#ifdef __cplusplus
-}
-#endif // __cplusplus
-
-#define STUB_LOG_INIT() stub_lib_log_init()
-#define STUB_LOG(fmt, ...) stub_lib_log_printf(fmt, ##__VA_ARGS__)
-
-#else // defined(STUB_LOG_ENABLED)
-
-#define STUB_LOG_INIT() do {} while(0)
-#define STUB_LOG(fmt, ...) do {} while(0)
-
-#endif // defined(STUB_LOG_ENABLED)
-
-#define STUB_LOGE(fmt, ...) STUB_LOG("STUB_E: " fmt, ##__VA_ARGS__)
-#define STUB_LOGW(fmt, ...) STUB_LOG("STUB_W: " fmt, ##__VA_ARGS__)
-#define STUB_LOGI(fmt, ...) STUB_LOG("STUB_I: " fmt, ##__VA_ARGS__)
-#define STUB_LOGD(fmt, ...) STUB_LOG("STUB_D: " fmt, ##__VA_ARGS__)
-#define STUB_LOGV(fmt, ...) STUB_LOG("STUB_V: " fmt, ##__VA_ARGS__)
-// trace only function name
-#define STUB_LOG_TRACE() STUB_LOG("STUB_TRACE %s()\n", __func__)
-// trace with format
-#define STUB_LOG_TRACEF(fmt, ...) STUB_LOG("STUB_TRACE %s(): " fmt, __func__, ##__VA_ARGS__)
+#include_next <common/log.h>

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(COMMON_SRCS src/log_printf.c)
+
+if(STUB_LOG_ENABLED IN_LIST STUB_COMPILE_DEFS)
+    if(STUB_LIB_LOG_UART IN_LIST STUB_COMPILE_DEFS)
+        list(APPEND COMMON_SRCS src/log_uart.c)
+    else()
+        # STUB_LIB_LOG_BUF is by default
+        if(NOT STUB_LIB_LOG_BUF IN_LIST STUB_COMPILE_DEFS)
+            list(APPEND STUB_COMPILE_DEFS STUB_LIB_LOG_BUF)
+        endif()
+        list(APPEND COMMON_SRCS src/log_buf.c)
+    endif()
+endif()
+
+add_library(${ESP_COMMON_LIB} STATIC ${COMMON_SRCS})
+
+target_include_directories(${ESP_COMMON_LIB}
+    PUBLIC include
+    PRIVATE include/common
+)
+
+target_compile_definitions(${ESP_COMMON_LIB} PRIVATE ${STUB_COMPILE_DEFS})

--- a/src/common/include/common/log.h
+++ b/src/common/include/common/log.h
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#if defined(STUB_LOG_ENABLED)
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void stub_lib_log_init();
+void stub_lib_log_printf(const char *fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#define STUB_LOG_INIT() stub_lib_log_init()
+#define STUB_LOG(fmt, ...) stub_lib_log_printf(fmt, ##__VA_ARGS__)
+
+#else // defined(STUB_LOG_ENABLED)
+
+#define STUB_LOG_INIT() do {} while(0)
+#define STUB_LOG(fmt, ...) do {} while(0)
+
+#endif // defined(STUB_LOG_ENABLED)
+
+#define STUB_LOGE(fmt, ...) STUB_LOG("STUB_E: " fmt, ##__VA_ARGS__)
+#define STUB_LOGW(fmt, ...) STUB_LOG("STUB_W: " fmt, ##__VA_ARGS__)
+#define STUB_LOGI(fmt, ...) STUB_LOG("STUB_I: " fmt, ##__VA_ARGS__)
+#define STUB_LOGD(fmt, ...) STUB_LOG("STUB_D: " fmt, ##__VA_ARGS__)
+#define STUB_LOGV(fmt, ...) STUB_LOG("STUB_V: " fmt, ##__VA_ARGS__)
+// trace only function name
+#define STUB_LOG_TRACE() STUB_LOG("STUB_T: %s()\n", __func__)
+// trace with format
+#define STUB_LOG_TRACEF(fmt, ...) STUB_LOG("STUB_T: %s(): " fmt, __func__, ##__VA_ARGS__)

--- a/src/common/src/log_buf.c
+++ b/src/common/src/log_buf.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
-#include <log.h>
-
 #include <stdint.h>
 #include <stddef.h>
+
+#include "log.h"
 
 extern void ets_printf(const char *fmt, ...);
 extern void ets_install_putc1(void (*p)(char c));

--- a/src/common/src/log_printf.c
+++ b/src/common/src/log_printf.c
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
-#include <log.h>
-
 #include <stdarg.h>
+
+#include "log.h"
 
 extern void ets_printf(const char *fmt, ...);
 

--- a/src/common/src/log_uart.c
+++ b/src/common/src/log_uart.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
-#include <log.h>
+#include <stddef.h>
 
 #include <target/uart.h>
-#include <stddef.h>
+#include "log.h"
 
 extern void ets_install_putc1(void (*p)(char c));
 extern void ets_install_putc2(void (*p)(char c));

--- a/src/esp32/CMakeLists.txt
+++ b/src/esp32/CMakeLists.txt
@@ -10,4 +10,5 @@ target_include_directories(${ESP_TARGET_LIB}
     PRIVATE include/target
 )
 
+target_compile_definitions(${ESP_TARGET_LIB} PRIVATE ${STUB_COMPILE_DEFS})
 target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32.rom.ld)

--- a/src/esp32/src/flash.c
+++ b/src/esp32/src/flash.c
@@ -4,16 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+#include <common/log.h>
 #include "flash.h"
 
 void stub_target_flash_init(void *state)
 {
     (void)state;
-    // TODO: Implement
+
+    STUB_LOG_TRACE();
 }
 
 void stub_target_flash_deinit(const void *state)
 {
     (void)state;
-    // TODO: Implement
+    STUB_LOG_TRACE();
 }

--- a/src/esp32c2/CMakeLists.txt
+++ b/src/esp32c2/CMakeLists.txt
@@ -10,4 +10,5 @@ target_include_directories(${ESP_TARGET_LIB}
     PRIVATE include/target
 )
 
+target_compile_definitions(${ESP_TARGET_LIB} PRIVATE ${STUB_COMPILE_DEFS})
 target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c2.rom.ld)

--- a/src/esp32c3/CMakeLists.txt
+++ b/src/esp32c3/CMakeLists.txt
@@ -10,4 +10,5 @@ target_include_directories(${ESP_TARGET_LIB}
     PRIVATE include/target
 )
 
+target_compile_definitions(${ESP_TARGET_LIB} PRIVATE ${STUB_COMPILE_DEFS})
 target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c3.rom.ld)

--- a/src/esp32c5/CMakeLists.txt
+++ b/src/esp32c5/CMakeLists.txt
@@ -10,4 +10,5 @@ target_include_directories(${ESP_TARGET_LIB}
     PRIVATE include/target
 )
 
+target_compile_definitions(${ESP_TARGET_LIB} PRIVATE ${STUB_COMPILE_DEFS})
 target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c5.rom.ld)

--- a/src/esp32c6/CMakeLists.txt
+++ b/src/esp32c6/CMakeLists.txt
@@ -10,4 +10,5 @@ target_include_directories(${ESP_TARGET_LIB}
     PRIVATE include/target
 )
 
+target_compile_definitions(${ESP_TARGET_LIB} PRIVATE ${STUB_COMPILE_DEFS})
 target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c6.rom.ld)

--- a/src/esp32c61/CMakeLists.txt
+++ b/src/esp32c61/CMakeLists.txt
@@ -10,4 +10,5 @@ target_include_directories(${ESP_TARGET_LIB}
     PRIVATE include/target
 )
 
+target_compile_definitions(${ESP_TARGET_LIB} PRIVATE ${STUB_COMPILE_DEFS})
 target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c61.rom.ld)

--- a/src/esp32h2/CMakeLists.txt
+++ b/src/esp32h2/CMakeLists.txt
@@ -10,4 +10,5 @@ target_include_directories(${ESP_TARGET_LIB}
     PRIVATE include/target
 )
 
+target_compile_definitions(${ESP_TARGET_LIB} PRIVATE ${STUB_COMPILE_DEFS})
 target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32h2.rom.ld)

--- a/src/esp32p4/CMakeLists.txt
+++ b/src/esp32p4/CMakeLists.txt
@@ -10,4 +10,5 @@ target_include_directories(${ESP_TARGET_LIB}
     PRIVATE include/target
 )
 
+target_compile_definitions(${ESP_TARGET_LIB} PRIVATE ${STUB_COMPILE_DEFS})
 target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32p4.rom.ld)

--- a/src/esp32s2/CMakeLists.txt
+++ b/src/esp32s2/CMakeLists.txt
@@ -10,4 +10,5 @@ target_include_directories(${ESP_TARGET_LIB}
     PRIVATE include/target
 )
 
+target_compile_definitions(${ESP_TARGET_LIB} PRIVATE ${STUB_COMPILE_DEFS})
 target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32s2.rom.ld)

--- a/src/esp32s3/CMakeLists.txt
+++ b/src/esp32s3/CMakeLists.txt
@@ -10,4 +10,5 @@ target_include_directories(${ESP_TARGET_LIB}
     PRIVATE include/target
 )
 
+target_compile_definitions(${ESP_TARGET_LIB} PRIVATE ${STUB_COMPILE_DEFS})
 target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32s3.rom.ld)

--- a/src/esp8266/CMakeLists.txt
+++ b/src/esp8266/CMakeLists.txt
@@ -10,4 +10,5 @@ target_include_directories(${ESP_TARGET_LIB}
     PRIVATE include/target
 )
 
+target_compile_definitions(${ESP_TARGET_LIB} PRIVATE ${STUB_COMPILE_DEFS})
 target_link_options(${ESP_TARGET_LIB} PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp8266.rom.ld)


### PR DESCRIPTION
Add a common folder to store source and include files that are not related to the target. Mostly utilities and macros will be added there. It will be able to be included both inside and outside of targets.