### PR TITLE
feat: add ROM function wrappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 set(srcs
     src/flash.c
+    src/rom_wrappers.c
 )
 
 if(STUB_LOG_ENABLED IN_LIST STUB_COMPILE_DEFS)

--- a/include/esp-stub-lib/rom_wrappers.h
+++ b/include/esp-stub-lib/rom_wrappers.h
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+void esp_stub_lib_delay_us(uint32_t us);
+uint16_t esp_stub_lib_crc16_le(uint16_t crc, const uint8_t *buf, uint32_t len);

--- a/src/rom_wrappers.c
+++ b/src/rom_wrappers.c
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#include <stdint.h>
+
+extern void ets_delay_us(uint32_t us);
+extern uint16_t crc16_le(uint16_t crc, const uint8_t *buf, uint32_t len);
+
+void esp_stub_lib_delay_us(uint32_t us)
+{
+    ets_delay_us(us);
+}
+
+uint16_t esp_stub_lib_crc16_le(uint16_t crc, const uint8_t *buf, uint32_t len)
+{
+    return crc16_le(crc, buf, len);
+}


### PR DESCRIPTION
Introduce rom_wrappers.c/h to abstract ROM function calls and provide a consistent api across targets. Initial wrappers include:
- Delay functionality (esp_stub_lib_delay_us)
- CRC16 calculation (esp_stub_lib_crc16_le)