### PR TITLE
fix(clock): Wait for the clocks to stabilize after init

### DIFF
--- a/src/clock.c
+++ b/src/clock.c
@@ -1,14 +1,16 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
 #include <target/clock.h>
+#include <rom_wrappers.h>
 
 void stub_lib_clock_init(void)
 {
     stub_target_clock_init();
+    stub_lib_delay_us(50); // Wait for the clocks to stabilize
 }
 
 void stub_lib_clock_disable_watchdogs(void)


### PR DESCRIPTION
Running another instruction immediately after clock initialization (increasing frequency) can cause `Guru Meditation Error detected (Illegal instruction)` in some cases (e.g., some P4 ECO5 boards).

Add a small delay to let the clocks stabilize first. `5us` was chosen as a safe measure, even though `1us` also seems to solve the issue.