### PR TITLE
Detailed error code handling

### DIFF
--- a/example/stub_main.h
+++ b/example/stub_main.h
@@ -13,6 +13,9 @@ enum esp_stub_cmd {
     ESP_STUB_CMD_FLASH_MAX_ID = 0x01,
 };
 
-// Stub return codes
-#define ESP_STUB_OK         0
-#define ESP_STUB_FAIL       -1
+// Stub return codes, all compatible with esp-stub-lib/err.h without overlap
+
+#define ESP_STUB_OK                         0x0     // Equal to STUB_LIB_OK
+#define ESP_STUB_FAIL                       0x1     // Different from STUB_LIB_FAIL
+
+#define ESP_STUB_ERR_CMD_NOT_SUPPORTED      0x2

--- a/include/esp-stub-lib/err.h
+++ b/include/esp-stub-lib/err.h
@@ -6,9 +6,22 @@
 
 #pragma once
 
-typedef int stub_lib_err_t;
+/**
+ * @file
+ * @brief Error codes used in esp-stub-lib
+ *
+ * Please use int for return codes
+ *
+ * The error code range of esp-stub-lib starts at STUB_LIB_ERROR_BASE, intentionally chosen to distinguish library codes
+ */
 
-#define STUB_LIB_OK                             0       // stub_lib_err_t value indicating success (no error)
-#define STUB_LIB_FAIL                           -1      // Generic stub_lib_err_t code indicating failure
+#define STUB_LIB_ERROR_BASE                     0x10000000
 
-#define STUB_LIB_ERR_UNKNOWN_FLASH_ID           0x1
+#define STUB_LIB_OK                             0                       /**< Success (no error) */
+#define STUB_LIB_FAIL                           STUB_LIB_ERROR_BASE     /**< A generic error code. Prefer specific codes instead. */
+
+/** @name Specific error codes
+ *  @{
+ */
+#define STUB_LIB_ERR_UNKNOWN_FLASH_ID           (STUB_LIB_ERROR_BASE + 0x1)
+/** @} */

--- a/include/esp-stub-lib/flash.h
+++ b/include/esp-stub-lib/flash.h
@@ -34,7 +34,7 @@ extern "C" {
  * - STUB_LIB_OK    - success
  * - STUB_LIB_ERR_UNKNOWN_FLASH_ID   - can't get size from flash id
  */
-stub_lib_err_t stub_lib_flash_init(void **state);
+int stub_lib_flash_init(void **state);
 
 /**
  * @brief Restore flash state at the end of the stub.
@@ -51,12 +51,12 @@ void stub_lib_flash_deinit(const void *state);
 void stub_lib_flash_get_info(stub_lib_flash_info_t *info);
 
 void stub_lib_flash_info_print(const stub_lib_flash_info_t *info);
-stub_lib_err_t stub_lib_flash_read_buff(uint32_t addr, void *buffer, uint32_t size);
-stub_lib_err_t stub_lib_flash_write_buff(uint32_t addr, const void *buffer, uint32_t size, int encrypt);
-stub_lib_err_t stub_lib_flash_erase_area(uint32_t addr, uint32_t size);
-stub_lib_err_t stub_lib_flash_erase_sector(uint32_t addr);
-stub_lib_err_t stub_lib_flash_erase_block(uint32_t addr);
-stub_lib_err_t stub_lib_flash_erase_chip(void);
+int stub_lib_flash_read_buff(uint32_t addr, void *buffer, uint32_t size);
+int stub_lib_flash_write_buff(uint32_t addr, const void *buffer, uint32_t size, int encrypt);
+int stub_lib_flash_erase_area(uint32_t addr, uint32_t size);
+int stub_lib_flash_erase_sector(uint32_t addr);
+int stub_lib_flash_erase_block(uint32_t addr);
+int stub_lib_flash_erase_chip(void);
 
 #ifdef __cplusplus
 }

--- a/src/flash.c
+++ b/src/flash.c
@@ -11,13 +11,12 @@
 #include <target/flash.h>
 #include <private/rom_flash_config.h>
 
-stub_lib_err_t stub_lib_flash_init(void **state)
+int stub_lib_flash_init(void **state)
 {
     stub_target_flash_init(state);
     uint32_t flash_id = stub_target_flash_get_flash_id();
     uint32_t flash_size = stub_target_flash_id_to_flash_size(flash_id);
     if (flash_size == 0) {
-        STUB_LOGE("Invalid flash size: 0\n");
         return STUB_LIB_ERR_UNKNOWN_FLASH_ID;
     }
     STUB_LOG_TRACEF("Flash size: %d MB\n", MB(flash_size));

--- a/src/target/common/src/flash.c
+++ b/src/target/common/src/flash.c
@@ -45,6 +45,6 @@ uint32_t stub_target_flash_id_to_flash_size(uint32_t flash_id)
         return 32 * 1024 * 1024;
     }
 
-    STUB_LOGE("Unknown flash_id: 0x%x", flash_id);
+    STUB_LOGE("Unknown flash_id: 0x%x\n", flash_id);
     return 0;
 }


### PR DESCRIPTION
Cleans up error codes

Assumes error codes will be more specific, allowing the client to get more context about where the error occurred

(Other changes are in the OOCD part)