### PR TITLE
feat: Add SLIP encoding support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 
 set(srcs
     src/flash.c
+    src/slip.c
     src/rom_wrappers.c
 )
 

--- a/include/esp-stub-lib/slip.h
+++ b/include/esp-stub-lib/slip.h
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* SLIP Protocol Constants */
+#define SLIP_END            0xC0    /* Frame delimiter */
+#define SLIP_ESC            0xDB    /* Escape character */
+#define SLIP_ESC_END        0xDC    /* Escaped frame delimiter */
+#define SLIP_ESC_ESC        0xDD    /* Escaped escape character */
+
+/* SLIP Return Values */
+#define SLIP_FINISHED_FRAME    -2   /* Complete frame received */
+#define SLIP_NO_BYTE          -1   /* No byte available */
+
+/* SLIP State Machine */
+typedef enum {
+    SLIP_NO_FRAME,          /* Not in a frame */
+    SLIP_FRAME,             /* Processing frame data */
+    SLIP_FRAME_ESCAPING     /* Processing escape sequence */
+} slip_state_t;
+
+/**
+ * @brief Send SLIP frame delimiter
+ */
+void slip_send_frame_delimiter(void);
+
+/**
+ * @brief Send single byte with SLIP escaping
+ *
+ * @param byte Byte to send
+ */
+void slip_send_frame_data(uint8_t byte);
+
+/**
+ * @brief Send buffer with SLIP escaping
+ *
+ * @param data Data buffer to send
+ * @param size Size of data in bytes
+ */
+void slip_send_frame_data_buf(const void *data, size_t size);
+
+/**
+ * @brief Send complete SLIP frame
+ *
+ * @param data Data to send
+ * @param size Size of data in bytes
+ */
+void slip_send_frame(const void *data, size_t size);
+
+/**
+ * @brief Process incoming byte through SLIP decoder
+ *
+ * @param byte Incoming byte
+ * @param state SLIP decoder state
+ * @return Decoded byte (>=0), SLIP_NO_BYTE, or SLIP_FINISHED_FRAME
+ */
+int16_t slip_recv_byte(uint8_t byte, slip_state_t *state);
+
+/**
+ * @brief Receive complete SLIP frame (synchronous)
+ *
+ * @param buffer Buffer to store received frame
+ * @param max_len Maximum buffer size
+ * @return Number of bytes received
+ */
+size_t slip_recv_frame(void *buffer, size_t max_len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/slip.c
+++ b/src/slip.c
@@ -1,0 +1,125 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <slip.h>
+#include <log.h>
+
+/* External ROM UART functions */
+extern void uart_tx_one_char(uint8_t ch);
+extern uint8_t uart_rx_one_char(void);
+extern void uart_tx_flush(void);
+
+void slip_send_frame_delimiter(void)
+{
+    uart_tx_one_char(SLIP_END);
+}
+
+void slip_send_frame_data(uint8_t byte)
+{
+    switch (byte) {
+    case SLIP_END:
+        uart_tx_one_char(SLIP_ESC);
+        uart_tx_one_char(SLIP_ESC_END);
+        break;
+    case SLIP_ESC:
+        uart_tx_one_char(SLIP_ESC);
+        uart_tx_one_char(SLIP_ESC_ESC);
+        break;
+    default:
+        uart_tx_one_char(byte);
+        break;
+    }
+}
+
+void slip_send_frame_data_buf(const void *data, size_t size)
+{
+    if (!data) {
+        return;
+    }
+
+    const uint8_t *buf = (const uint8_t *)data;
+    for (size_t i = 0; i < size; i++) {
+        slip_send_frame_data(buf[i]);
+    }
+}
+
+void slip_send_frame(const void *data, size_t size)
+{
+    if (!data) {
+        return;
+    }
+
+    slip_send_frame_delimiter();
+    slip_send_frame_data_buf(data, size);
+    slip_send_frame_delimiter();
+}
+
+int16_t slip_recv_byte(uint8_t byte, slip_state_t *state)
+{
+    if (!state) {
+        return SLIP_NO_BYTE;
+    }
+
+    if (byte == SLIP_END) {
+        if (*state == SLIP_NO_FRAME) {
+            *state = SLIP_FRAME;
+            return SLIP_NO_BYTE;
+        } else {
+            *state = SLIP_NO_FRAME;
+            return SLIP_FINISHED_FRAME;
+        }
+    }
+
+    switch (*state) {
+    case SLIP_NO_FRAME:
+        return SLIP_NO_BYTE;
+
+    case SLIP_FRAME:
+        if (byte == SLIP_ESC) {
+            *state = SLIP_FRAME_ESCAPING;
+            return SLIP_NO_BYTE;
+        }
+        return (int16_t)byte;
+
+    case SLIP_FRAME_ESCAPING:
+        *state = SLIP_FRAME;
+        switch (byte) {
+        case SLIP_ESC_END:
+            return SLIP_END;
+        case SLIP_ESC_ESC:
+            return SLIP_ESC;
+        default:
+            /* Framing error - ignore invalid escape sequence */
+            return SLIP_NO_BYTE;
+        }
+    }
+
+    return SLIP_NO_BYTE;
+}
+
+size_t slip_recv_frame(void *buffer, size_t max_len)
+{
+    if (!buffer) {
+        return 0;
+    }
+
+    size_t len = 0;
+    slip_state_t state = SLIP_NO_FRAME;
+    uint8_t *buf = (uint8_t *)buffer;
+
+    while (len < max_len) {
+        uint8_t byte = uart_rx_one_char();
+        int16_t result = slip_recv_byte(byte, &state);
+
+        if (result == SLIP_FINISHED_FRAME) {
+            break;
+        } else if (result >= 0) {
+            buf[len++] = (uint8_t)result;
+        }
+    }
+
+    return len;
+}


### PR DESCRIPTION
## Description

Add SLIP encoding support.

Will be extended in the future to allow sending/receiving bytes via different peripherals (USB-OTG, USB-Serial/JTAG), instead of just UART0 with `uart_tx_one_char`.