### PR TITLE
fix(md5): Use proper context structure for esp32c2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(srcs
     src/usb_serial_jtag.c
     src/usb_otg.c
     src/clock.c
+    src/md5.c
 )
 
 if(STUB_LOG_ENABLED IN_LIST STUB_COMPILE_DEFS)

--- a/example/stub_main.c
+++ b/example/stub_main.c
@@ -19,6 +19,7 @@
 #include <esp-stub-lib/usb_serial_jtag.h>
 #include <esp-stub-lib/rom_wrappers.h>
 #include <esp-stub-lib/miniz.h>
+#include <esp-stub-lib/md5.h>
 
 #include "stub_main.h"
 

--- a/include/esp-stub-lib/md5.h
+++ b/include/esp-stub-lib/md5.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include <stdint.h>
+
+struct stub_lib_md5_ctx {
+    uint32_t total[4];
+    uint32_t state[2];
+    uint8_t buffer[64];
+};
+
+/**
+ * @brief Initialize an MD5 context.
+ *
+ * @param ctx Pointer to the MD5 context.
+ */
+void stub_lib_md5_init(void *ctx);
+
+/**
+ * @brief Update an MD5 context with additional data.
+ *
+ * @param ctx Pointer to the MD5 context.
+ * @param data Pointer to the data to update the context with.
+ * @param len Number of bytes to process.
+ */
+void stub_lib_md5_update(void *ctx, const uint8_t *data, uint32_t len);
+
+/**
+ * @brief Finalize an MD5 context and compute the digest.
+ *
+ * @param ctx Pointer to the MD5 context.
+ * @param digest Pointer to the buffer to store the digest.
+ */
+void stub_lib_md5_final(void *ctx, uint8_t digest[16]);

--- a/include/esp-stub-lib/rom_wrappers.h
+++ b/include/esp-stub-lib/rom_wrappers.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -11,12 +11,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
-
-struct stub_lib_md5_ctx {
-    uint32_t total[2];
-    uint32_t state[4];
-    uint8_t buffer[64];
-};
 
 /**
  * @brief Busy-wait delay for the given number of microseconds.
@@ -34,31 +28,6 @@ void stub_lib_delay_us(uint32_t us);
  * @return Updated CRC16 value.
  */
 uint16_t stub_lib_crc16_le(uint16_t crc, const uint8_t *buf, uint32_t len);
-
-/**
- * @brief Initialize an MD5 context.
- *
- * @param ctx Pointer to the MD5 context.
- */
-void stub_lib_md5_init(struct stub_lib_md5_ctx *ctx);
-
-/**
- * @brief Update an MD5 context with additional data.
- *
- * @param ctx Pointer to the MD5 context.
- * @param data Pointer to the data to update the context with.
- * @param len Number of bytes to process.
- */
-void stub_lib_md5_update(struct stub_lib_md5_ctx *ctx, const uint8_t *data, uint32_t len);
-
-/**
- * @brief Finalize an MD5 context and compute the digest.
- *
- * @param ctx Pointer to the MD5 context.
- * @param digest Pointer to the buffer to store the digest.
- *
- */
-void stub_lib_md5_final(struct stub_lib_md5_ctx *ctx, uint8_t digest[16]);
 
 #ifdef __cplusplus
 }

--- a/src/md5.c
+++ b/src/md5.c
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#include <stdint.h>
+#include <target/md5.h>
+
+void stub_lib_md5_init(void *ctx)
+{
+    stub_target_md5_init(ctx);
+}
+
+void stub_lib_md5_update(void *ctx, const uint8_t *data, uint32_t len)
+{
+    stub_target_md5_update(ctx, data, len);
+}
+
+void stub_lib_md5_final(void *ctx, uint8_t digest[16])
+{
+    stub_target_md5_final(ctx, digest);
+}

--- a/src/rom_wrappers.c
+++ b/src/rom_wrappers.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -8,9 +8,6 @@
 
 extern void ets_delay_us(uint32_t us);
 extern uint16_t crc16_le(uint16_t crc, const uint8_t *buf, uint32_t len);
-extern void MD5Init(struct stub_lib_md5_ctx *ctx);
-extern void MD5Update(struct stub_lib_md5_ctx *ctx, const uint8_t *data, uint32_t len);
-extern void MD5Final(uint8_t digest[16], struct stub_lib_md5_ctx *ctx);
 
 void stub_lib_delay_us(uint32_t us)
 {
@@ -20,19 +17,4 @@ void stub_lib_delay_us(uint32_t us)
 uint16_t stub_lib_crc16_le(uint16_t crc, const uint8_t *buf, uint32_t len)
 {
     return crc16_le(crc, buf, len);
-}
-
-void stub_lib_md5_init(struct stub_lib_md5_ctx *ctx)
-{
-    MD5Init(ctx);
-}
-
-void stub_lib_md5_update(struct stub_lib_md5_ctx *ctx, const uint8_t *data, uint32_t len)
-{
-    MD5Update(ctx, data, len);
-}
-
-void stub_lib_md5_final(struct stub_lib_md5_ctx *ctx, uint8_t digest[16])
-{
-    MD5Final(digest, ctx);
 }

--- a/src/target/base/include/target/md5.h
+++ b/src/target/base/include/target/md5.h
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+/**
+ * @brief Initialize an MD5 context.
+ *
+ * @param ctx Pointer to the MD5 context.
+ */
+void stub_target_md5_init(void *ctx);
+
+/**
+ * @brief Update an MD5 context with additional data.
+ *
+ * @param ctx Pointer to the MD5 context.
+ * @param data Pointer to the data to update the context with.
+ * @param len Number of bytes to process.
+ */
+void stub_target_md5_update(void *ctx, const uint8_t *data, uint32_t len);
+
+/**
+ * @brief Finalize an MD5 context and compute the digest.
+ *
+ * @param ctx Pointer to the MD5 context.
+ * @param digest Pointer to the buffer to store the digest.
+ *
+ */
+void stub_target_md5_final(void *ctx, uint8_t digest[16]);

--- a/src/target/common/CMakeLists.txt
+++ b/src/target/common/CMakeLists.txt
@@ -7,6 +7,7 @@ set(common_srcs
     src/uart.c
     src/usb_serial_jtag.c
     src/usb_otg.c
+    src/md5.c
 )
 
 add_library(${ESP_COMMON_LIB} STATIC ${common_srcs})

--- a/src/target/common/src/md5.c
+++ b/src/target/common/src/md5.c
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#include <stdint.h>
+
+extern void MD5Init(void *ctx);
+extern void MD5Update(void *ctx, const uint8_t *data, uint32_t len);
+extern void MD5Final(uint8_t digest[16], void *ctx);
+
+void __attribute__((weak)) stub_target_md5_init(void *ctx)
+{
+    MD5Init(ctx);
+}
+
+void __attribute__((weak)) stub_target_md5_update(void *ctx, const uint8_t *data, uint32_t len)
+{
+    MD5Update(ctx, data, len);
+}
+
+void __attribute__((weak)) stub_target_md5_final(void *ctx, uint8_t digest[16])
+{
+    MD5Final(digest, ctx);
+}

--- a/src/target/esp32c2/CMakeLists.txt
+++ b/src/target/esp32c2/CMakeLists.txt
@@ -2,6 +2,7 @@ set(srcs
     src/flash.c
     src/uart.c
     src/clock.c
+    src/md5.c
 )
 
 add_library(${ESP_TARGET_LIB} STATIC ${srcs})

--- a/src/target/esp32c2/ld/esp32c2.rom.api.ld
+++ b/src/target/esp32c2/ld/esp32c2.rom.api.ld
@@ -43,10 +43,6 @@ PROVIDE ( esp_rom_output_rx_string      = UartRxString );
 PROVIDE ( esp_rom_output_set_as_console = uart_tx_switch );
 PROVIDE ( esp_rom_output_putc           = ets_write_char_uart );
 
-PROVIDE ( MD5Init = mbedtls_md5_starts_ret );
-PROVIDE ( MD5Update = mbedtls_md5_update_ret );
-PROVIDE ( MD5Final = mbedtls_md5_finish_ret );
-
 PROVIDE ( esp_rom_software_reset_system = software_reset );
 PROVIDE ( esp_rom_software_reset_cpu    = software_reset_cpu );
 

--- a/src/target/esp32c2/src/md5.c
+++ b/src/target/esp32c2/src/md5.c
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#include <stdint.h>
+
+// ESP32-C2 ROM uses mbedtls_md5 instead of MD5Init, MD5Update, MD5Final
+// Context structure is a bit different, but the layout is the same.
+extern int mbedtls_md5_starts_ret(void *ctx);
+extern int mbedtls_md5_update_ret(void *ctx, const uint8_t *data, uint32_t len);
+extern int mbedtls_md5_finish_ret(void *ctx, uint8_t digest[16]);
+
+void stub_target_md5_init(void *ctx)
+{
+    mbedtls_md5_starts_ret(ctx);
+}
+
+void stub_target_md5_update(void *ctx, const uint8_t *data, uint32_t len)
+{
+    mbedtls_md5_update_ret(ctx, data, len);
+}
+
+void stub_target_md5_final(void *ctx, uint8_t digest[16])
+{
+    mbedtls_md5_finish_ret(ctx, digest);
+}


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

ESP32-C2 uses mbedtls functions which have different context structure. This is not the cleanest solution, but avoids a lot of context copying for ESP32-C2.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
