### PR TITLE
change: format files with clang-format

### DIFF
--- a/.astyle-rules.yml
+++ b/.astyle-rules.yml
@@ -1,5 +1,0 @@
----
-DEFAULT:
-  # These formatting options will be used by default.
-  options: "--style=otbs --attach-namespaces --attach-classes --indent=spaces=4 --convert-tabs --align-reference=name --align-pointer=name\
-    \ --keep-one-line-statements --pad-header --pad-oper --pad-comma --unpad-paren --max-continuation-indent=120 --max-code-length=120"

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,24 @@
+---
+BasedOnStyle: LLVM
+IndentWidth: 4
+ContinuationIndentWidth: 4
+ColumnLimit: 120
+BreakBeforeBraces: Linux
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+PointerAlignment: Right
+SpaceBeforeParens: ControlStatements
+SortIncludes: Never
+BinPackArguments: false
+BinPackParameters: false
+Cpp11BracedListStyle: false
+
+AlignConsecutiveMacros:
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: true
+
+PenaltyBreakBeforeFirstCallParameter: 1000

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # clang-format reformat
-27605ac
+aa64d6a

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,8 +42,9 @@ repos:
       - id: conventional-precommit-linter
         stages: [commit-msg]
 
-  - repo: https://github.com/espressif/astyle_py.git
-    rev: v1.1.0
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v21.1.8
     hooks:
-      - id: astyle_py
-        args: ['--astyle-version=3.4.7', '--rules=.astyle-rules.yml']
+      - id: clang-format
+        files: \.(c|h|cpp|hpp|cc|cxx)$
+        exclude: ^(include/esp-stub-lib/miniz\.h|src/target/esp8266/src/miniz\.c|src/target/.*/include/soc/.*\.h)$

--- a/example/stub_main.c
+++ b/example/stub_main.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -111,7 +111,9 @@ static int __attribute__((unused)) handle_test_uart(void)
     (void)stub_lib_uart_clear_intr_flags(UART_NUM_0);
     (void)stub_lib_uart_read_rxfifo_byte(UART_NUM_0);
     (void)stub_lib_uart_rx_one_char();
-    stub_lib_uart_rominit_intr_attach(UART_NUM_0, 5, uart_rx_interrupt_handler,
+    stub_lib_uart_rominit_intr_attach(UART_NUM_0,
+                                      5,
+                                      uart_rx_interrupt_handler,
                                       UART_INTR_RXFIFO_FULL | UART_INTR_RXFIFO_TOUT);
     stub_lib_uart_tx_one_char('A');
     stub_lib_uart_tx_flush(UART_NUM_0);
@@ -144,7 +146,7 @@ static int __attribute__((unused)) handle_test_flash(void)
     return 0;
 }
 
-static  __attribute__((unused)) int handle_test1(va_list ap)
+static __attribute__((unused)) int handle_test1(va_list ap)
 {
     (void)ap;
 
@@ -173,7 +175,7 @@ static  __attribute__((unused)) int handle_test1(va_list ap)
     return 0;
 }
 
-static  __attribute__((unused)) int handle_test2(va_list ap)
+static __attribute__((unused)) int handle_test2(va_list ap)
 {
     (void)ap;
 
@@ -184,22 +186,19 @@ static  __attribute__((unused)) int handle_test2(va_list ap)
     return 0;
 }
 
-static const struct stub_cmd_handler cmd_handlers[] = {
-    {ESP_STUB_CMD_TEST1, "CMD_TEST1", handle_test1},
-    {ESP_STUB_CMD_TEST2, "CMD_TEST2", handle_test2},
-    {0, NULL, NULL}
-};
+static const struct stub_cmd_handler cmd_handlers[] = { { ESP_STUB_CMD_TEST1, "CMD_TEST1", handle_test1 },
+                                                        { ESP_STUB_CMD_TEST2, "CMD_TEST2", handle_test2 },
+                                                        { 0, NULL, NULL } };
 
 int stub_main(int cmd, ...) __attribute__((used));
 
 #ifdef ESP8266
-__asm__(
-    ".global stub_main_esp8266\n"
-    ".literal_position\n"
-    ".align 4\n"
-    "stub_main_esp8266:\n"
-    "movi a0, 0x400010a8;"
-    "j stub_main;");
+__asm__(".global stub_main_esp8266\n"
+        ".literal_position\n"
+        ".align 4\n"
+        "stub_main_esp8266:\n"
+        "movi a0, 0x400010a8;"
+        "j stub_main;");
 #endif
 
 const char *stub_err_str(int ret_code)

--- a/example/stub_main.h
+++ b/example/stub_main.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -15,7 +15,7 @@ enum esp_stub_cmd {
 
 // Stub return codes, all compatible with esp-stub-lib/err.h without overlap
 
-#define ESP_STUB_OK                         0x0     // Equal to STUB_LIB_OK
-#define ESP_STUB_FAIL                       0x1     // Different from STUB_LIB_FAIL
+#define ESP_STUB_OK                    0x0 // Equal to STUB_LIB_OK
+#define ESP_STUB_FAIL                  0x1 // Different from STUB_LIB_FAIL
 
-#define ESP_STUB_ERR_CMD_NOT_SUPPORTED      0x2
+#define ESP_STUB_ERR_CMD_NOT_SUPPORTED 0x2

--- a/include/esp-stub-lib/bit_utils.h
+++ b/include/esp-stub-lib/bit_utils.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -11,47 +11,47 @@ extern "C" {
 #endif
 
 #ifndef BIT
-#define BIT(nr)                 (1UL << (nr))
+#define BIT(nr) (1UL << (nr))
 #endif
 
 #ifndef BIT64
-#define BIT64(nr)               (1ULL << (nr))
+#define BIT64(nr) (1ULL << (nr))
 #endif
 
 #ifndef ALIGN_MASK
-#define ALIGN_MASK(x, mask)             \
-({                                      \
-    typeof(mask) _mask = (mask);        \
-    ((x) + _mask) & ~_mask;             \
-})
+#define ALIGN_MASK(x, mask)                                                                                            \
+    ({                                                                                                                 \
+        typeof(mask) _mask = (mask);                                                                                   \
+        ((x) + _mask) & ~_mask;                                                                                        \
+    })
 #endif
 
 #ifndef ALIGN_UP
-#define ALIGN_UP(x, a)          ALIGN_MASK(x, (typeof(x))(a) - 1)
+#define ALIGN_UP(x, a) ALIGN_MASK(x, (typeof(x))(a) - 1)
 #endif
 
 #ifndef ALIGN_DOWN
-#define ALIGN_DOWN(x, a)        ((x) & ~((typeof(x))(a) - 1))
+#define ALIGN_DOWN(x, a) ((x) & ~((typeof(x))(a) - 1))
 #endif
 
 #ifndef IS_ALIGNED
-#define IS_ALIGNED(x, a)        (((x) & ((typeof(x))(a) - 1)) == 0)
+#define IS_ALIGNED(x, a) (((x) & ((typeof(x))(a) - 1)) == 0)
 #endif
 
 #ifndef MIN
-#define MIN(a, b)               ((a) < (b) ? (a) : (b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
 #ifndef MAX
-#define MAX(a, b)               ((a) > (b) ? (a) : (b))
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
 #ifndef KB
-#define KB(bytes)               ((bytes) / 1024)
+#define KB(bytes) ((bytes) / 1024)
 #endif
 
 #ifndef MB
-#define MB(bytes)               ((bytes) / (1024 * 1024))
+#define MB(bytes) ((bytes) / (1024 * 1024))
 #endif
 
 #ifdef __cplusplus

--- a/include/esp-stub-lib/err.h
+++ b/include/esp-stub-lib/err.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -15,21 +15,21 @@
  * The error code range of esp-stub-lib starts at STUB_LIB_ERROR_BASE, intentionally chosen to distinguish library codes
  */
 
-#define STUB_LIB_ERROR_BASE                     0x10000000
+#define STUB_LIB_ERROR_BASE                0x10000000
 
-#define STUB_LIB_OK                             0                       /**< Success (no error) */
-#define STUB_LIB_FAIL                           STUB_LIB_ERROR_BASE     /**< A generic error code. Prefer specific codes instead. */
+#define STUB_LIB_OK                        0                   /**< Success (no error) */
+#define STUB_LIB_FAIL                      STUB_LIB_ERROR_BASE /**< A generic error code. Prefer specific codes instead. */
 
 /** @name Specific error codes
  *  @{
  */
-#define STUB_LIB_ERR_UNKNOWN_FLASH_ID           (STUB_LIB_ERROR_BASE + 0x1)
-#define STUB_LIB_ERR_FLASH_READ_UNALIGNED       (STUB_LIB_ERROR_BASE + 0x2)
-#define STUB_LIB_ERR_FLASH_WRITE_UNALIGNED      (STUB_LIB_ERROR_BASE + 0x3)
-#define STUB_LIB_ERR_FLASH_READ_ROM_ERR         (STUB_LIB_ERROR_BASE + 0x4)
-#define STUB_LIB_ERR_NOT_SUPPORTED              (STUB_LIB_ERROR_BASE + 0x5)
-#define STUB_LIB_ERR_INVALID_ARG                (STUB_LIB_ERROR_BASE + 0x6)
-#define STUB_LIB_ERR_FLASH_BUSY                 (STUB_LIB_ERROR_BASE + 0x7)
-#define STUB_LIB_ERR_FLASH_WRITE                (STUB_LIB_ERROR_BASE + 0x8)
-#define STUB_LIB_ERR_TIMEOUT                    (STUB_LIB_ERROR_BASE + 0x9)
+#define STUB_LIB_ERR_UNKNOWN_FLASH_ID      (STUB_LIB_ERROR_BASE + 0x1)
+#define STUB_LIB_ERR_FLASH_READ_UNALIGNED  (STUB_LIB_ERROR_BASE + 0x2)
+#define STUB_LIB_ERR_FLASH_WRITE_UNALIGNED (STUB_LIB_ERROR_BASE + 0x3)
+#define STUB_LIB_ERR_FLASH_READ_ROM_ERR    (STUB_LIB_ERROR_BASE + 0x4)
+#define STUB_LIB_ERR_NOT_SUPPORTED         (STUB_LIB_ERROR_BASE + 0x5)
+#define STUB_LIB_ERR_INVALID_ARG           (STUB_LIB_ERROR_BASE + 0x6)
+#define STUB_LIB_ERR_FLASH_BUSY            (STUB_LIB_ERROR_BASE + 0x7)
+#define STUB_LIB_ERR_FLASH_WRITE           (STUB_LIB_ERROR_BASE + 0x8)
+#define STUB_LIB_ERR_TIMEOUT               (STUB_LIB_ERROR_BASE + 0x9)
 /** @} */

--- a/include/esp-stub-lib/flash.h
+++ b/include/esp-stub-lib/flash.h
@@ -10,10 +10,10 @@
 #include <stdbool.h>
 
 /* Flash geometry constants */
-#define STUB_FLASH_SECTOR_SIZE          0x1000U
-#define STUB_FLASH_BLOCK_SIZE           0x10000U
-#define STUB_FLASH_PAGE_SIZE            0x100U
-#define STUB_FLASH_STATUS_MASK          0xFFFFU
+#define STUB_FLASH_SECTOR_SIZE 0x1000U
+#define STUB_FLASH_BLOCK_SIZE  0x10000U
+#define STUB_FLASH_PAGE_SIZE   0x100U
+#define STUB_FLASH_STATUS_MASK 0xFFFFU
 
 typedef struct stub_lib_flash_info {
     uint32_t id;

--- a/include/esp-stub-lib/log.h
+++ b/include/esp-stub-lib/log.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -19,22 +19,26 @@ void stub_lib_log_printf(const char *fmt, ...);
 }
 #endif // __cplusplus
 
-#define STUB_LOG_INIT() stub_lib_log_init()
+#define STUB_LOG_INIT()    stub_lib_log_init()
 #define STUB_LOG(fmt, ...) stub_lib_log_printf(fmt, ##__VA_ARGS__)
 
 #else // defined(STUB_LOG_ENABLED)
 
-#define STUB_LOG_INIT() do {} while(0)
-#define STUB_LOG(fmt, ...) do {} while(0)
+#define STUB_LOG_INIT()                                                                                                \
+    do {                                                                                                               \
+    } while (0)
+#define STUB_LOG(fmt, ...)                                                                                             \
+    do {                                                                                                               \
+    } while (0)
 
 #endif // defined(STUB_LOG_ENABLED)
 
-#define STUB_LOGE(fmt, ...) STUB_LOG("STUB_E: " fmt, ##__VA_ARGS__)
-#define STUB_LOGW(fmt, ...) STUB_LOG("STUB_W: " fmt, ##__VA_ARGS__)
-#define STUB_LOGI(fmt, ...) STUB_LOG("STUB_I: " fmt, ##__VA_ARGS__)
-#define STUB_LOGD(fmt, ...) STUB_LOG("STUB_D: " fmt, ##__VA_ARGS__)
-#define STUB_LOGV(fmt, ...) STUB_LOG("STUB_V: " fmt, ##__VA_ARGS__)
+#define STUB_LOGE(fmt, ...)       STUB_LOG("STUB_E: " fmt, ##__VA_ARGS__)
+#define STUB_LOGW(fmt, ...)       STUB_LOG("STUB_W: " fmt, ##__VA_ARGS__)
+#define STUB_LOGI(fmt, ...)       STUB_LOG("STUB_I: " fmt, ##__VA_ARGS__)
+#define STUB_LOGD(fmt, ...)       STUB_LOG("STUB_D: " fmt, ##__VA_ARGS__)
+#define STUB_LOGV(fmt, ...)       STUB_LOG("STUB_V: " fmt, ##__VA_ARGS__)
 // trace only function name
-#define STUB_LOG_TRACE() STUB_LOG("STUB_T: %s()\n", __func__)
+#define STUB_LOG_TRACE()          STUB_LOG("STUB_T: %s()\n", __func__)
 // trace with format
 #define STUB_LOG_TRACEF(fmt, ...) STUB_LOG("STUB_T: %s(): " fmt, __func__, ##__VA_ARGS__)

--- a/include/esp-stub-lib/soc_utils.h
+++ b/include/esp-stub-lib/soc_utils.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -9,82 +9,85 @@
 #include <stdint.h>
 
 #define ETS_UNCACHED_ADDR(addr) (addr)
-#define ETS_CACHED_ADDR(addr) (addr)
+#define ETS_CACHED_ADDR(addr)   (addr)
 
 // Base register read/write macros
-#define REG_READ(_r) ({                                                                                                \
-            (*(volatile uint32_t *)(_r));                                                                              \
-        })
+#define REG_READ(_r)            ({ (*(volatile uint32_t *)(_r)); })
 
-#define REG_WRITE(_r, _v)  do {                                                                                        \
-            (*(volatile uint32_t *)(_r)) = (_v);                                                                       \
-        } while(0)
+#define REG_WRITE(_r, _v)                                                                                              \
+    do {                                                                                                               \
+        (*(volatile uint32_t *)(_r)) = (_v);                                                                           \
+    } while (0)
 
 // Bit manipulation macros
-#define REG_GET_BIT(_r, _b)  ({                                                                                        \
-            (REG_READ(_r) & (_b));                                                                                     \
-        })
+#define REG_GET_BIT(_r, _b) ({ (REG_READ(_r) & (_b)); })
 
-#define REG_SET_BIT(_r, _b)  do {                                                                                      \
-            REG_WRITE(_r, REG_READ(_r) | (_b));                                                                        \
-        } while(0)
+#define REG_SET_BIT(_r, _b)                                                                                            \
+    do {                                                                                                               \
+        REG_WRITE(_r, REG_READ(_r) | (_b));                                                                            \
+    } while (0)
 
-#define REG_CLR_BIT(_r, _b)  do {                                                                                      \
-            REG_WRITE(_r, REG_READ(_r) & (~(volatile uint32_t)(_b)));                                                  \
-        } while(0)
+#define REG_CLR_BIT(_r, _b)                                                                                            \
+    do {                                                                                                               \
+        REG_WRITE(_r, REG_READ(_r) & (~(volatile uint32_t)(_b)));                                                      \
+    } while (0)
 
-#define REG_SET_BITS(_r, _b, _m) do {                                                                                  \
-            REG_WRITE(_r, (REG_READ(_r) & ~(volatile uint32_t)(_m)) | ((volatile uint32_t)(_b) & (volatile uint32_t)(_m))); \
-        } while(0)
+#define REG_SET_BITS(_r, _b, _m)                                                                                       \
+    do {                                                                                                               \
+        REG_WRITE(_r,                                                                                                  \
+                  (REG_READ(_r) & ~(volatile uint32_t)(_m)) | ((volatile uint32_t)(_b) & (volatile uint32_t)(_m)));    \
+    } while (0)
 
 // Field manipulation macros
-#define REG_GET_FIELD(_r, _f) ({                                                                                       \
-            ((REG_READ(_r) >> (_f##_S)) & (_f##_V));                                                                   \
-        })
+#define REG_GET_FIELD(_r, _f) ({ ((REG_READ(_r) >> (_f##_S)) & (_f##_V)); })
 
-#define REG_SET_FIELD(_r, _f, _v) do {                                                                                 \
-            REG_WRITE(_r, (REG_READ(_r) & ~((volatile uint32_t)((_f##_V) << (_f##_S)))) | (((volatile uint32_t)(_v) & (_f##_V)) << (_f##_S))); \
-        } while(0)
+#define REG_SET_FIELD(_r, _f, _v)                                                                                      \
+    do {                                                                                                               \
+        REG_WRITE(_r,                                                                                                  \
+                  (REG_READ(_r) & ~((volatile uint32_t)((_f##_V) << (_f##_S)))) |                                      \
+                      (((volatile uint32_t)(_v) & (_f##_V)) << (_f##_S)));                                             \
+    } while (0)
 
 // Value field manipulation macros
-#define VALUE_GET_FIELD(_r, _f) (((_r) >> (_f##_S)) & (_f))
+#define VALUE_GET_FIELD(_r, _f)  (((_r) >> (_f##_S)) & (_f))
 
 #define VALUE_GET_FIELD2(_r, _f) (((_r) & (_f)) >> (_f##_S))
 
-#define VALUE_SET_FIELD(_r, _f, _v) ((_r) = ((_r) & ~((volatile uint32_t)((_f) << (_f##_S)))) | ((volatile uint32_t)(_v) << (_f##_S)))
+#define VALUE_SET_FIELD(_r, _f, _v)                                                                                    \
+    ((_r) = ((_r) & ~((volatile uint32_t)((_f) << (_f##_S)))) | ((volatile uint32_t)(_v) << (_f##_S)))
 
 #define VALUE_SET_FIELD2(_r, _f, _v) ((_r) = ((_r) & ~(volatile uint32_t)(_f)) | ((volatile uint32_t)(_v) << (_f##_S)))
 
 // Field to value conversion macros
-#define FIELD_TO_VALUE(_f, _v) (((_v) & (_f)) << _f##_S)
+#define FIELD_TO_VALUE(_f, _v)       (((_v) & (_f)) << _f##_S)
 
-#define FIELD_TO_VALUE2(_f, _v) (((_v) << _f##_S) & (_f))
+#define FIELD_TO_VALUE2(_f, _v)      (((_v) << _f##_S) & (_f))
 
 // Peripheral register macros
-#define READ_PERI_REG(addr) REG_READ(ETS_UNCACHED_ADDR(addr))
+#define READ_PERI_REG(addr)          REG_READ(ETS_UNCACHED_ADDR(addr))
 
-#define WRITE_PERI_REG(addr, val) REG_WRITE(ETS_UNCACHED_ADDR(addr), (uint32_t)(val))
+#define WRITE_PERI_REG(addr, val)    REG_WRITE(ETS_UNCACHED_ADDR(addr), (uint32_t)(val))
 
-#define CLEAR_PERI_REG_MASK(reg, mask) do {                                                                            \
-            WRITE_PERI_REG(reg, READ_PERI_REG(reg) & (~(volatile uint32_t)(mask)));                                    \
-        } while(0)
+#define CLEAR_PERI_REG_MASK(reg, mask)                                                                                 \
+    do {                                                                                                               \
+        WRITE_PERI_REG(reg, READ_PERI_REG(reg) & (~(volatile uint32_t)(mask)));                                        \
+    } while (0)
 
-#define SET_PERI_REG_MASK(reg, mask) do {                                                                              \
-            WRITE_PERI_REG(reg, READ_PERI_REG(reg) | (mask));                                                          \
-        } while(0)
+#define SET_PERI_REG_MASK(reg, mask)                                                                                   \
+    do {                                                                                                               \
+        WRITE_PERI_REG(reg, READ_PERI_REG(reg) | (mask));                                                              \
+    } while (0)
 
-#define GET_PERI_REG_MASK(reg, mask) ({                                                                                \
-            (READ_PERI_REG(reg) & (mask));                                                                             \
-        })
+#define GET_PERI_REG_MASK(reg, mask) ({ (READ_PERI_REG(reg) & (mask)); })
 
-#define GET_PERI_REG_BITS(reg, hipos, lowpos) ({                                                                       \
-            ((READ_PERI_REG(reg) >> (lowpos)) & ((1 << ((hipos) - (lowpos) + 1)) - 1));                                \
-        })
+#define GET_PERI_REG_BITS(reg, hipos, lowpos)                                                                          \
+    ({ ((READ_PERI_REG(reg) >> (lowpos)) & ((1 << ((hipos) - (lowpos) + 1)) - 1)); })
 
-#define SET_PERI_REG_BITS(reg, bit_map, value, shift) do {                                                             \
-            WRITE_PERI_REG(reg, (READ_PERI_REG(reg) & (~((volatile uint32_t)(bit_map) << (shift)))) | (((volatile uint32_t)(value) & (volatile uint32_t)(bit_map)) << (shift))); \
-        } while(0)
+#define SET_PERI_REG_BITS(reg, bit_map, value, shift)                                                                  \
+    do {                                                                                                               \
+        WRITE_PERI_REG(reg,                                                                                            \
+                       (READ_PERI_REG(reg) & (~((volatile uint32_t)(bit_map) << (shift)))) |                           \
+                           (((volatile uint32_t)(value) & (volatile uint32_t)(bit_map)) << (shift)));                  \
+    } while (0)
 
-#define GET_PERI_REG_BITS2(reg, mask, shift) ({                                                                        \
-            ((READ_PERI_REG(reg) >> (shift)) & (mask));                                                                \
-        })
+#define GET_PERI_REG_BITS2(reg, mask, shift) ({ ((READ_PERI_REG(reg) >> (shift)) & (mask)); })

--- a/include/esp-stub-lib/trax_mem.h
+++ b/include/esp-stub-lib/trax_mem.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -11,17 +11,17 @@
 #include <target/trax.h>
 #include "bit_utils.h"
 
-#define ERI_DEBUG_OFFSET        0x100000
-#define ERI_TRAX_OFFSET         (ERI_DEBUG_OFFSET + 0x0)
-#define ERI_PERFMON_OFFSET      (ERI_DEBUG_OFFSET + 0x1000)
-#define ERI_TRAX_TRAXCTRL       (ERI_TRAX_OFFSET + 0x4)
-#define ERI_TRAX_TRIGGERPC      (ERI_TRAX_OFFSET + 0x14)
-#define ERI_TRAX_DELAYCNT       (ERI_TRAX_OFFSET + 0x1C)
+#define ERI_DEBUG_OFFSET   0x100000
+#define ERI_TRAX_OFFSET    (ERI_DEBUG_OFFSET + 0x0)
+#define ERI_PERFMON_OFFSET (ERI_DEBUG_OFFSET + 0x1000)
+#define ERI_TRAX_TRAXCTRL  (ERI_TRAX_OFFSET + 0x4)
+#define ERI_TRAX_TRIGGERPC (ERI_TRAX_OFFSET + 0x14)
+#define ERI_TRAX_DELAYCNT  (ERI_TRAX_OFFSET + 0x1C)
 
-#define ERI_PERFMON_PM1         (ERI_PERFMON_OFFSET + 0x84) /* used in apptrace module to store CRC16 */
+#define ERI_PERFMON_PM1    (ERI_PERFMON_OFFSET + 0x84) /* used in apptrace module to store CRC16 */
 
-#define TRAXCTRL_TRSTP          BIT(1)  // Trace Stop. Make 1 to stop trace.
-#define TRAXCTRL_TMEN           BIT(7)  // Trace Memory Enable. Always set.
+#define TRAXCTRL_TRSTP     BIT(1) // Trace Stop. Make 1 to stop trace.
+#define TRAXCTRL_TMEN      BIT(7) // Trace Memory Enable. Always set.
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,19 +30,13 @@ extern "C" {
 static inline uint32_t eri_read(int addr)
 {
     uint32_t ret;
-    asm volatile(
-        "RER %0,%1"
-        :"=r"(ret):"r"(addr)
-    );
+    asm volatile("RER %0,%1" : "=r"(ret) : "r"(addr));
     return ret;
 }
 
 static inline void eri_write(int addr, uint32_t data)
 {
-    asm volatile(
-        "WER %0,%1"
-        ::"r"(data), "r"(addr)
-    );
+    asm volatile("WER %0,%1" ::"r"(data), "r"(addr));
 }
 
 /*

--- a/include/esp-stub-lib/uart.h
+++ b/include/esp-stub-lib/uart.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -22,22 +22,22 @@ extern "C" {
  */
 
 typedef enum {
-    UART_NUM_0,                         /*!< UART port 0 */
-    UART_NUM_1,                         /*!< UART port 1 */
+    UART_NUM_0, /*!< UART port 0 */
+    UART_NUM_1, /*!< UART port 1 */
 #if SOC_UART_HP_NUM > 2
-    UART_NUM_2,                         /*!< UART port 2 */
+    UART_NUM_2, /*!< UART port 2 */
 #endif
 #if SOC_UART_HP_NUM > 3
-    UART_NUM_3,                         /*!< UART port 3 */
+    UART_NUM_3, /*!< UART port 3 */
 #endif
 #if SOC_UART_HP_NUM > 4
-    UART_NUM_4,                         /*!< UART port 4 */
+    UART_NUM_4, /*!< UART port 4 */
 #endif
-    UART_NUM_MAX,                       /*!< UART port max */
+    UART_NUM_MAX, /*!< UART port max */
 } uart_port_t;
 
-#define UART_INTR_RXFIFO_FULL      (0x1 << 0)
-#define UART_INTR_RXFIFO_TOUT      (0x1 << 8)
+#define UART_INTR_RXFIFO_FULL (0x1 << 0)
+#define UART_INTR_RXFIFO_TOUT (0x1 << 8)
 
 /**
  * @brief Wait until UART is idle

--- a/include/esp-stub-lib/usb_serial_jtag.h
+++ b/include/esp-stub-lib/usb_serial_jtag.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -10,11 +10,10 @@
 #include <stdbool.h>
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif // __cplusplus
 
-#define USB_SERIAL_JTAG_OUT_RECV_PKT_INT_ENA    (0x1 << 2)
+#define USB_SERIAL_JTAG_OUT_RECV_PKT_INT_ENA (0x1 << 2)
 
 /**
  * @brief Check if USB-Serial/JTAG is currently being used for communication

--- a/src/flash.c
+++ b/src/flash.c
@@ -22,8 +22,12 @@ static bool large_flash_mode = false;
 
 int stub_lib_flash_update_config(stub_lib_flash_config_t *config)
 {
-    return stub_target_flash_update_config(config->flash_id, config->flash_size, config->block_size, config->sector_size,
-                                           config->page_size, config->status_mask);
+    return stub_target_flash_update_config(config->flash_id,
+                                           config->flash_size,
+                                           config->block_size,
+                                           config->sector_size,
+                                           config->page_size,
+                                           config->status_mask);
 }
 
 void stub_lib_flash_attach(uint32_t ishspi, bool legacy)
@@ -45,8 +49,12 @@ int stub_lib_flash_init(void **state)
     }
     STUB_LOG_TRACEF("Flash size: %d MB\n", MB(flash_size));
 
-    return stub_target_flash_update_config(flash_id, flash_size, STUB_FLASH_BLOCK_SIZE, STUB_FLASH_SECTOR_SIZE,
-                                           STUB_FLASH_PAGE_SIZE, STUB_FLASH_STATUS_MASK);
+    return stub_target_flash_update_config(flash_id,
+                                           flash_size,
+                                           STUB_FLASH_BLOCK_SIZE,
+                                           STUB_FLASH_SECTOR_SIZE,
+                                           STUB_FLASH_PAGE_SIZE,
+                                           STUB_FLASH_STATUS_MASK);
 }
 
 void stub_lib_flash_deinit(const void *state)
@@ -63,7 +71,7 @@ void stub_lib_flash_get_info(stub_lib_flash_info_t *info)
     info->block_size = chip->block_size;
     info->sector_size = chip->sector_size;
     info->page_size = chip->page_size;
-    info->mode = 0; // TODO: Implement
+    info->mode = 0;      // TODO: Implement
     info->encrypted = 0; // TODO: Implement
 }
 
@@ -76,12 +84,14 @@ void stub_lib_flash_info_print(const stub_lib_flash_info_t *info)
               "\tmode: %d, enc: %d\n",
               info->id,
               KB(info->size),
-              KB(info->block_size), info->block_size,
-              info->sector_size, info->sector_size,
-              info->page_size, info->page_size,
+              KB(info->block_size),
+              info->block_size,
+              info->sector_size,
+              info->sector_size,
+              info->page_size,
+              info->page_size,
               info->mode,
-              info->encrypted
-             );
+              info->encrypted);
 }
 
 int stub_lib_flash_read_buff(uint32_t addr, void *buffer, uint32_t size)
@@ -93,7 +103,11 @@ int stub_lib_flash_read_buff(uint32_t addr, void *buffer, uint32_t size)
 
     if (large_flash_mode) {
         int res = stub_target_flash_4byte_read(SPI_NUM, addr, (uint8_t *)buffer, size);
-        STUB_LOG_TRACEF("stub_target_flash_4byte_read(0x%x, 0x%x, %u) results: %d\n", addr, (uint32_t)buffer, size, res);
+        STUB_LOG_TRACEF("stub_target_flash_4byte_read(0x%x, 0x%x, %u) results: %d\n",
+                        addr,
+                        (uint32_t)buffer,
+                        size,
+                        res);
         return (res == 0) ? STUB_LIB_OK : STUB_LIB_ERR_FLASH_READ_ROM_ERR;
     }
     return stub_target_flash_read_buff(addr, buffer, size);
@@ -108,7 +122,11 @@ int stub_lib_flash_write_buff(uint32_t addr, const void *buffer, uint32_t size, 
 
     if (large_flash_mode) {
         int res = stub_target_flash_4byte_write(SPI_NUM, addr, buffer, size, encrypt);
-        STUB_LOG_TRACEF("stub_target_flash_4byte_write(0x%x, 0x%x, %u) results: %d\n", addr, (uint32_t)buffer, size, res);
+        STUB_LOG_TRACEF("stub_target_flash_4byte_write(0x%x, 0x%x, %u) results: %d\n",
+                        addr,
+                        (uint32_t)buffer,
+                        size,
+                        res);
         return (res == 0) ? STUB_LIB_OK : STUB_LIB_FAIL;
     }
     return stub_target_flash_write_buff(addr, buffer, size, encrypt);

--- a/src/log_common.c
+++ b/src/log_common.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -23,14 +23,14 @@ void stub_lib_log_printf(const char *fmt, ...)
             continue;
         }
 
-        fmt++;  // Skip the '%'
+        fmt++; // Skip the '%'
 
         switch (*fmt) {
         case 's': {
             const char *s = va_arg(args, const char *);
             ets_printf("%s", s ? s : "(null)");
+            break;
         }
-        break;
         case 'd': {
             int d = va_arg(args, int);
             if (d < 0) {
@@ -38,8 +38,8 @@ void stub_lib_log_printf(const char *fmt, ...)
             } else {
                 ets_printf("%u", (unsigned int)d);
             }
+            break;
         }
-        break;
         case 'u':
         case 'x':
         case 'X':

--- a/src/target/base/include/private/rom_flash.h
+++ b/src/target/base/include/private/rom_flash.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -11,7 +11,7 @@
 
 typedef struct esp_rom_spiflash_chip {
     uint32_t flash_id;
-    uint32_t chip_size;    // chip size in bytes
+    uint32_t chip_size; // chip size in bytes
     uint32_t block_size;
     uint32_t sector_size;
     uint32_t page_size;
@@ -25,62 +25,65 @@ typedef enum {
 } esp_rom_spiflash_result_t;
 
 /**
-  * @brief SPI Flash init
-  *
-  * @param spiconfig
-  * (for ESP32 chip)
-  * - 0 for default SPI pins
-  * - 1 for default HSPI pins
-  * - other for custom pin configuration
-  *
-  * (for S2, C3, S3 chips)
-  * - 0 for auto SPI configuration from eFuse is supported
-  * - value for custom pin configuration
-  *
-  * (others chips)
-  * - 0 is only a compatibility value, auto SPI configuration is not supported
-  *
-  * @param legacy
-  * - false is only a deprecated compatibility API value, for all chips
-  *
-  */
+ * @brief SPI Flash init
+ *
+ * @param spiconfig
+ * (for ESP32 chip)
+ * - 0 for default SPI pins
+ * - 1 for default HSPI pins
+ * - other for custom pin configuration
+ *
+ * (for S2, C3, S3 chips)
+ * - 0 for auto SPI configuration from eFuse is supported
+ * - value for custom pin configuration
+ *
+ * (others chips)
+ * - 0 is only a compatibility value, auto SPI configuration is not supported
+ *
+ * @param legacy
+ * - false is only a deprecated compatibility API value, for all chips
+ *
+ */
 extern void esp_rom_spiflash_attach(uint32_t spiconfig, bool legacy);
 
 /**
-  * @brief Initialize internal ROM config's flash_id from hw registers
-  *
-  */
+ * @brief Initialize internal ROM config's flash_id from hw registers
+ *
+ */
 extern void esp_rom_spi_flash_update_id(void);
 
 /**
-  * @brief Initialize internal ROM config from arguments
-  *
-  * @return Always returns 0.
-  */
-extern int esp_rom_spiflash_config_param(uint32_t flash_id, uint32_t chip_size,
-                                         uint32_t block_size, uint32_t sector_size,
-                                         uint32_t page_size, uint32_t status_mask);
+ * @brief Initialize internal ROM config from arguments
+ *
+ * @return Always returns 0.
+ */
+extern int esp_rom_spiflash_config_param(uint32_t flash_id,
+                                         uint32_t chip_size,
+                                         uint32_t block_size,
+                                         uint32_t sector_size,
+                                         uint32_t page_size,
+                                         uint32_t status_mask);
 
 /**
-  * @brief Read data from Flash
-  *
-  * @param src_addr Address to read from. Should be 4 bytes aligned.
-  * @param buffer Destination buffer
-  * @param size Number of bytes to read. Should be 4 bytes aligned.
-  *
-  * @return Result
-  * - ESP_ROM_SPIFLASH_RESULT_OK
-  * - ESP_ROM_SPIFLASH_RESULT_ERR
-  */
+ * @brief Read data from Flash
+ *
+ * @param src_addr Address to read from. Should be 4 bytes aligned.
+ * @param buffer Destination buffer
+ * @param size Number of bytes to read. Should be 4 bytes aligned.
+ *
+ * @return Result
+ * - ESP_ROM_SPIFLASH_RESULT_OK
+ * - ESP_ROM_SPIFLASH_RESULT_ERR
+ */
 esp_rom_spiflash_result_t esp_rom_spiflash_read(uint32_t src_addr, uint32_t *dest, int32_t len);
 
 /**
-  * @brief Unlock SPI Flash
-  *
-  * @return Result
-  * - ESP_ROM_SPIFLASH_RESULT_OK
-  * - ESP_ROM_SPIFLASH_RESULT_ERR
-  */
+ * @brief Unlock SPI Flash
+ *
+ * @return Result
+ * - ESP_ROM_SPIFLASH_RESULT_OK
+ * - ESP_ROM_SPIFLASH_RESULT_ERR
+ */
 esp_rom_spiflash_result_t esp_rom_spiflash_unlock(void);
 
 /**

--- a/src/target/base/include/target/aes_xts.h
+++ b/src/target/base/include/target/aes_xts.h
@@ -28,8 +28,8 @@
  */
 static inline int stub_target_wait_reg_state(uint32_t reg, uint32_t expected_state, uint64_t *timeout_us)
 {
-    if (!timeout_us || *timeout_us == 0)  {
-        return REG_READ(reg) == expected_state ? STUB_LIB_OK  :  STUB_LIB_ERR_TIMEOUT;
+    if (!timeout_us || *timeout_us == 0) {
+        return REG_READ(reg) == expected_state ? STUB_LIB_OK : STUB_LIB_ERR_TIMEOUT;
     }
 
     while ((*timeout_us)--) {

--- a/src/target/base/include/target/flash.h
+++ b/src/target/base/include/target/flash.h
@@ -73,8 +73,12 @@ struct esp_rom_spiflash_chip *stub_target_flash_get_config(void);
  * - STUB_LIB_OK if success
  * - STUB_LIB_FAIL on ROM config error
  */
-int stub_target_flash_update_config(uint32_t flash_id, uint32_t flash_size, uint32_t block_size, uint32_t sector_size,
-                                    uint32_t page_size, uint32_t status_mask);
+int stub_target_flash_update_config(uint32_t flash_id,
+                                    uint32_t flash_size,
+                                    uint32_t block_size,
+                                    uint32_t sector_size,
+                                    uint32_t page_size,
+                                    uint32_t status_mask);
 
 /**
  * @brief Infer flash size (in bytes) from Flash ID
@@ -212,19 +216,19 @@ void stub_target_flash_write_enable(void);
  * flash command with configurable parameters.
  */
 typedef struct opiflash_cmd_params {
-    int spi_num;                        /**< SPI peripheral number (typically 1 for flash) */
-    spi_flash_mode_t mode;              /**< Read mode (SLOWRD, FASTRD, etc.) */
-    uint32_t cmd;                       /**< Command opcode */
-    int cmd_bit_len;                    /**< Command length in bits */
-    uint32_t addr;                      /**< Address value */
-    int addr_bit_len;                   /**< Address length in bits (32 for 4-byte addressing) */
-    int dummy_bits;                     /**< Number of dummy clock cycles */
-    const uint8_t *mosi_data;           /**< Data to send (write operations) */
-    int mosi_bit_len;                   /**< Length of data to send in bits */
-    uint8_t *miso_data;                 /**< Buffer to receive data (read operations) */
-    int miso_bit_len;                   /**< Length of data to receive in bits */
-    uint32_t cs_mask;                   /**< Chip select mask (ESP_ROM_OPIFLASH_SEL_CS0 or CS1) */
-    bool is_write_erase_operation;      /**< True for write/erase, false for read */
+    int spi_num;                   /**< SPI peripheral number (typically 1 for flash) */
+    spi_flash_mode_t mode;         /**< Read mode (SLOWRD, FASTRD, etc.) */
+    uint32_t cmd;                  /**< Command opcode */
+    int cmd_bit_len;               /**< Command length in bits */
+    uint32_t addr;                 /**< Address value */
+    int addr_bit_len;              /**< Address length in bits (32 for 4-byte addressing) */
+    int dummy_bits;                /**< Number of dummy clock cycles */
+    const uint8_t *mosi_data;      /**< Data to send (write operations) */
+    int mosi_bit_len;              /**< Length of data to send in bits */
+    uint8_t *miso_data;            /**< Buffer to receive data (read operations) */
+    int miso_bit_len;              /**< Length of data to receive in bits */
+    uint32_t cs_mask;              /**< Chip select mask (ESP_ROM_OPIFLASH_SEL_CS0 or CS1) */
+    bool is_write_erase_operation; /**< True for write/erase, false for read */
 } opiflash_cmd_params_t;
 
 /**

--- a/src/target/common/src/aes_xts.c
+++ b/src/target/common/src/aes_xts.c
@@ -13,8 +13,8 @@ void __attribute__((weak)) stub_target_aes_xts_init(void)
     // Empty weak function for targets that does not support AES-XTS
 }
 
-void __attribute__((weak)) stub_target_aes_xts_encrypt_trigger(uint32_t flash_addr, const void *data,
-                                                               uint32_t block_size)
+void __attribute__((weak))
+stub_target_aes_xts_encrypt_trigger(uint32_t flash_addr, const void *data, uint32_t block_size)
 {
     // Empty weak function for targets that does not support AES-XTS
     (void)flash_addr;

--- a/src/target/common/src/flash.c
+++ b/src/target/common/src/flash.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -24,11 +24,15 @@ extern void esp_rom_spiflash_write_encrypted_enable(void);
 extern void esp_rom_spiflash_write_encrypted_disable(void);
 extern esp_rom_spiflash_result_t esp_rom_spiflash_unlock(void);
 
-int stub_target_flash_update_config(uint32_t flash_id, uint32_t flash_size, uint32_t block_size, uint32_t sector_size,
-                                    uint32_t page_size, uint32_t status_mask)
+int stub_target_flash_update_config(uint32_t flash_id,
+                                    uint32_t flash_size,
+                                    uint32_t block_size,
+                                    uint32_t sector_size,
+                                    uint32_t page_size,
+                                    uint32_t status_mask)
 {
-    esp_rom_spiflash_result_t res = esp_rom_spiflash_config_param(flash_id, flash_size, block_size, sector_size, page_size,
-                                                                  status_mask);
+    esp_rom_spiflash_result_t res =
+        esp_rom_spiflash_config_param(flash_id, flash_size, block_size, sector_size, page_size, status_mask);
     if (res != ESP_ROM_SPIFLASH_RESULT_OK) {
         STUB_LOGE("Failed to update flash config: %d\n", res);
         return STUB_LIB_FAIL;
@@ -40,17 +44,17 @@ uint32_t stub_target_flash_id_to_flash_size(uint32_t flash_id)
 {
     const uint32_t id = flash_id & 0xff;
     switch (id) {
-    case 0x12:  // 256 KB
+    case 0x12: // 256 KB
     case 0x13:
-    case 0x14:  // 1 MB
+    case 0x14: // 1 MB
     case 0x15:
     case 0x16:
     case 0x17:
     case 0x18:
-    case 0x19:  // 32 MB
-    case 0x1A:  // 64 MB
-    case 0x1B:  // 128 MB
-    case 0x1C:  // 256 MB
+    case 0x19: // 32 MB
+    case 0x1A: // 64 MB
+    case 0x1B: // 128 MB
+    case 0x1C: // 256 MB
         return 1u << id;
     case 0x39:
         return 32 * 1024 * 1024;
@@ -113,7 +117,7 @@ int __attribute__((weak)) stub_target_flash_read_buff(uint32_t addr, void *buffe
 
 int stub_target_flash_erase_chip(void)
 {
-    if (esp_rom_spiflash_erase_chip()  == ESP_ROM_SPIFLASH_RESULT_OK) {
+    if (esp_rom_spiflash_erase_chip() == ESP_ROM_SPIFLASH_RESULT_OK) {
         return STUB_LIB_OK;
     }
     return STUB_LIB_FAIL;

--- a/src/target/common/src/flash_4byte.c
+++ b/src/target/common/src/flash_4byte.c
@@ -17,9 +17,9 @@
 #include <esp-stub-lib/flash.h>
 
 // Timeout values for flash operations, inspired by esptool
-#define DEFAULT_TIMEOUT_US 10000U
-#define ERASE_PER_KB_TIMEOUT_US 30000U
-#define WRITE_PER_KB_TIMEOUT_US 30000U
+#define DEFAULT_TIMEOUT_US        10000U
+#define ERASE_PER_KB_TIMEOUT_US   30000U
+#define WRITE_PER_KB_TIMEOUT_US   30000U
 
 // AES-XTS encryption block sizes for encrypted flash write operations
 // The hardware AES-XTS engine can process multiple 128-bit blocks simultaneously when
@@ -38,59 +38,53 @@
 
 static void exec_write_cmd_4b(int spi_num, uint32_t flash_addr, const uint8_t *data, int bit_len)
 {
-    stub_target_opiflash_exec_cmd(&(opiflash_cmd_params_t) {
-        .spi_num = spi_num,
-        .mode = SPI_FLASH_FASTRD_MODE,
-        .cmd = CMD_PROGRAM_PAGE_4B,
-        .cmd_bit_len = 8,
-        .addr = flash_addr,
-        .addr_bit_len = 32,
-        .dummy_bits = 0,
-        .mosi_data = data,
-        .mosi_bit_len = bit_len,
-        .miso_data = NULL,
-        .miso_bit_len = 0,
-        .cs_mask = ESP_ROM_OPIFLASH_SEL_CS0,
-        .is_write_erase_operation = true
-    });
+    stub_target_opiflash_exec_cmd(&(opiflash_cmd_params_t){ .spi_num = spi_num,
+                                                            .mode = SPI_FLASH_FASTRD_MODE,
+                                                            .cmd = CMD_PROGRAM_PAGE_4B,
+                                                            .cmd_bit_len = 8,
+                                                            .addr = flash_addr,
+                                                            .addr_bit_len = 32,
+                                                            .dummy_bits = 0,
+                                                            .mosi_data = data,
+                                                            .mosi_bit_len = bit_len,
+                                                            .miso_data = NULL,
+                                                            .miso_bit_len = 0,
+                                                            .cs_mask = ESP_ROM_OPIFLASH_SEL_CS0,
+                                                            .is_write_erase_operation = true });
 }
 
 static void exec_read_cmd_4b(int spi_num, uint32_t flash_addr, uint8_t *buffer, int bit_len)
 {
-    stub_target_opiflash_exec_cmd(&(opiflash_cmd_params_t) {
-        .spi_num = spi_num,
-        .mode = SPI_FLASH_FASTRD_MODE,
-        .cmd = CMD_FSTRD4B,
-        .cmd_bit_len = 8,
-        .addr = flash_addr,
-        .addr_bit_len = 32,
-        .dummy_bits = 8,
-        .mosi_data = NULL,
-        .mosi_bit_len = 0,
-        .miso_data = buffer,
-        .miso_bit_len = bit_len,
-        .cs_mask = ESP_ROM_OPIFLASH_SEL_CS0,
-        .is_write_erase_operation = false
-    });
+    stub_target_opiflash_exec_cmd(&(opiflash_cmd_params_t){ .spi_num = spi_num,
+                                                            .mode = SPI_FLASH_FASTRD_MODE,
+                                                            .cmd = CMD_FSTRD4B,
+                                                            .cmd_bit_len = 8,
+                                                            .addr = flash_addr,
+                                                            .addr_bit_len = 32,
+                                                            .dummy_bits = 8,
+                                                            .mosi_data = NULL,
+                                                            .mosi_bit_len = 0,
+                                                            .miso_data = buffer,
+                                                            .miso_bit_len = bit_len,
+                                                            .cs_mask = ESP_ROM_OPIFLASH_SEL_CS0,
+                                                            .is_write_erase_operation = false });
 }
 
 static void exec_erase_cmd_4b(int spi_num, uint32_t flash_addr, uint8_t erase_cmd)
 {
-    stub_target_opiflash_exec_cmd(&(opiflash_cmd_params_t) {
-        .spi_num = spi_num,
-        .mode = SPI_FLASH_SLOWRD_MODE,
-        .cmd = erase_cmd,
-        .cmd_bit_len = 8,
-        .addr = flash_addr,
-        .addr_bit_len = 32,
-        .dummy_bits = 0,
-        .mosi_data = NULL,
-        .mosi_bit_len = 0,
-        .miso_data = NULL,
-        .miso_bit_len = 0,
-        .cs_mask = ESP_ROM_OPIFLASH_SEL_CS0,
-        .is_write_erase_operation = true
-    });
+    stub_target_opiflash_exec_cmd(&(opiflash_cmd_params_t){ .spi_num = spi_num,
+                                                            .mode = SPI_FLASH_SLOWRD_MODE,
+                                                            .cmd = erase_cmd,
+                                                            .cmd_bit_len = 8,
+                                                            .addr = flash_addr,
+                                                            .addr_bit_len = 32,
+                                                            .dummy_bits = 0,
+                                                            .mosi_data = NULL,
+                                                            .mosi_bit_len = 0,
+                                                            .miso_data = NULL,
+                                                            .miso_bit_len = 0,
+                                                            .cs_mask = ESP_ROM_OPIFLASH_SEL_CS0,
+                                                            .is_write_erase_operation = true });
 }
 
 /**
@@ -108,18 +102,18 @@ static inline uint32_t get_write_chunk_size_unencrypted(uint32_t remaining, uint
  */
 static inline uint8_t get_write_block_size_encrypted(uint32_t flash_addr, uint32_t remaining, uint32_t page_space)
 {
-    if (IS_ALIGNED(flash_addr, AES_XTS_QUAD_BLOCK_SIZE) && remaining >= AES_XTS_QUAD_BLOCK_SIZE
-            && page_space >= AES_XTS_QUAD_BLOCK_SIZE) {
+    if (IS_ALIGNED(flash_addr, AES_XTS_QUAD_BLOCK_SIZE) && remaining >= AES_XTS_QUAD_BLOCK_SIZE &&
+        page_space >= AES_XTS_QUAD_BLOCK_SIZE) {
         return AES_XTS_QUAD_BLOCK_SIZE;
-    } else if (IS_ALIGNED(flash_addr, AES_XTS_DOUBLE_BLOCK_SIZE) && remaining >= AES_XTS_DOUBLE_BLOCK_SIZE
-               && page_space >= AES_XTS_DOUBLE_BLOCK_SIZE) {
+    } else if (IS_ALIGNED(flash_addr, AES_XTS_DOUBLE_BLOCK_SIZE) && remaining >= AES_XTS_DOUBLE_BLOCK_SIZE &&
+               page_space >= AES_XTS_DOUBLE_BLOCK_SIZE) {
         return AES_XTS_DOUBLE_BLOCK_SIZE;
     }
     return AES_XTS_MIN_BLOCK_SIZE;
 }
 
-static int stub_target_flash_4byte_write_unencrypted(int spi_num, uint32_t flash_addr, const uint8_t *data,
-                                                     uint32_t size, uint64_t timeout_us)
+static int stub_target_flash_4byte_write_unencrypted(
+    int spi_num, uint32_t flash_addr, const uint8_t *data, uint32_t size, uint64_t timeout_us)
 {
     if (stub_lib_flash_wait_ready(timeout_us) != STUB_LIB_OK) {
         return STUB_LIB_ERR_TIMEOUT;
@@ -143,8 +137,8 @@ static int stub_target_flash_4byte_write_unencrypted(int spi_num, uint32_t flash
     return STUB_LIB_OK;
 }
 
-static int stub_target_flash_4byte_write_encrypted(int spi_num, uint32_t flash_addr, const uint8_t *data, uint32_t size,
-                                                   uint64_t timeout_us)
+static int stub_target_flash_4byte_write_encrypted(
+    int spi_num, uint32_t flash_addr, const uint8_t *data, uint32_t size, uint64_t timeout_us)
 {
     int ret = STUB_LIB_ERR_TIMEOUT;
 
@@ -177,7 +171,8 @@ static int stub_target_flash_4byte_write_encrypted(int spi_num, uint32_t flash_a
             goto cleanup;
         }
 
-        // Note: mosi_bit_len uses -1, possibly related to hardware bit counter (0-based), not clear why, should be investigated.
+        // Note: mosi_bit_len uses -1, possibly related to hardware bit counter (0-based), not clear why, should be
+        // investigated.
         exec_write_cmd_4b(spi_num, flash_addr, NULL, (int)(8 * block_size - 1));
         stub_target_aes_xts_clear();
 

--- a/src/target/esp32/include/esp_rom_caps.h
+++ b/src/target/esp32/include/esp_rom_caps.h
@@ -1,22 +1,24 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
 #pragma once
 
-#define ESP_ROM_HAS_CRC_LE              (1) // ROM CRC library supports Little Endian
-#define ESP_ROM_HAS_CRC_BE              (1) // ROM CRC library supports Big Endian
-#define ESP_ROM_HAS_MZ_CRC32            (1) // ROM has mz_crc32 function
-#define ESP_ROM_HAS_JPEG_DECODE         (1) // ROM has JPEG decode library
-#define ESP_ROM_HAS_UART_BUF_SWITCH     (1) // ROM has exported the uart buffer switch function
-#define ESP_ROM_NEEDS_SWSETUP_WORKAROUND    (1) // ROM uses 32-bit time_t. A workaround is required to prevent printf functions from crashing
-#define ESP_ROM_HAS_NEWLIB              (1) // ROM has newlib (at least parts of it) functions included
-#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT  (1) // ROM has the newlib nano version of formatting functions
-#define ESP_ROM_HAS_NEWLIB_32BIT_TIME   (1) // ROM was compiled with 32 bit time_t
-#define ESP_ROM_HAS_SW_FLOAT            (1) // ROM has libgcc software floating point emulation functions
-#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
-#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (-1) // No USB_SERIAL_JTAG in the ROM, set -1 for Kconfig usage.
-#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
-#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC    (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_HAS_CRC_LE          (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE          (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_HAS_MZ_CRC32        (1) // ROM has mz_crc32 function
+#define ESP_ROM_HAS_JPEG_DECODE     (1) // ROM has JPEG decode library
+#define ESP_ROM_HAS_UART_BUF_SWITCH (1) // ROM has exported the uart buffer switch function
+#define ESP_ROM_NEEDS_SWSETUP_WORKAROUND                                                                               \
+    (1) // ROM uses 32-bit time_t. A workaround is required to prevent printf functions from crashing
+#define ESP_ROM_HAS_NEWLIB             (1)  // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT (1)  // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_HAS_NEWLIB_32BIT_TIME  (1)  // ROM was compiled with 32 bit time_t
+#define ESP_ROM_HAS_SW_FLOAT           (1)  // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_OTG_NUM            (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM  (-1) // No USB_SERIAL_JTAG in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB                                                                         \
+    (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)

--- a/src/target/esp32/include/soc/reg_base.h
+++ b/src/target/esp32/include/soc/reg_base.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32/include/soc/rtc_cntl_reg.h
+++ b/src/target/esp32/include/soc/rtc_cntl_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32/include/soc/soc.h
+++ b/src/target/esp32/include/soc/soc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32/include/soc/soc_caps.h
+++ b/src/target/esp32/include/soc/soc_caps.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32/include/soc/spi_reg.h
+++ b/src/target/esp32/include/soc/spi_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32/include/soc/uart_reg.h
+++ b/src/target/esp32/include/soc/uart_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32/src/flash.c
+++ b/src/target/esp32/src/flash.c
@@ -14,7 +14,7 @@
 #include <soc/spi_reg.h>
 #include <private/rom_flash.h>
 
-#define SPI_NUM 1
+#define SPI_NUM         1
 #define STATUS_BUSY_BIT BIT(0)
 
 extern struct esp_rom_spiflash_chip g_rom_flashchip;
@@ -26,9 +26,10 @@ struct esp_rom_spiflash_chip *stub_target_flash_get_config(void)
 
 static uint32_t get_flash_id(void)
 {
-    WRITE_PERI_REG(SPI_W0_REG(SPI_NUM), 0);    // clear register
+    WRITE_PERI_REG(SPI_W0_REG(SPI_NUM), 0); // clear register
     WRITE_PERI_REG(SPI_CMD_REG(SPI_NUM), SPI_FLASH_RDID);
-    while (READ_PERI_REG(SPI_CMD_REG(SPI_NUM)) != 0);
+    while (READ_PERI_REG(SPI_CMD_REG(SPI_NUM)) != 0)
+        ;
     return REG_READ(SPI_W0_REG(SPI_NUM)) & 0xffffff;
 }
 
@@ -53,7 +54,8 @@ bool stub_target_flash_is_busy(void)
 
     REG_WRITE(SPI_RD_STATUS_REG(SPI_NUM), 0);
     REG_WRITE(SPI_CMD_REG(SPI_NUM), SPI_FLASH_RDSR);
-    while (REG_READ(SPI_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_CMD_REG(SPI_NUM)) != 0) {
+    }
     uint32_t status_value = REG_READ(SPI_RD_STATUS_REG(SPI_NUM));
 
     return (status_value & STATUS_BUSY_BIT) != 0;
@@ -66,7 +68,8 @@ void stub_target_flash_erase_sector_start(uint32_t addr)
 
     REG_WRITE(SPI_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_CMD_REG(SPI_NUM), SPI_FLASH_SE);
-    while (REG_READ(SPI_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started sector erase at 0x%x\n", addr);
 }
@@ -78,7 +81,8 @@ void stub_target_flash_erase_block_start(uint32_t addr)
 
     REG_WRITE(SPI_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_CMD_REG(SPI_NUM), SPI_FLASH_BE);
-    while (REG_READ(SPI_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32/src/trax.c
+++ b/src/target/esp32/src/trax.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -10,12 +10,12 @@
 
 #include "soc/reg_base.h"
 
-#define TRACEMEM_MUX_MODE_REG           (DR_REG_DPORT_BASE + 0x070)
-#define TRACEMEM_ENA_REG                (DR_REG_DPORT_BASE + 0x074)
-#define TRACEMEM_ENA_M                  (0x1)
+#define TRACEMEM_MUX_MODE_REG  (DR_REG_DPORT_BASE + 0x070)
+#define TRACEMEM_ENA_REG       (DR_REG_DPORT_BASE + 0x074)
+#define TRACEMEM_ENA_M         (0x1)
 
-#define TRACEMEM_MUX_BLK0_ONLY          1
-#define TRACEMEM_MUX_BLK1_ONLY          2
+#define TRACEMEM_MUX_BLK0_ONLY 1
+#define TRACEMEM_MUX_BLK1_ONLY 2
 
 void stub_target_trax_mem_enable(void)
 {

--- a/src/target/esp32/src/uart.c
+++ b/src/target/esp32/src/uart.c
@@ -70,7 +70,7 @@ uint32_t stub_target_get_apb_freq(void)
 
 void stub_target_rom_uart_attach(void *rxBuffer)
 {
-    (void)rxBuffer;  // ESP32 ROM doesn't take parameter
+    (void)rxBuffer; // ESP32 ROM doesn't take parameter
     esp_rom_uart_attach();
 }
 

--- a/src/target/esp32c2/include/esp_rom_caps.h
+++ b/src/target/esp32c2/include/esp_rom_caps.h
@@ -1,35 +1,38 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
 #pragma once
 
-#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
-#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
-#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
-#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
-#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
-#define ESP_ROM_HAS_RVFPLIB                 (1) // ROM has the rvfplib
-#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
-#define ESP_ROM_HAS_HAL_SYSTIMER            (1) // ROM has the implementation of Systimer HAL driver
-#define ESP_ROM_HAS_HEAP_TLSF               (1) // ROM has the implementation of the tlsf and multi-heap library
-#define ESP_ROM_TLSF_CHECK_PATCH            (1) // ROM does not contain the patch of tlsf_check_pool()
-#define ESP_ROM_MULTI_HEAP_WALK_PATCH       (1) // ROM does not contain the patch of multi_heap_walk()
-#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
-#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
-#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
-#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
-#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano version of formatting functions
-#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
-#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
-#define ESP_ROM_HAS_MBEDTLS_CRYPTO_LIB      (1) // ROM has the mbedtls crypto algorithm lib
-#define ESP_ROM_HAS_SW_FLOAT                (1) // ROM has libgcc software floating point emulation functions
-#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
-#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (-1) // No USB_SERIAL_JTAG in the ROM, set -1 for Kconfig usage.
-#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
-#define ESP_ROM_HAS_VPRINTF_FUNC            (1) // ROM has ets_vprintf
-#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
-#define ESP_ROM_CONSOLE_OUTPUT_SECONDARY    (1) // The console output functions will also output to the USB-serial secondary console
-#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.
+#define ESP_ROM_HAS_CRC_LE               (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE               (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_UART_CLK_IS_XTAL         (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING (1) // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ             (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_RVFPLIB              (1) // ROM has the rvfplib
+#define ESP_ROM_HAS_HAL_WDT              (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER         (1) // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_HAS_HEAP_TLSF            (1) // ROM has the implementation of the tlsf and multi-heap library
+#define ESP_ROM_TLSF_CHECK_PATCH         (1) // ROM does not contain the patch of tlsf_check_pool()
+#define ESP_ROM_MULTI_HEAP_WALK_PATCH    (1) // ROM does not contain the patch of multi_heap_walk()
+#define ESP_ROM_HAS_LAYOUT_TABLE         (1) // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH            (1) // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP       (1) // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_HAS_NEWLIB               (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT   (1) // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE                                                                               \
+    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT (1)  // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_MBEDTLS_CRYPTO_LIB (1)  // ROM has the mbedtls crypto algorithm lib
+#define ESP_ROM_HAS_SW_FLOAT           (1)  // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_OTG_NUM            (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM  (-1) // No USB_SERIAL_JTAG in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_HAS_VERSION            (1)  // ROM has version/eco information
+#define ESP_ROM_HAS_VPRINTF_FUNC       (1)  // ROM has ets_vprintf
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC   (1)  // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_CONSOLE_OUTPUT_SECONDARY                                                                               \
+    (1) // The console output functions will also output to the USB-serial secondary console
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY                                                             \
+    (1) // ROM mem/str functions are not optimized well for misaligned memory access.

--- a/src/target/esp32c2/include/soc/reg_base.h
+++ b/src/target/esp32c2/include/soc/reg_base.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c2/include/soc/rtc_cntl_reg.h
+++ b/src/target/esp32c2/include/soc/rtc_cntl_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2017-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2017-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c2/include/soc/soc.h
+++ b/src/target/esp32c2/include/soc/soc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c2/include/soc/spi_mem_reg.h
+++ b/src/target/esp32c2/include/soc/spi_mem_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c2/include/soc/system_reg.h
+++ b/src/target/esp32c2/include/soc/system_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2021-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c2/include/soc/uart_reg.h
+++ b/src/target/esp32c2/include/soc/uart_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c2/src/flash.c
+++ b/src/target/esp32c2/src/flash.c
@@ -13,7 +13,7 @@
 #include <esp-stub-lib/err.h>
 #include <soc/spi_mem_reg.h>
 
-#define SPI_NUM 1
+#define SPI_NUM         1
 #define STATUS_BUSY_BIT BIT(0)
 
 static void spi_wait_ready(void)
@@ -29,7 +29,8 @@ bool stub_target_flash_is_busy(void)
 
     REG_WRITE(SPI_MEM_RD_STATUS_REG(SPI_NUM), 0);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
     uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(SPI_NUM));
 
     return (status_value & STATUS_BUSY_BIT) != 0;
@@ -42,7 +43,8 @@ void stub_target_flash_erase_sector_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started sector erase at 0x%x\n", addr);
 }
@@ -54,7 +56,8 @@ void stub_target_flash_erase_block_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32c3/include/esp_rom_caps.h
+++ b/src/target/esp32c3/include/esp_rom_caps.h
@@ -1,34 +1,40 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
 #pragma once
 
-#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
-#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
-#define ESP_ROM_HAS_MZ_CRC32                (1) // ROM has mz_crc32 function
-#define ESP_ROM_HAS_JPEG_DECODE             (1) // ROM has JPEG decode library
-#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
-#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (3) // UART uses USB_SERIAL_JTAG port in ROM.
-#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
-#define ESP_ROM_HAS_ERASE_0_REGION_BUG      (1) // ROM has esp_flash_erase_region(size=0) bug
-#define ESP_ROM_HAS_ENCRYPTED_WRITES_USING_LEGACY_DRV     (1) // `esp_flash_write_encrypted` in ROM has bug.
-#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
-#define ESP_ROM_NEEDS_SWSETUP_WORKAROUND    (1) // ROM uses 32-bit time_t. A workaround is required to prevent printf functions from crashing
-#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
-#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
-#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
-#define ESP_ROM_HAS_ETS_PRINTF_BUG          (1) // ROM has ets_printf bug when disable the ROM log either by eFuse or RTC storage register
-#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
-#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano version of formatting functions
-#define ESP_ROM_HAS_NEWLIB_32BIT_TIME       (1) // ROM was compiled with 32 bit time_t
-#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
-#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
-#define ESP_ROM_HAS_SW_FLOAT                (1) // ROM has libgcc software floating point emulation functions
-#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
-#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
-#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
-#define ESP_ROM_CONSOLE_OUTPUT_SECONDARY    (1) // The console output functions will also output to the USB-serial secondary console
-#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.
+#define ESP_ROM_HAS_CRC_LE                            (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE                            (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_HAS_MZ_CRC32                          (1) // ROM has mz_crc32 function
+#define ESP_ROM_HAS_JPEG_DECODE                       (1) // ROM has JPEG decode library
+#define ESP_ROM_UART_CLK_IS_XTAL                      (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM                 (3) // UART uses USB_SERIAL_JTAG port in ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING              (1) // ROM was built with retargetable locking
+#define ESP_ROM_HAS_ERASE_0_REGION_BUG                (1) // ROM has esp_flash_erase_region(size=0) bug
+#define ESP_ROM_HAS_ENCRYPTED_WRITES_USING_LEGACY_DRV (1) // `esp_flash_write_encrypted` in ROM has bug.
+#define ESP_ROM_GET_CLK_FREQ                          (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_NEEDS_SWSETUP_WORKAROUND                                                                               \
+    (1) // ROM uses 32-bit time_t. A workaround is required to prevent printf functions from crashing
+#define ESP_ROM_HAS_LAYOUT_TABLE   (1) // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH      (1) // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP (1) // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_HAS_ETS_PRINTF_BUG                                                                                     \
+    (1) // ROM has ets_printf bug when disable the ROM log either by eFuse or RTC storage register
+#define ESP_ROM_HAS_NEWLIB             (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT (1) // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_HAS_NEWLIB_32BIT_TIME  (1) // ROM was compiled with 32 bit time_t
+#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE                                                                               \
+    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT (1)  // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_SW_FLOAT           (1)  // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_OTG_NUM            (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_HAS_VERSION            (1)  // ROM has version/eco information
+#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB                                                                         \
+    (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
+#define ESP_ROM_CONSOLE_OUTPUT_SECONDARY                                                                               \
+    (1) // The console output functions will also output to the USB-serial secondary console
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY                                                             \
+    (1) // ROM mem/str functions are not optimized well for misaligned memory access.

--- a/src/target/esp32c3/include/soc/interrupt_core0_reg.h
+++ b/src/target/esp32c3/include/soc/interrupt_core0_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c3/include/soc/reg_base.h
+++ b/src/target/esp32c3/include/soc/reg_base.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c3/include/soc/rtc_cntl_reg.h
+++ b/src/target/esp32c3/include/soc/rtc_cntl_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c3/include/soc/soc.h
+++ b/src/target/esp32c3/include/soc/soc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c3/include/soc/soc_caps.h
+++ b/src/target/esp32c3/include/soc/soc_caps.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c3/include/soc/spi_mem_reg.h
+++ b/src/target/esp32c3/include/soc/spi_mem_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c3/include/soc/system_reg.h
+++ b/src/target/esp32c3/include/soc/system_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c3/include/soc/uart_reg.h
+++ b/src/target/esp32c3/include/soc/uart_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c3/include/soc/usb_serial_jtag_reg.h
+++ b/src/target/esp32c3/include/soc/usb_serial_jtag_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c3/src/flash.c
+++ b/src/target/esp32c3/src/flash.c
@@ -13,7 +13,7 @@
 #include <esp-stub-lib/err.h>
 #include <soc/spi_mem_reg.h>
 
-#define SPI_NUM 1
+#define SPI_NUM         1
 #define STATUS_BUSY_BIT BIT(0)
 
 static void spi_wait_ready(void)
@@ -29,7 +29,8 @@ bool stub_target_flash_is_busy(void)
 
     REG_WRITE(SPI_MEM_RD_STATUS_REG(SPI_NUM), 0);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
     uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(SPI_NUM));
 
     return (status_value & STATUS_BUSY_BIT) != 0;
@@ -42,7 +43,8 @@ void stub_target_flash_erase_sector_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started sector erase at 0x%x\n", addr);
 }
@@ -54,7 +56,8 @@ void stub_target_flash_erase_block_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32c5/include/esp_rom_caps.h
+++ b/src/target/esp32c5/include/esp_rom_caps.h
@@ -1,36 +1,41 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
 #pragma once
 
-#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
-#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
-#define ESP_ROM_HAS_JPEG_DECODE             (1) // ROM has JPEG decode library
-#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
-#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (3) // UART uses USB_SERIAL_JTAG port in ROM.
-#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
-#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
-#define ESP_ROM_HAS_RVFPLIB                 (1) // ROM has the rvfplib
-#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
-#define ESP_ROM_HAS_HAL_SYSTIMER            (1) // ROM has the implementation of Systimer HAL driver
-#define ESP_ROM_HAS_HEAP_TLSF               (1) // ROM has the implementation of the tlsf and multi-heap library
-#define ESP_ROM_TLSF_CHECK_PATCH            (1) // ROM does not contain the patch of tlsf_check_pool()
-#define ESP_ROM_MULTI_HEAP_WALK_PATCH       (1) // ROM does not contain the patch of multi_heap_walk()
-#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
-#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
-#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
-#define ESP_ROM_WITHOUT_REGI2C              (1) // ROM has no regi2c APIs       TODO: IDF-10110 need refactor
-#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
-#define ESP_ROM_HAS_NEWLIB_NORMAL_FORMAT    (1) // ROM has the newlib normal/full version of formatting functions (as opposed to the nano versions)
-#define ESP_ROM_WDT_INIT_PATCH              (1) // ROM version does not configure the clock
-#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
-#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
-#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
-#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
-#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
-#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
-#define ESP_ROM_CLIC_INT_THRESH_PATCH       (1) // ROM version of esprv_intc_int_set_threshold incorrectly assumes lowest MINTTHRESH is 0x1F, should be 0xF
-#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.
+#define ESP_ROM_HAS_CRC_LE               (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE               (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_HAS_JPEG_DECODE          (1) // ROM has JPEG decode library
+#define ESP_ROM_UART_CLK_IS_XTAL         (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM    (3) // UART uses USB_SERIAL_JTAG port in ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING (1) // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ             (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_RVFPLIB              (1) // ROM has the rvfplib
+#define ESP_ROM_HAS_HAL_WDT              (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER         (1) // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_HAS_HEAP_TLSF            (1) // ROM has the implementation of the tlsf and multi-heap library
+#define ESP_ROM_TLSF_CHECK_PATCH         (1) // ROM does not contain the patch of tlsf_check_pool()
+#define ESP_ROM_MULTI_HEAP_WALK_PATCH    (1) // ROM does not contain the patch of multi_heap_walk()
+#define ESP_ROM_HAS_LAYOUT_TABLE         (1) // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH            (1) // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP       (1) // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_WITHOUT_REGI2C           (1) // ROM has no regi2c APIs       TODO: IDF-10110 need refactor
+#define ESP_ROM_HAS_NEWLIB               (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NORMAL_FORMAT                                                                               \
+    (1) // ROM has the newlib normal/full version of formatting functions (as opposed to the nano versions)
+#define ESP_ROM_WDT_INIT_PATCH (1) // ROM version does not configure the clock
+#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE                                                                               \
+    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_VERSION            (1) // ROM has version/eco information
+#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB                                                                         \
+    (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
+#define ESP_ROM_USB_OTG_NUM          (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC (1)  // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_CLIC_INT_THRESH_PATCH                                                                                  \
+    (1) // ROM version of esprv_intc_int_set_threshold incorrectly assumes lowest MINTTHRESH is 0x1F, should be 0xF
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY                                                             \
+    (1) // ROM mem/str functions are not optimized well for misaligned memory access.

--- a/src/target/esp32c5/include/soc/clic_reg.h
+++ b/src/target/esp32c5/include/soc/clic_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c5/include/soc/interrupt_matrix_reg.h
+++ b/src/target/esp32c5/include/soc/interrupt_matrix_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c5/include/soc/lp_wdt_reg.h
+++ b/src/target/esp32c5/include/soc/lp_wdt_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c5/include/soc/pcr_reg.h
+++ b/src/target/esp32c5/include/soc/pcr_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c5/include/soc/reg_base.h
+++ b/src/target/esp32c5/include/soc/reg_base.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c5/include/soc/soc.h
+++ b/src/target/esp32c5/include/soc/soc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c5/include/soc/soc_caps.h
+++ b/src/target/esp32c5/include/soc/soc_caps.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c5/include/soc/spi1_mem_reg.h
+++ b/src/target/esp32c5/include/soc/spi1_mem_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c5/include/soc/uart_reg.h
+++ b/src/target/esp32c5/include/soc/uart_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c5/include/soc/usb_serial_jtag_reg.h
+++ b/src/target/esp32c5/include/soc/usb_serial_jtag_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c5/src/aes_xts.c
+++ b/src/target/esp32c5/src/aes_xts.c
@@ -13,7 +13,7 @@
 #include <esp-stub-lib/rom_wrappers.h>
 #include <soc/spi_mem_c_reg.h>
 
-#define INTERNAL_SPI_NUM 0
+#define INTERNAL_SPI_NUM      0
 
 /* AES-XTS state register values:
  * 0: idle
@@ -21,10 +21,10 @@
  * 2: encryption calculation is done but the encrypted result is invisible to mspi
  * 3: the encrypted result is visible to mspi
  */
-#define AES_XTS_STATE_IDLE        0x0
-#define AES_XTS_STATE_BUSY        0x1
-#define AES_XTS_STATE_DONE        0x2
-#define AES_XTS_STATE_VISIBLE     0x3
+#define AES_XTS_STATE_IDLE    0x0
+#define AES_XTS_STATE_BUSY    0x1
+#define AES_XTS_STATE_DONE    0x2
+#define AES_XTS_STATE_VISIBLE 0x3
 
 extern void *memcpy(void *dest, const void *src, size_t n);
 

--- a/src/target/esp32c5/src/flash.c
+++ b/src/target/esp32c5/src/flash.c
@@ -14,45 +14,71 @@
 #include <private/rom_flash.h>
 #include <soc/spi1_mem_reg.h>
 
-#define SPI_NUM 1
+#define SPI_NUM         1
 #define STATUS_BUSY_BIT BIT(0)
 
 /* ECO version from ROM - used to route to correct ROM functions */
 extern uint32_t _rom_eco_version;
 
 /* ECO-specific ROM function declarations */
-extern void esp_rom_opiflash_exec_cmd_eco2(int spi_num, spi_flash_mode_t mode,
-                                           uint32_t cmd, int cmd_bit_len,
-                                           uint32_t addr, int addr_bit_len,
+extern void esp_rom_opiflash_exec_cmd_eco2(int spi_num,
+                                           spi_flash_mode_t mode,
+                                           uint32_t cmd,
+                                           int cmd_bit_len,
+                                           uint32_t addr,
+                                           int addr_bit_len,
                                            int dummy_bits,
-                                           const uint8_t *mosi_data, int mosi_bit_len,
-                                           uint8_t *miso_data, int miso_bit_len,
+                                           const uint8_t *mosi_data,
+                                           int mosi_bit_len,
+                                           uint8_t *miso_data,
+                                           int miso_bit_len,
                                            uint32_t cs_mask,
                                            bool is_write_erase_operation);
 
-extern void esp_rom_opiflash_exec_cmd_eco3(int spi_num, spi_flash_mode_t mode,
-                                           uint32_t cmd, int cmd_bit_len,
-                                           uint32_t addr, int addr_bit_len,
+extern void esp_rom_opiflash_exec_cmd_eco3(int spi_num,
+                                           spi_flash_mode_t mode,
+                                           uint32_t cmd,
+                                           int cmd_bit_len,
+                                           uint32_t addr,
+                                           int addr_bit_len,
                                            int dummy_bits,
-                                           const uint8_t *mosi_data, int mosi_bit_len,
-                                           uint8_t *miso_data, int miso_bit_len,
+                                           const uint8_t *mosi_data,
+                                           int mosi_bit_len,
+                                           uint8_t *miso_data,
+                                           int miso_bit_len,
                                            uint32_t cs_mask,
                                            bool is_write_erase_operation);
 
 void stub_target_opiflash_exec_cmd(const opiflash_cmd_params_t *params)
 {
     if (_rom_eco_version >= 3) {
-        esp_rom_opiflash_exec_cmd_eco3(params->spi_num, params->mode, params->cmd, params->cmd_bit_len,
-                                       params->addr, params->addr_bit_len, params->dummy_bits,
-                                       params->mosi_data, params->mosi_bit_len,
-                                       params->miso_data, params->miso_bit_len,
-                                       params->cs_mask, params->is_write_erase_operation);
+        esp_rom_opiflash_exec_cmd_eco3(params->spi_num,
+                                       params->mode,
+                                       params->cmd,
+                                       params->cmd_bit_len,
+                                       params->addr,
+                                       params->addr_bit_len,
+                                       params->dummy_bits,
+                                       params->mosi_data,
+                                       params->mosi_bit_len,
+                                       params->miso_data,
+                                       params->miso_bit_len,
+                                       params->cs_mask,
+                                       params->is_write_erase_operation);
     } else {
-        esp_rom_opiflash_exec_cmd_eco2(params->spi_num, params->mode, params->cmd, params->cmd_bit_len,
-                                       params->addr, params->addr_bit_len, params->dummy_bits,
-                                       params->mosi_data, params->mosi_bit_len,
-                                       params->miso_data, params->miso_bit_len,
-                                       params->cs_mask, params->is_write_erase_operation);
+        esp_rom_opiflash_exec_cmd_eco2(params->spi_num,
+                                       params->mode,
+                                       params->cmd,
+                                       params->cmd_bit_len,
+                                       params->addr,
+                                       params->addr_bit_len,
+                                       params->dummy_bits,
+                                       params->mosi_data,
+                                       params->mosi_bit_len,
+                                       params->miso_data,
+                                       params->miso_bit_len,
+                                       params->cs_mask,
+                                       params->is_write_erase_operation);
     }
 }
 
@@ -69,7 +95,8 @@ bool stub_target_flash_is_busy(void)
 
     REG_WRITE(SPI_MEM_RD_STATUS_REG(SPI_NUM), 0);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
     uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(SPI_NUM));
 
     return (status_value & STATUS_BUSY_BIT) != 0;
@@ -81,7 +108,8 @@ void stub_target_flash_erase_sector_start(uint32_t addr)
     spi_wait_ready();
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started sector erase at 0x%x\n", addr);
 }
@@ -92,7 +120,8 @@ void stub_target_flash_erase_block_start(uint32_t addr)
     spi_wait_ready();
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32c5/src/uart.c
+++ b/src/target/esp32c5/src/uart.c
@@ -18,6 +18,6 @@ void stub_target_rom_uart_attach(void *rxBuffer)
 
 void stub_target_rom_uart_init(uint8_t uart_no, uint32_t clock)
 {
-    (void)clock;  // Ignore clock parameter for 1-param ROM function
+    (void)clock; // Ignore clock parameter for 1-param ROM function
     esp_rom_uart_init(uart_no);
 }

--- a/src/target/esp32c6/include/esp_rom_caps.h
+++ b/src/target/esp32c6/include/esp_rom_caps.h
@@ -1,38 +1,43 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
 #pragma once
 
-#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
-#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
-#define ESP_ROM_HAS_JPEG_DECODE             (1) // ROM has JPEG decode library
-#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
-#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (3) // UART uses USB_SERIAL_JTAG port in ROM.
-#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
-#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
-#define ESP_ROM_HAS_RVFPLIB                 (1) // ROM has the rvfplib
-#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
-#define ESP_ROM_HAS_HAL_SYSTIMER            (1) // ROM has the implementation of Systimer HAL driver
-#define ESP_ROM_HAS_HEAP_TLSF               (1) // ROM has the implementation of the tlsf and multi-heap library
-#define ESP_ROM_TLSF_CHECK_PATCH            (1) // ROM does not contain the patch of tlsf_check_pool()
-#define ESP_ROM_MULTI_HEAP_WALK_PATCH       (1) // ROM does not contain the patch of multi_heap_walk()
-#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
-#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
-#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
-#define ESP_ROM_HAS_REGI2C_BUG              (1) // ROM has the regi2c bug
-#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
-#define ESP_ROM_HAS_NEWLIB_NORMAL_FORMAT    (1) // ROM has the newlib normal/full version of formatting functions (as opposed to the nano versions)
-#define ESP_ROM_REV0_HAS_NO_ECDSA_INTERFACE (1) // ECO 0 does not have ets_ecdsa_verify symbol, future revision will have it
-#define ESP_ROM_WDT_INIT_PATCH              (1) // ROM version does not configure the clock
-#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
-#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
-#define ESP_ROM_HAS_SW_FLOAT                (1) // ROM has libgcc software floating point emulation functions
-#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
-#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
-#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
-#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
-#define ESP_ROM_NO_USB_SERIAL_OUTPUT_API    (1) // ROM does not export the usb-serial-jtag write char function
-#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.
+#define ESP_ROM_HAS_CRC_LE               (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE               (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_HAS_JPEG_DECODE          (1) // ROM has JPEG decode library
+#define ESP_ROM_UART_CLK_IS_XTAL         (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM    (3) // UART uses USB_SERIAL_JTAG port in ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING (1) // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ             (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_RVFPLIB              (1) // ROM has the rvfplib
+#define ESP_ROM_HAS_HAL_WDT              (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER         (1) // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_HAS_HEAP_TLSF            (1) // ROM has the implementation of the tlsf and multi-heap library
+#define ESP_ROM_TLSF_CHECK_PATCH         (1) // ROM does not contain the patch of tlsf_check_pool()
+#define ESP_ROM_MULTI_HEAP_WALK_PATCH    (1) // ROM does not contain the patch of multi_heap_walk()
+#define ESP_ROM_HAS_LAYOUT_TABLE         (1) // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH            (1) // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP       (1) // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_HAS_REGI2C_BUG           (1) // ROM has the regi2c bug
+#define ESP_ROM_HAS_NEWLIB               (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NORMAL_FORMAT                                                                               \
+    (1) // ROM has the newlib normal/full version of formatting functions (as opposed to the nano versions)
+#define ESP_ROM_REV0_HAS_NO_ECDSA_INTERFACE                                                                            \
+    (1)                            // ECO 0 does not have ets_ecdsa_verify symbol, future revision will have it
+#define ESP_ROM_WDT_INIT_PATCH (1) // ROM version does not configure the clock
+#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE                                                                               \
+    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT (1)  // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_SW_FLOAT           (1)  // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_OTG_NUM            (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_HAS_VERSION            (1)  // ROM has version/eco information
+#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB                                                                         \
+    (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC     (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_NO_USB_SERIAL_OUTPUT_API (1) // ROM does not export the usb-serial-jtag write char function
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY                                                             \
+    (1) // ROM mem/str functions are not optimized well for misaligned memory access.

--- a/src/target/esp32c6/include/soc/interrupt_matrix_reg.h
+++ b/src/target/esp32c6/include/soc/interrupt_matrix_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c6/include/soc/lp_wdt_reg.h
+++ b/src/target/esp32c6/include/soc/lp_wdt_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c6/include/soc/pcr_reg.h
+++ b/src/target/esp32c6/include/soc/pcr_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c6/include/soc/reg_base.h
+++ b/src/target/esp32c6/include/soc/reg_base.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c6/include/soc/soc.h
+++ b/src/target/esp32c6/include/soc/soc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c6/include/soc/soc_caps.h
+++ b/src/target/esp32c6/include/soc/soc_caps.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c6/include/soc/spi_mem_reg.h
+++ b/src/target/esp32c6/include/soc/spi_mem_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c6/include/soc/uart_reg.h
+++ b/src/target/esp32c6/include/soc/uart_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c6/include/soc/usb_serial_jtag_reg.h
+++ b/src/target/esp32c6/include/soc/usb_serial_jtag_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c6/src/flash.c
+++ b/src/target/esp32c6/src/flash.c
@@ -13,13 +13,13 @@
 #include <esp-stub-lib/err.h>
 #include <soc/spi_mem_reg.h>
 
-#define SPI_NUM 1
+#define SPI_NUM         1
 #define STATUS_BUSY_BIT BIT(0)
 
 static void spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_MST_ST) ||
-            REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_SLV_ST)) {
+           REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_SLV_ST)) {
         /* busy wait */
     }
 }
@@ -30,7 +30,8 @@ bool stub_target_flash_is_busy(void)
 
     REG_WRITE(SPI_MEM_RD_STATUS_REG(SPI_NUM), 0);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
     uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(SPI_NUM));
 
     return (status_value & STATUS_BUSY_BIT) != 0;
@@ -43,7 +44,8 @@ void stub_target_flash_erase_sector_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started sector erase at 0x%x\n", addr);
 }
@@ -55,7 +57,8 @@ void stub_target_flash_erase_block_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32c6/src/uart.c
+++ b/src/target/esp32c6/src/uart.c
@@ -18,6 +18,6 @@ void stub_target_rom_uart_attach(void *rxBuffer)
 
 void stub_target_rom_uart_init(uint8_t uart_no, uint32_t clock)
 {
-    (void)clock;  // Ignore clock parameter for 1-param ROM function
+    (void)clock; // Ignore clock parameter for 1-param ROM function
     esp_rom_uart_init(uart_no);
 }

--- a/src/target/esp32c61/include/esp_rom_caps.h
+++ b/src/target/esp32c61/include/esp_rom_caps.h
@@ -1,37 +1,38 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
 #pragma once
 
-#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
-#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
-#define ESP_ROM_HAS_JPEG_DECODE             (1) // ROM has JPEG decode library
-#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
-#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (4) // UART uses USB_SERIAL_JTAG port in ROM.
-#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
-#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
-#define ESP_ROM_HAS_RVFPLIB                 (1) // ROM has the rvfplib
-#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
-#define ESP_ROM_HAS_HAL_SYSTIMER            (1) // ROM has the implementation of Systimer HAL driver
-#define ESP_ROM_SYSTIMER_INIT_PATCH         (1) // ROM version initializes SYSTIMER without ETM
-#define ESP_ROM_HAS_HEAP_TLSF               (1) // ROM has the implementation of the tlsf and multi-heap library
-#define ESP_ROM_TLSF_CHECK_PATCH            (1) // ROM does not contain the patch of tlsf_check_pool()
-#define ESP_ROM_MULTI_HEAP_WALK_PATCH       (1) // ROM does not contain the patch of multi_heap_walk()
-#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
-#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
-#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
-#define ESP_ROM_WITHOUT_REGI2C              (1) // ROM has no regi2c APIs       TODO: IDF-10110 need refactor
-#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
-#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano version of formatting functions
-#define ESP_ROM_HAS_NEWLIB_NANO_PRINTF_FLOAT_BUG  (1) // ROM has the printf float bug with newlib nano version
-#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
-#define ESP_ROM_WDT_INIT_PATCH              (1) // ROM version does not configure the clock
-#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
-#define ESP_ROM_HAS_SW_FLOAT                (1) // ROM has libgcc software floating point emulation functions
-#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
-#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
-#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.
-#define ESP_ROM_DELAY_US_PATCH              (1) // ROM ets_delay_us needs patch for U-mode operation
+#define ESP_ROM_HAS_CRC_LE                       (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE                       (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_HAS_JPEG_DECODE                  (1) // ROM has JPEG decode library
+#define ESP_ROM_UART_CLK_IS_XTAL                 (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM            (4) // UART uses USB_SERIAL_JTAG port in ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING         (1) // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ                     (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_RVFPLIB                      (1) // ROM has the rvfplib
+#define ESP_ROM_HAS_HAL_WDT                      (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER                 (1) // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_SYSTIMER_INIT_PATCH              (1) // ROM version initializes SYSTIMER without ETM
+#define ESP_ROM_HAS_HEAP_TLSF                    (1) // ROM has the implementation of the tlsf and multi-heap library
+#define ESP_ROM_TLSF_CHECK_PATCH                 (1) // ROM does not contain the patch of tlsf_check_pool()
+#define ESP_ROM_MULTI_HEAP_WALK_PATCH            (1) // ROM does not contain the patch of multi_heap_walk()
+#define ESP_ROM_HAS_LAYOUT_TABLE                 (1) // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH                    (1) // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP               (1) // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_WITHOUT_REGI2C                   (1) // ROM has no regi2c APIs       TODO: IDF-10110 need refactor
+#define ESP_ROM_HAS_NEWLIB                       (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT           (1) // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_HAS_NEWLIB_NANO_PRINTF_FLOAT_BUG (1) // ROM has the printf float bug with newlib nano version
+#define ESP_ROM_HAS_VERSION                      (1) // ROM has version/eco information
+#define ESP_ROM_WDT_INIT_PATCH                   (1) // ROM version does not configure the clock
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT           (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_SW_FLOAT                     (1)  // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_OTG_NUM                      (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC             (1)  // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY                                                             \
+    (1)                            // ROM mem/str functions are not optimized well for misaligned memory access.
+#define ESP_ROM_DELAY_US_PATCH (1) // ROM ets_delay_us needs patch for U-mode operation

--- a/src/target/esp32c61/include/soc/clic_reg.h
+++ b/src/target/esp32c61/include/soc/clic_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c61/include/soc/interrupt_core0_reg.h
+++ b/src/target/esp32c61/include/soc/interrupt_core0_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c61/include/soc/lp_wdt_reg.h
+++ b/src/target/esp32c61/include/soc/lp_wdt_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c61/include/soc/pcr_reg.h
+++ b/src/target/esp32c61/include/soc/pcr_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c61/include/soc/reg_base.h
+++ b/src/target/esp32c61/include/soc/reg_base.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c61/include/soc/soc.h
+++ b/src/target/esp32c61/include/soc/soc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c61/include/soc/spi1_mem_reg.h
+++ b/src/target/esp32c61/include/soc/spi1_mem_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c61/include/soc/uart_reg.h
+++ b/src/target/esp32c61/include/soc/uart_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c61/include/soc/usb_serial_jtag_reg.h
+++ b/src/target/esp32c61/include/soc/usb_serial_jtag_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32c61/src/flash.c
+++ b/src/target/esp32c61/src/flash.c
@@ -13,13 +13,13 @@
 #include <esp-stub-lib/err.h>
 #include <soc/spi1_mem_reg.h>
 
-#define SPI_NUM 1
+#define SPI_NUM         1
 #define STATUS_BUSY_BIT BIT(0)
 
 static void spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_MST_ST) ||
-            REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_SLV_ST)) {
+           REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_SLV_ST)) {
         /* busy wait */
     }
 }
@@ -30,7 +30,8 @@ bool stub_target_flash_is_busy(void)
 
     REG_WRITE(SPI_MEM_RD_STATUS_REG(SPI_NUM), 0);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
     uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(SPI_NUM));
 
     return (status_value & STATUS_BUSY_BIT) != 0;
@@ -43,7 +44,8 @@ void stub_target_flash_erase_sector_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started sector erase at 0x%x\n", addr);
 }
@@ -55,7 +57,8 @@ void stub_target_flash_erase_block_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32c61/src/uart.c
+++ b/src/target/esp32c61/src/uart.c
@@ -18,6 +18,6 @@ void stub_target_rom_uart_attach(void *rxBuffer)
 
 void stub_target_rom_uart_init(uint8_t uart_no, uint32_t clock)
 {
-    (void)clock;  // Ignore clock parameter for 1-param ROM function
+    (void)clock; // Ignore clock parameter for 1-param ROM function
     esp_rom_uart_init(uart_no);
 }

--- a/src/target/esp32h2/include/esp_rom_caps.h
+++ b/src/target/esp32h2/include/esp_rom_caps.h
@@ -1,36 +1,39 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
 #pragma once
 
-#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
-#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
-#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
-#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (3) // UART uses USB_SERIAL_JTAG port in ROM.
-#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
-#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
-#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
-#define ESP_ROM_HAS_HAL_SYSTIMER            (1) // ROM has the implementation of Systimer HAL driver
-#define ESP_ROM_HAS_HEAP_TLSF               (1) // ROM has the implementation of the tlsf and multi-heap library
-#define ESP_ROM_TLSF_CHECK_PATCH            (1) // ROM does not contain the patch of tlsf_check_pool()
-#define ESP_ROM_MULTI_HEAP_WALK_PATCH       (1) // ROM does not contain the patch of multi_heap_walk()
-#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
-#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
-#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
-#define ESP_ROM_WITHOUT_REGI2C              (1) // ROM has no regi2c APIs
-#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
-#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano versions of formatting functions
-#define ESP_ROM_HAS_NEWLIB_NANO_PRINTF_FLOAT_BUG  (1) // ROM has the printf float bug with newlib nano version
-#define ESP_ROM_WDT_INIT_PATCH              (1) // ROM version does not configure the clock
-#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
-#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
-#define ESP_ROM_HAS_SW_FLOAT                (1) // ROM has libgcc software floating point emulation functions
-#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
-#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
-#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
-#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
-#define ESP_ROM_NO_USB_SERIAL_OUTPUT_API    (1) // ROM does not export the usb-serial-jtag write char function
-#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.
+#define ESP_ROM_HAS_CRC_LE                       (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE                       (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_UART_CLK_IS_XTAL                 (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM            (3) // UART uses USB_SERIAL_JTAG port in ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING         (1) // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ                     (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_HAL_WDT                      (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER                 (1) // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_HAS_HEAP_TLSF                    (1) // ROM has the implementation of the tlsf and multi-heap library
+#define ESP_ROM_TLSF_CHECK_PATCH                 (1) // ROM does not contain the patch of tlsf_check_pool()
+#define ESP_ROM_MULTI_HEAP_WALK_PATCH            (1) // ROM does not contain the patch of multi_heap_walk()
+#define ESP_ROM_HAS_LAYOUT_TABLE                 (1) // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH                    (1) // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP               (1) // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_WITHOUT_REGI2C                   (1) // ROM has no regi2c APIs
+#define ESP_ROM_HAS_NEWLIB                       (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT           (1) // ROM has the newlib nano versions of formatting functions
+#define ESP_ROM_HAS_NEWLIB_NANO_PRINTF_FLOAT_BUG (1) // ROM has the printf float bug with newlib nano version
+#define ESP_ROM_WDT_INIT_PATCH                   (1) // ROM version does not configure the clock
+#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE                                                                               \
+    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT (1)  // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_SW_FLOAT           (1)  // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_OTG_NUM            (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_HAS_VERSION            (1)  // ROM has version/eco information
+#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB                                                                         \
+    (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC     (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_NO_USB_SERIAL_OUTPUT_API (1) // ROM does not export the usb-serial-jtag write char function
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY                                                             \
+    (1) // ROM mem/str functions are not optimized well for misaligned memory access.

--- a/src/target/esp32h2/include/soc/interrupt_matrix_reg.h
+++ b/src/target/esp32h2/include/soc/interrupt_matrix_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h2/include/soc/lp_wdt_reg.h
+++ b/src/target/esp32h2/include/soc/lp_wdt_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2022-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2022-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h2/include/soc/pcr_reg.h
+++ b/src/target/esp32h2/include/soc/pcr_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h2/include/soc/reg_base.h
+++ b/src/target/esp32h2/include/soc/reg_base.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h2/include/soc/soc.h
+++ b/src/target/esp32h2/include/soc/soc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h2/include/soc/soc_caps.h
+++ b/src/target/esp32h2/include/soc/soc_caps.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h2/include/soc/spi_mem_reg.h
+++ b/src/target/esp32h2/include/soc/spi_mem_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h2/include/soc/uart_reg.h
+++ b/src/target/esp32h2/include/soc/uart_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h2/include/soc/usb_serial_jtag_reg.h
+++ b/src/target/esp32h2/include/soc/usb_serial_jtag_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h2/src/flash.c
+++ b/src/target/esp32h2/src/flash.c
@@ -13,13 +13,13 @@
 #include <esp-stub-lib/err.h>
 #include <soc/spi_mem_reg.h>
 
-#define SPI_NUM 1
+#define SPI_NUM         1
 #define STATUS_BUSY_BIT BIT(0)
 
 static void spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_MST_ST) ||
-            REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_SLV_ST)) {
+           REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_SLV_ST)) {
         /* busy wait */
     }
 }
@@ -30,7 +30,8 @@ bool stub_target_flash_is_busy(void)
 
     REG_WRITE(SPI_MEM_RD_STATUS_REG(SPI_NUM), 0);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
     uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(SPI_NUM));
 
     return (status_value & STATUS_BUSY_BIT) != 0;
@@ -43,7 +44,8 @@ void stub_target_flash_erase_sector_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started sector erase at 0x%x\n", addr);
 }
@@ -55,7 +57,8 @@ void stub_target_flash_erase_block_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32h2/src/uart.c
+++ b/src/target/esp32h2/src/uart.c
@@ -18,6 +18,6 @@ void stub_target_rom_uart_attach(void *rxBuffer)
 
 void stub_target_rom_uart_init(uint8_t uart_no, uint32_t clock)
 {
-    (void)clock;  // Ignore clock parameter for 1-param ROM function
+    (void)clock; // Ignore clock parameter for 1-param ROM function
     esp_rom_uart_init(uart_no);
 }

--- a/src/target/esp32h21/include/esp_rom_caps.h
+++ b/src/target/esp32h21/include/esp_rom_caps.h
@@ -1,34 +1,36 @@
 /*
- * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
 #pragma once
 
-#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
-#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
-#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
-#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (3) // UART uses USB_SERIAL_JTAG port in ROM.
-#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
-#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
-#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
-#define ESP_ROM_HAS_HAL_SYSTIMER            (1) // ROM has the implementation of Systimer HAL driver
-#define ESP_ROM_SYSTIMER_INIT_PATCH         (1) // ROM version initializes SYSTIMER without ETM
-#define ESP_ROM_HAS_HEAP_TLSF               (1) // ROM has the implementation of the tlsf and multi-heap library
-#define ESP_ROM_MULTI_HEAP_WALK_PATCH       (1) // ROM does not contain the patch of multi_heap_walk()
-#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
-#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
-#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
-#define ESP_ROM_WITHOUT_REGI2C              (1) // ROM has no regi2c APIs
-#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
-#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano versions of formatting functions
-#define ESP_ROM_WDT_INIT_PATCH              (1) // ROM version does not configure the clock
-#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
-#define ESP_ROM_HAS_SW_FLOAT                (1) // ROM has libgcc software floating point emulation functions
-#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
-#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
-// #define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep. //TODO: [ESP32H21] IDF-11515
-#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
-#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.
-#define ESP_ROM_NO_USB_SERIAL_OUTPUT_API    (1) // ROM does not export the usb-serial-jtag write char function
+#define ESP_ROM_HAS_CRC_LE               (1)  // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE               (1)  // ROM CRC library supports Big Endian
+#define ESP_ROM_UART_CLK_IS_XTAL         (1)  // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM    (3)  // UART uses USB_SERIAL_JTAG port in ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING (1)  // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ             (1)  // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_HAL_WDT              (1)  // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER         (1)  // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_SYSTIMER_INIT_PATCH      (1)  // ROM version initializes SYSTIMER without ETM
+#define ESP_ROM_HAS_HEAP_TLSF            (1)  // ROM has the implementation of the tlsf and multi-heap library
+#define ESP_ROM_MULTI_HEAP_WALK_PATCH    (1)  // ROM does not contain the patch of multi_heap_walk()
+#define ESP_ROM_HAS_LAYOUT_TABLE         (1)  // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH            (1)  // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP       (1)  // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_WITHOUT_REGI2C           (1)  // ROM has no regi2c APIs
+#define ESP_ROM_HAS_NEWLIB               (1)  // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT   (1)  // ROM has the newlib nano versions of formatting functions
+#define ESP_ROM_WDT_INIT_PATCH           (1)  // ROM version does not configure the clock
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT   (1)  // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_SW_FLOAT             (1)  // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_OTG_NUM              (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_HAS_VERSION              (1)  // ROM has version/eco information
+// #define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute
+// stub code after waking up from deepsleep. //TODO: [ESP32H21] IDF-11515
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC     (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY                                                             \
+    (1) // ROM mem/str functions are not optimized well for misaligned memory access.
+#define ESP_ROM_NO_USB_SERIAL_OUTPUT_API (1) // ROM does not export the usb-serial-jtag write char function

--- a/src/target/esp32h21/include/soc/interrupt_matrix_reg.h
+++ b/src/target/esp32h21/include/soc/interrupt_matrix_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h21/include/soc/lp_wdt_reg.h
+++ b/src/target/esp32h21/include/soc/lp_wdt_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h21/include/soc/pcr_reg.h
+++ b/src/target/esp32h21/include/soc/pcr_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h21/include/soc/reg_base.h
+++ b/src/target/esp32h21/include/soc/reg_base.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h21/include/soc/soc.h
+++ b/src/target/esp32h21/include/soc/soc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h21/include/soc/soc_caps.h
+++ b/src/target/esp32h21/include/soc/soc_caps.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h21/include/soc/spi1_mem_reg.h
+++ b/src/target/esp32h21/include/soc/spi1_mem_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2024-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2024-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h21/include/soc/uart_reg.h
+++ b/src/target/esp32h21/include/soc/uart_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h21/include/soc/usb_serial_jtag_reg.h
+++ b/src/target/esp32h21/include/soc/usb_serial_jtag_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h21/src/flash.c
+++ b/src/target/esp32h21/src/flash.c
@@ -13,13 +13,13 @@
 #include <esp-stub-lib/err.h>
 #include <soc/spi1_mem_reg.h>
 
-#define SPI_NUM 1
+#define SPI_NUM         1
 #define STATUS_BUSY_BIT BIT(0)
 
 static void spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_MST_ST) ||
-            REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_SLV_ST)) {
+           REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_SLV_ST)) {
         /* busy wait */
     }
 }
@@ -30,7 +30,8 @@ bool stub_target_flash_is_busy(void)
 
     REG_WRITE(SPI_MEM_RD_STATUS_REG(SPI_NUM), 0);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
     uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(SPI_NUM));
 
     return (status_value & STATUS_BUSY_BIT) != 0;
@@ -43,7 +44,8 @@ void stub_target_flash_erase_sector_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started sector erase at 0x%x\n", addr);
 }
@@ -55,7 +57,8 @@ void stub_target_flash_erase_block_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32h21/src/uart.c
+++ b/src/target/esp32h21/src/uart.c
@@ -18,6 +18,6 @@ void stub_target_rom_uart_attach(void *rxBuffer)
 
 void stub_target_rom_uart_init(uint8_t uart_no, uint32_t clock)
 {
-    (void)clock;  // Ignore clock parameter for 1-param ROM function
+    (void)clock; // Ignore clock parameter for 1-param ROM function
     esp_rom_uart_init(uart_no);
 }

--- a/src/target/esp32h4/include/esp_rom_caps.h
+++ b/src/target/esp32h4/include/esp_rom_caps.h
@@ -1,27 +1,27 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
 #pragma once
 
-#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
-#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
-#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
-#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (3) // UART uses USB_SERIAL_JTAG port in ROM.
-#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
-#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
-#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
-#define ESP_ROM_HAS_HAL_SYSTIMER            (1) // ROM has the implementation of Systimer HAL driver
-#define ESP_ROM_SYSTIMER_INIT_PATCH         (1) // ROM version initializes SYSTIMER without ETM
-#define ESP_ROM_HAS_HEAP_TLSF               (1) // ROM has the implementation of the tlsf and multi-heap library
-#define ESP_ROM_MULTI_HEAP_WALK_PATCH       (1) // ROM does not contain the patch of multi_heap_walk()
-#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
-#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
-#define ESP_ROM_WITHOUT_REGI2C              (1) // ROM has the regi2c bug or rom does not support regi2c function
-#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
-#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano versions of formatting functions
-#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
-#define ESP_ROM_WDT_INIT_PATCH              (1) // ROM version does not configure the clock
-#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_CRC_LE               (1)  // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE               (1)  // ROM CRC library supports Big Endian
+#define ESP_ROM_UART_CLK_IS_XTAL         (1)  // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM    (3)  // UART uses USB_SERIAL_JTAG port in ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING (1)  // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ             (1)  // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_HAL_WDT              (1)  // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER         (1)  // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_SYSTIMER_INIT_PATCH      (1)  // ROM version initializes SYSTIMER without ETM
+#define ESP_ROM_HAS_HEAP_TLSF            (1)  // ROM has the implementation of the tlsf and multi-heap library
+#define ESP_ROM_MULTI_HEAP_WALK_PATCH    (1)  // ROM does not contain the patch of multi_heap_walk()
+#define ESP_ROM_HAS_LAYOUT_TABLE         (1)  // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH            (1)  // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_WITHOUT_REGI2C           (1)  // ROM has the regi2c bug or rom does not support regi2c function
+#define ESP_ROM_HAS_NEWLIB               (1)  // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT   (1)  // ROM has the newlib nano versions of formatting functions
+#define ESP_ROM_USB_OTG_NUM              (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_WDT_INIT_PATCH           (1)  // ROM version does not configure the clock
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT   (1)  // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init

--- a/src/target/esp32h4/include/soc/clic_reg.h
+++ b/src/target/esp32h4/include/soc/clic_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h4/include/soc/interrupt_matrix_reg.h
+++ b/src/target/esp32h4/include/soc/interrupt_matrix_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h4/include/soc/lp_wdt_reg.h
+++ b/src/target/esp32h4/include/soc/lp_wdt_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h4/include/soc/pcr_reg.h
+++ b/src/target/esp32h4/include/soc/pcr_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h4/include/soc/reg_base.h
+++ b/src/target/esp32h4/include/soc/reg_base.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h4/include/soc/soc.h
+++ b/src/target/esp32h4/include/soc/soc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h4/include/soc/spi1_mem_reg.h
+++ b/src/target/esp32h4/include/soc/spi1_mem_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h4/include/soc/uart_reg.h
+++ b/src/target/esp32h4/include/soc/uart_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h4/include/soc/usb_serial_jtag_reg.h
+++ b/src/target/esp32h4/include/soc/usb_serial_jtag_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32h4/src/flash.c
+++ b/src/target/esp32h4/src/flash.c
@@ -13,13 +13,13 @@
 #include <esp-stub-lib/err.h>
 #include <soc/spi1_mem_reg.h>
 
-#define SPI_NUM 1
+#define SPI_NUM         1
 #define STATUS_BUSY_BIT BIT(0)
 
 static void spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_MST_ST) ||
-            REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_SLV_ST)) {
+           REG_GET_FIELD(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_SLV_ST)) {
         /* busy wait */
     }
 }
@@ -30,7 +30,8 @@ bool stub_target_flash_is_busy(void)
 
     REG_WRITE(SPI_MEM_RD_STATUS_REG(SPI_NUM), 0);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
     uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(SPI_NUM));
 
     return (status_value & STATUS_BUSY_BIT) != 0;
@@ -43,7 +44,8 @@ void stub_target_flash_erase_sector_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started sector erase at 0x%x\n", addr);
 }
@@ -55,7 +57,8 @@ void stub_target_flash_erase_block_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32h4/src/uart.c
+++ b/src/target/esp32h4/src/uart.c
@@ -18,6 +18,6 @@ void stub_target_rom_uart_attach(void *rxBuffer)
 
 void stub_target_rom_uart_init(uint8_t uart_no, uint32_t clock)
 {
-    (void)clock;  // Ignore clock parameter for 1-param ROM function
+    (void)clock; // Ignore clock parameter for 1-param ROM function
     esp_rom_uart_init(uart_no);
 }

--- a/src/target/esp32p4/include/esp_rom_caps.h
+++ b/src/target/esp32p4/include/esp_rom_caps.h
@@ -1,29 +1,30 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
 #pragma once
 
-#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
-#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
-#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
-#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (6) // The serial port ID (UART, USB, ...) of USB_SERIAL_JTAG in the ROM.
-#define ESP_ROM_USB_OTG_NUM                 (5) // The serial port ID (UART, USB, ...) of USB_OTG_CDC in the ROM.
-#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
-#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
-#define ESP_ROM_HAS_RVFPLIB                 (1) // ROM has the rvfplib
-#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
-#define ESP_ROM_HAS_HAL_SYSTIMER            (1) // ROM has the implementation of Systimer HAL driver
-#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
-#define ESP_ROM_WDT_INIT_PATCH              (1) // ROM version does not configure the clock
-#define ESP_ROM_HAS_LP_ROM                  (1) // ROM also has a LP ROM placed in LP memory
-#define ESP_ROM_WITHOUT_REGI2C              (1) // ROM has no regi2c APIs
-#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
-#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano version of formatting functions
-#define ESP_ROM_HAS_NEWLIB_NANO_PRINTF_FLOAT_BUG  (1) // ROM has the printf float bug with newlib nano version
-#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
-#define ESP_ROM_CLIC_INT_TYPE_PATCH         (1) // ROM api esprv_intc_int_set_type configuring edge type interrupt is invalid
-#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
-#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY  (1) // ROM mem/str functions are not optimized well for misaligned memory access.
+#define ESP_ROM_HAS_CRC_LE                       (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE                       (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_UART_CLK_IS_XTAL                 (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM            (6) // The serial port ID (UART, USB, ...) of USB_SERIAL_JTAG in the ROM.
+#define ESP_ROM_USB_OTG_NUM                      (5) // The serial port ID (UART, USB, ...) of USB_OTG_CDC in the ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING         (1) // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ                     (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_RVFPLIB                      (1) // ROM has the rvfplib
+#define ESP_ROM_HAS_HAL_WDT                      (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER                 (1) // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_HAS_LAYOUT_TABLE                 (1) // ROM has the layout table
+#define ESP_ROM_WDT_INIT_PATCH                   (1) // ROM version does not configure the clock
+#define ESP_ROM_HAS_LP_ROM                       (1) // ROM also has a LP ROM placed in LP memory
+#define ESP_ROM_WITHOUT_REGI2C                   (1) // ROM has no regi2c APIs
+#define ESP_ROM_HAS_NEWLIB                       (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT           (1) // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_HAS_NEWLIB_NANO_PRINTF_FLOAT_BUG (1) // ROM has the printf float bug with newlib nano version
+#define ESP_ROM_HAS_VERSION                      (1) // ROM has version/eco information
+#define ESP_ROM_CLIC_INT_TYPE_PATCH              (1) // ROM api esprv_intc_int_set_type configuring edge type interrupt is invalid
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC             (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_HAS_SUBOPTIMAL_NEWLIB_ON_MISALIGNED_MEMORY                                                             \
+    (1) // ROM mem/str functions are not optimized well for misaligned memory access.

--- a/src/target/esp32p4/include/soc/clic_reg.h
+++ b/src/target/esp32p4/include/soc/clic_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32p4/include/soc/hp_system_reg.h
+++ b/src/target/esp32p4/include/soc/hp_system_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32p4/include/soc/interrupt_core0_reg.h
+++ b/src/target/esp32p4/include/soc/interrupt_core0_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32p4/include/soc/lp_clkrst_reg.h
+++ b/src/target/esp32p4/include/soc/lp_clkrst_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32p4/include/soc/lp_system_reg.h
+++ b/src/target/esp32p4/include/soc/lp_system_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32p4/include/soc/lp_wdt_reg.h
+++ b/src/target/esp32p4/include/soc/lp_wdt_reg.h
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  *  SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32p4/include/soc/reg_base.h
+++ b/src/target/esp32p4/include/soc/reg_base.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32p4/include/soc/soc.h
+++ b/src/target/esp32p4/include/soc/soc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32p4/include/soc/soc_caps.h
+++ b/src/target/esp32p4/include/soc/soc_caps.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32p4/include/soc/spi1_mem_c_reg.h
+++ b/src/target/esp32p4/include/soc/spi1_mem_c_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32p4/include/soc/uart_reg.h
+++ b/src/target/esp32p4/include/soc/uart_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32p4/include/soc/usb_serial_jtag_reg.h
+++ b/src/target/esp32p4/include/soc/usb_serial_jtag_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32p4/src/aes_xts.c
+++ b/src/target/esp32p4/src/aes_xts.c
@@ -19,10 +19,10 @@
  * 2: encryption calculation is done but the encrypted result is invisible to mspi
  * 3: the encrypted result is visible to mspi
  */
-#define AES_XTS_STATE_IDLE        0x0
-#define AES_XTS_STATE_BUSY        0x1
-#define AES_XTS_STATE_DONE        0x2
-#define AES_XTS_STATE_VISIBLE     0x3
+#define AES_XTS_STATE_IDLE    0x0
+#define AES_XTS_STATE_BUSY    0x1
+#define AES_XTS_STATE_DONE    0x2
+#define AES_XTS_STATE_VISIBLE 0x3
 
 extern void *memcpy(void *dest, const void *src, size_t n);
 

--- a/src/target/esp32p4/src/flash.c
+++ b/src/target/esp32p4/src/flash.c
@@ -18,71 +18,127 @@
 /* ECO version from ROM - used to route to correct ROM functions */
 extern uint32_t _rom_eco_version;
 
-extern void esp_rom_opiflash_exec_cmd_eco1(int spi_num, spi_flash_mode_t mode,
-                                           uint32_t cmd, int cmd_bit_len,
-                                           uint32_t addr, int addr_bit_len,
+extern void esp_rom_opiflash_exec_cmd_eco1(int spi_num,
+                                           spi_flash_mode_t mode,
+                                           uint32_t cmd,
+                                           int cmd_bit_len,
+                                           uint32_t addr,
+                                           int addr_bit_len,
                                            int dummy_bits,
-                                           const uint8_t *mosi_data, int mosi_bit_len,
-                                           uint8_t *miso_data, int miso_bit_len,
-                                           uint32_t cs_mask, bool is_write_erase_operation);
+                                           const uint8_t *mosi_data,
+                                           int mosi_bit_len,
+                                           uint8_t *miso_data,
+                                           int miso_bit_len,
+                                           uint32_t cs_mask,
+                                           bool is_write_erase_operation);
 
-extern void esp_rom_opiflash_exec_cmd_eco2(int spi_num, spi_flash_mode_t mode,
-                                           uint32_t cmd, int cmd_bit_len,
-                                           uint32_t addr, int addr_bit_len,
+extern void esp_rom_opiflash_exec_cmd_eco2(int spi_num,
+                                           spi_flash_mode_t mode,
+                                           uint32_t cmd,
+                                           int cmd_bit_len,
+                                           uint32_t addr,
+                                           int addr_bit_len,
                                            int dummy_bits,
-                                           const uint8_t *mosi_data, int mosi_bit_len,
-                                           uint8_t *miso_data, int miso_bit_len,
-                                           uint32_t cs_mask, bool is_write_erase_operation);
+                                           const uint8_t *mosi_data,
+                                           int mosi_bit_len,
+                                           uint8_t *miso_data,
+                                           int miso_bit_len,
+                                           uint32_t cs_mask,
+                                           bool is_write_erase_operation);
 
-extern void esp_rom_opiflash_exec_cmd_eco5(int spi_num, spi_flash_mode_t mode,
-                                           uint32_t cmd, int cmd_bit_len,
-                                           uint32_t addr, int addr_bit_len,
+extern void esp_rom_opiflash_exec_cmd_eco5(int spi_num,
+                                           spi_flash_mode_t mode,
+                                           uint32_t cmd,
+                                           int cmd_bit_len,
+                                           uint32_t addr,
+                                           int addr_bit_len,
                                            int dummy_bits,
-                                           const uint8_t *mosi_data, int mosi_bit_len,
-                                           uint8_t *miso_data, int miso_bit_len,
-                                           uint32_t cs_mask, bool is_write_erase_operation);
+                                           const uint8_t *mosi_data,
+                                           int mosi_bit_len,
+                                           uint8_t *miso_data,
+                                           int miso_bit_len,
+                                           uint32_t cs_mask,
+                                           bool is_write_erase_operation);
 
-extern void esp_rom_opiflash_exec_cmd_eco6(int spi_num, spi_flash_mode_t mode,
-                                           uint32_t cmd, int cmd_bit_len,
-                                           uint32_t addr, int addr_bit_len,
+extern void esp_rom_opiflash_exec_cmd_eco6(int spi_num,
+                                           spi_flash_mode_t mode,
+                                           uint32_t cmd,
+                                           int cmd_bit_len,
+                                           uint32_t addr,
+                                           int addr_bit_len,
                                            int dummy_bits,
-                                           const uint8_t *mosi_data, int mosi_bit_len,
-                                           uint8_t *miso_data, int miso_bit_len,
-                                           uint32_t cs_mask, bool is_write_erase_operation);
+                                           const uint8_t *mosi_data,
+                                           int mosi_bit_len,
+                                           uint8_t *miso_data,
+                                           int miso_bit_len,
+                                           uint32_t cs_mask,
+                                           bool is_write_erase_operation);
 
 void stub_target_opiflash_exec_cmd(const opiflash_cmd_params_t *params)
 {
     if (_rom_eco_version == 2) {
-        esp_rom_opiflash_exec_cmd_eco2(params->spi_num, params->mode, params->cmd, params->cmd_bit_len,
-                                       params->addr, params->addr_bit_len, params->dummy_bits,
-                                       params->mosi_data, params->mosi_bit_len,
-                                       params->miso_data, params->miso_bit_len,
-                                       params->cs_mask, params->is_write_erase_operation);
+        esp_rom_opiflash_exec_cmd_eco2(params->spi_num,
+                                       params->mode,
+                                       params->cmd,
+                                       params->cmd_bit_len,
+                                       params->addr,
+                                       params->addr_bit_len,
+                                       params->dummy_bits,
+                                       params->mosi_data,
+                                       params->mosi_bit_len,
+                                       params->miso_data,
+                                       params->miso_bit_len,
+                                       params->cs_mask,
+                                       params->is_write_erase_operation);
     } else if (_rom_eco_version == 5) {
-        esp_rom_opiflash_exec_cmd_eco5(params->spi_num, params->mode, params->cmd, params->cmd_bit_len,
-                                       params->addr, params->addr_bit_len, params->dummy_bits,
-                                       params->mosi_data, params->mosi_bit_len,
-                                       params->miso_data, params->miso_bit_len,
-                                       params->cs_mask, params->is_write_erase_operation);
+        esp_rom_opiflash_exec_cmd_eco5(params->spi_num,
+                                       params->mode,
+                                       params->cmd,
+                                       params->cmd_bit_len,
+                                       params->addr,
+                                       params->addr_bit_len,
+                                       params->dummy_bits,
+                                       params->mosi_data,
+                                       params->mosi_bit_len,
+                                       params->miso_data,
+                                       params->miso_bit_len,
+                                       params->cs_mask,
+                                       params->is_write_erase_operation);
     } else if (_rom_eco_version < 5) {
-        esp_rom_opiflash_exec_cmd_eco1(params->spi_num, params->mode, params->cmd, params->cmd_bit_len,
-                                       params->addr, params->addr_bit_len, params->dummy_bits,
-                                       params->mosi_data, params->mosi_bit_len,
-                                       params->miso_data, params->miso_bit_len,
-                                       params->cs_mask, params->is_write_erase_operation);
+        esp_rom_opiflash_exec_cmd_eco1(params->spi_num,
+                                       params->mode,
+                                       params->cmd,
+                                       params->cmd_bit_len,
+                                       params->addr,
+                                       params->addr_bit_len,
+                                       params->dummy_bits,
+                                       params->mosi_data,
+                                       params->mosi_bit_len,
+                                       params->miso_data,
+                                       params->miso_bit_len,
+                                       params->cs_mask,
+                                       params->is_write_erase_operation);
     } else {
-        esp_rom_opiflash_exec_cmd_eco6(params->spi_num, params->mode, params->cmd, params->cmd_bit_len,
-                                       params->addr, params->addr_bit_len, params->dummy_bits,
-                                       params->mosi_data, params->mosi_bit_len,
-                                       params->miso_data, params->miso_bit_len,
-                                       params->cs_mask, params->is_write_erase_operation);
+        esp_rom_opiflash_exec_cmd_eco6(params->spi_num,
+                                       params->mode,
+                                       params->cmd,
+                                       params->cmd_bit_len,
+                                       params->addr,
+                                       params->addr_bit_len,
+                                       params->dummy_bits,
+                                       params->mosi_data,
+                                       params->mosi_bit_len,
+                                       params->miso_data,
+                                       params->miso_bit_len,
+                                       params->cs_mask,
+                                       params->is_write_erase_operation);
     }
 }
 
 static void spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI1_MEM_C_CMD_REG, SPI1_MEM_C_MST_ST) ||
-            REG_GET_FIELD(SPI1_MEM_C_CMD_REG, SPI1_MEM_C_SLV_ST)) {
+           REG_GET_FIELD(SPI1_MEM_C_CMD_REG, SPI1_MEM_C_SLV_ST)) {
         /* busy wait */
     }
 }
@@ -93,7 +149,8 @@ bool stub_target_flash_is_busy(void)
 
     REG_WRITE(SPI1_MEM_C_RD_STATUS_REG, 0);
     REG_WRITE(SPI1_MEM_C_CMD_REG, SPI1_MEM_C_FLASH_RDSR);
-    while (REG_READ(SPI1_MEM_C_CMD_REG) != 0) { }
+    while (REG_READ(SPI1_MEM_C_CMD_REG) != 0) {
+    }
     uint32_t status_value = REG_READ(SPI1_MEM_C_RD_STATUS_REG);
 
     return (status_value & STATUS_BUSY_BIT) != 0;
@@ -106,7 +163,8 @@ void stub_target_flash_erase_sector_start(uint32_t addr)
 
     REG_WRITE(SPI1_MEM_C_ADDR_REG, addr & 0xffffff);
     REG_WRITE(SPI1_MEM_C_CMD_REG, SPI1_MEM_C_FLASH_SE);
-    while (REG_READ(SPI1_MEM_C_CMD_REG) != 0) { }
+    while (REG_READ(SPI1_MEM_C_CMD_REG) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started sector erase at 0x%x\n", addr);
 }
@@ -118,7 +176,8 @@ void stub_target_flash_erase_block_start(uint32_t addr)
 
     REG_WRITE(SPI1_MEM_C_ADDR_REG, addr & 0xffffff);
     REG_WRITE(SPI1_MEM_C_CMD_REG, SPI1_MEM_C_FLASH_BE);
-    while (REG_READ(SPI1_MEM_C_CMD_REG) != 0) { }
+    while (REG_READ(SPI1_MEM_C_CMD_REG) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32p4/src/uart.c
+++ b/src/target/esp32p4/src/uart.c
@@ -18,6 +18,6 @@ void stub_target_rom_uart_attach(void *rxBuffer)
 
 void stub_target_rom_uart_init(uint8_t uart_no, uint32_t clock)
 {
-    (void)clock;  // Ignore clock parameter for 1-param ROM function
+    (void)clock; // Ignore clock parameter for 1-param ROM function
     esp_rom_uart_init(uart_no);
 }

--- a/src/target/esp32p4/src/usb_otg.c
+++ b/src/target/esp32p4/src/usb_otg.c
@@ -32,8 +32,8 @@ extern void esp_rom_usb_dw_isr_handler(void *arg);
 extern void esp_rom_esprv_intc_int_set_priority(int int_num, int priority);
 
 #define USB_GAHBCFG_REG_OFFSET 0x008
-#define USB_GLBLLNTRMSK (1 << 0)
-#define USBDC_PERSIST_ENA (1U << 31)
+#define USB_GLBLLNTRMSK        (1 << 0)
+#define USBDC_PERSIST_ENA      (1U << 31)
 
 bool stub_target_usb_otg_is_supported(void)
 {

--- a/src/target/esp32s2/include/esp_rom_caps.h
+++ b/src/target/esp32s2/include/esp_rom_caps.h
@@ -1,25 +1,28 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
 #pragma once
 
-#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
-#define ESP_ROM_HAS_MZ_CRC32                (1) // ROM has mz_crc32 function
-#define ESP_ROM_HAS_UART_BUF_SWITCH         (1) // ROM has exported the uart buffer switch function
-#define ESP_ROM_NEEDS_SWSETUP_WORKAROUND    (1) // ROM uses 32-bit time_t. A workaround is required to prevent printf functions from crashing
-#define ESP_ROM_HAS_REGI2C_BUG              (1) // ROM has the regi2c bug
-#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
-#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano version of formatting functions
-#define ESP_ROM_HAS_NEWLIB_32BIT_TIME       (1) // ROM was compiled with 32 bit time_t
-#define ESP_ROM_USB_OTG_NUM                 (2) // The serial port ID (UART, USB, ...) of USB_OTG CDC in the ROM.
-#define ESP_ROM_HAS_FLASH_COUNT_PAGES_BUG   (1) // ROM api Cache_Count_Flash_Pages will return unexpected value
-#define ESP_ROM_HAS_SW_FLOAT            (1) // ROM has libgcc software floating point emulation functions
-#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (-1) // No USB_SERIAL_JTAG in the ROM, set -1 for Kconfig usage.
-#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
+#define ESP_ROM_HAS_CRC_LE          (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_MZ_CRC32        (1) // ROM has mz_crc32 function
+#define ESP_ROM_HAS_UART_BUF_SWITCH (1) // ROM has exported the uart buffer switch function
+#define ESP_ROM_NEEDS_SWSETUP_WORKAROUND                                                                               \
+    (1) // ROM uses 32-bit time_t. A workaround is required to prevent printf functions from crashing
+#define ESP_ROM_HAS_REGI2C_BUG            (1)  // ROM has the regi2c bug
+#define ESP_ROM_HAS_NEWLIB                (1)  // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT    (1)  // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_HAS_NEWLIB_32BIT_TIME     (1)  // ROM was compiled with 32 bit time_t
+#define ESP_ROM_USB_OTG_NUM               (2)  // The serial port ID (UART, USB, ...) of USB_OTG CDC in the ROM.
+#define ESP_ROM_HAS_FLASH_COUNT_PAGES_BUG (1)  // ROM api Cache_Count_Flash_Pages will return unexpected value
+#define ESP_ROM_HAS_SW_FLOAT              (1)  // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM     (-1) // No USB_SERIAL_JTAG in the ROM, set -1 for Kconfig usage.
+#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB                                                                         \
+    (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
 #define ESP_ROM_HAS_VPRINTF_FUNC            (1) // ROM has ets_vprintf
 #define ESP_ROM_HAS_OUTPUT_TO_CHANNELS_FUNC (1) // ROM has ets_write_char, alias is esp_rom_output_to_channels
 #define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
-#define ESP_ROM_CONSOLE_OUTPUT_SECONDARY    (1) // The console output functions will also output to the USB-serial secondary console
+#define ESP_ROM_CONSOLE_OUTPUT_SECONDARY                                                                               \
+    (1) // The console output functions will also output to the USB-serial secondary console

--- a/src/target/esp32s2/include/soc/reg_base.h
+++ b/src/target/esp32s2/include/soc/reg_base.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s2/include/soc/rtc_cntl_reg.h
+++ b/src/target/esp32s2/include/soc/rtc_cntl_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2017-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2017-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s2/include/soc/soc.h
+++ b/src/target/esp32s2/include/soc/soc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s2/include/soc/soc_caps.h
+++ b/src/target/esp32s2/include/soc/soc_caps.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s2/include/soc/spi_mem_reg.h
+++ b/src/target/esp32s2/include/soc/spi_mem_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s2/include/soc/system_reg.h
+++ b/src/target/esp32s2/include/soc/system_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2017-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2017-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s2/include/soc/uart_reg.h
+++ b/src/target/esp32s2/include/soc/uart_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s2/include/soc/usb_reg.h
+++ b/src/target/esp32s2/include/soc/usb_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s2/src/flash.c
+++ b/src/target/esp32s2/src/flash.c
@@ -13,7 +13,7 @@
 #include <esp-stub-lib/err.h>
 #include <soc/spi_mem_reg.h>
 
-#define SPI_NUM 1
+#define SPI_NUM         1
 #define STATUS_BUSY_BIT BIT(0)
 
 extern struct esp_rom_spiflash_chip g_rom_flashchip;
@@ -36,7 +36,8 @@ bool stub_target_flash_is_busy(void)
 
     REG_WRITE(SPI_MEM_RD_STATUS_REG(SPI_NUM), 0);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
     uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(SPI_NUM));
 
     return (status_value & STATUS_BUSY_BIT) != 0;
@@ -49,7 +50,8 @@ void stub_target_flash_erase_sector_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started sector erase at 0x%x\n", addr);
 }
@@ -61,7 +63,8 @@ void stub_target_flash_erase_block_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32s2/src/trax.c
+++ b/src/target/esp32s2/src/trax.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -11,14 +11,13 @@
 
 #include "soc/reg_base.h"
 
-#define PMS_OCCUPY_3_REG                (DR_REG_SENSITIVE_BASE + 0x0E0)
+#define PMS_OCCUPY_3_REG      (DR_REG_SENSITIVE_BASE + 0x0E0)
 
-#define TRACEMEM_MUX_BLK0_NUM           19
-#define TRACEMEM_MUX_BLK1_NUM           20
+#define TRACEMEM_MUX_BLK0_NUM 19
+#define TRACEMEM_MUX_BLK1_NUM 20
 
 void stub_target_trax_mem_enable(void)
-{
-    /* nothing to do for ESP32S2 */
+{ /* nothing to do for ESP32S2 */
 }
 
 void stub_target_trax_select_mem_block(int block)

--- a/src/target/esp32s2/src/usb_otg.c
+++ b/src/target/esp32s2/src/usb_otg.c
@@ -30,7 +30,7 @@ extern void esp_rom_chip_usb_set_persist_flags(uint32_t flags);
 extern void esp_rom_usb_dw_isr_handler(void *arg);
 
 #define ETS_USB_INTR_SOURCE 48
-#define USBDC_PERSIST_ENA (1U << 31)
+#define USBDC_PERSIST_ENA   (1U << 31)
 
 bool stub_target_usb_otg_is_supported(void)
 {

--- a/src/target/esp32s3/include/esp_rom_caps.h
+++ b/src/target/esp32s3/include/esp_rom_caps.h
@@ -1,38 +1,45 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
 #pragma once
 
-#define ESP_ROM_HAS_CRC_LE                  (1) // ROM CRC library supports Little Endian
-#define ESP_ROM_HAS_CRC_BE                  (1) // ROM CRC library supports Big Endian
-#define ESP_ROM_HAS_MZ_CRC32                (1) // ROM has mz_crc32 function
-#define ESP_ROM_HAS_JPEG_DECODE             (1) // ROM has JPEG decode library
-#define ESP_ROM_UART_CLK_IS_XTAL            (1) // UART clock source is selected to XTAL in ROM
-#define ESP_ROM_HAS_RETARGETABLE_LOCKING    (1) // ROM was built with retargetable locking
-#define ESP_ROM_USB_OTG_NUM                 (3) // The serial port ID (UART, USB, ...) of USB_OTG CDC in the ROM.
-#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (4) // The serial port ID (UART, USB, ...) of USB_SERIAL_JTAG in the ROM.
-#define ESP_ROM_HAS_ERASE_0_REGION_BUG      (1) // ROM has esp_flash_erase_region(size=0) bug
-#define ESP_ROM_HAS_ENCRYPTED_WRITES_USING_LEGACY_DRV     (1) // `esp_flash_write_encrypted` in ROM has bug.
-#define ESP_ROM_GET_CLK_FREQ                (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
-#define ESP_ROM_HAS_HAL_WDT                 (1) // ROM has the implementation of Watchdog HAL driver
-#define ESP_ROM_NEEDS_SWSETUP_WORKAROUND    (1) // ROM uses 32-bit time_t. A workaround is required to prevent printf functions from crashing
-#define ESP_ROM_HAS_LAYOUT_TABLE            (1) // ROM has the layout table
-#define ESP_ROM_HAS_SPI_FLASH               (1) // ROM has the implementation of SPI Flash driver
-#define ESP_ROM_HAS_SPI_FLASH_MMAP          (1) // ROM has the implementation of SPI Flash mmap driver
-#define ESP_ROM_HAS_ETS_PRINTF_BUG          (1) // ROM has ets_printf bug when disable the ROM log either by eFuse or RTC storage register
-#define ESP_ROM_HAS_NEWLIB                  (1) // ROM has newlib (at least parts of it) functions included
-#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT      (1) // ROM has the newlib nano version of formatting functions
-#define ESP_ROM_HAS_NEWLIB_32BIT_TIME       (1) // ROM was compiled with 32 bit time_t
-#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
-#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT      (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
-#define ESP_ROM_HAS_FLASH_COUNT_PAGES_BUG   (1) // ROM api Cache_Count_Flash_Pages will return unexpected value
-#define ESP_ROM_HAS_CACHE_SUSPEND_WAITI_BUG (1) // ROM api Cache_Suspend_I/DCache and Cache_Freeze_I/DCache_Enable does not waiti
-#define ESP_ROM_HAS_CACHE_WRITEBACK_BUG     (1) // ROM api Cache_WriteBack_Addr address or size misalignment may cause cache hit with wrong value.
-#define ESP_ROM_HAS_SW_FLOAT                (1) // ROM has libgcc software floating point emulation functions
-#define ESP_ROM_HAS_VERSION                 (1) // ROM has version/eco information
-#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB  (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
-#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC        (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
-#define ESP_ROM_CONSOLE_OUTPUT_SECONDARY    (1) // The console output functions will also output to the USB-serial secondary console
+#define ESP_ROM_HAS_CRC_LE                            (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE                            (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_HAS_MZ_CRC32                          (1) // ROM has mz_crc32 function
+#define ESP_ROM_HAS_JPEG_DECODE                       (1) // ROM has JPEG decode library
+#define ESP_ROM_UART_CLK_IS_XTAL                      (1) // UART clock source is selected to XTAL in ROM
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING              (1) // ROM was built with retargetable locking
+#define ESP_ROM_USB_OTG_NUM                           (3) // The serial port ID (UART, USB, ...) of USB_OTG CDC in the ROM.
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM                 (4) // The serial port ID (UART, USB, ...) of USB_SERIAL_JTAG in the ROM.
+#define ESP_ROM_HAS_ERASE_0_REGION_BUG                (1) // ROM has esp_flash_erase_region(size=0) bug
+#define ESP_ROM_HAS_ENCRYPTED_WRITES_USING_LEGACY_DRV (1) // `esp_flash_write_encrypted` in ROM has bug.
+#define ESP_ROM_GET_CLK_FREQ                          (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_HAL_WDT                           (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_NEEDS_SWSETUP_WORKAROUND                                                                               \
+    (1) // ROM uses 32-bit time_t. A workaround is required to prevent printf functions from crashing
+#define ESP_ROM_HAS_LAYOUT_TABLE   (1) // ROM has the layout table
+#define ESP_ROM_HAS_SPI_FLASH      (1) // ROM has the implementation of SPI Flash driver
+#define ESP_ROM_HAS_SPI_FLASH_MMAP (1) // ROM has the implementation of SPI Flash mmap driver
+#define ESP_ROM_HAS_ETS_PRINTF_BUG                                                                                     \
+    (1) // ROM has ets_printf bug when disable the ROM log either by eFuse or RTC storage register
+#define ESP_ROM_HAS_NEWLIB             (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT (1) // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_HAS_NEWLIB_32BIT_TIME  (1) // ROM was compiled with 32 bit time_t
+#define ESP_ROM_NEEDS_SET_CACHE_MMU_SIZE                                                                               \
+    (1) // ROM needs to set cache MMU size according to instruction and rodata for flash mmap
+#define ESP_ROM_RAM_APP_NEEDS_MMU_INIT    (1) // ROM doesn't init cache MMU when it's a RAM APP, needs MMU hal to init
+#define ESP_ROM_HAS_FLASH_COUNT_PAGES_BUG (1) // ROM api Cache_Count_Flash_Pages will return unexpected value
+#define ESP_ROM_HAS_CACHE_SUSPEND_WAITI_BUG                                                                            \
+    (1) // ROM api Cache_Suspend_I/DCache and Cache_Freeze_I/DCache_Enable does not waiti
+#define ESP_ROM_HAS_CACHE_WRITEBACK_BUG                                                                                \
+    (1) // ROM api Cache_WriteBack_Addr address or size misalignment may cause cache hit with wrong value.
+#define ESP_ROM_HAS_SW_FLOAT (1) // ROM has libgcc software floating point emulation functions
+#define ESP_ROM_HAS_VERSION  (1) // ROM has version/eco information
+#define ESP_ROM_SUPPORT_DEEP_SLEEP_WAKEUP_STUB                                                                         \
+    (1) // ROM supports the HP core to jump to the RTC memory to execute stub code after waking up from deepsleep.
+#define ESP_ROM_HAS_OUTPUT_PUTC_FUNC (1) // ROM has esp_rom_output_putc (or ets_write_char_uart)
+#define ESP_ROM_CONSOLE_OUTPUT_SECONDARY                                                                               \
+    (1) // The console output functions will also output to the USB-serial secondary console

--- a/src/target/esp32s3/include/soc/interrupt_core0_reg.h
+++ b/src/target/esp32s3/include/soc/interrupt_core0_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s3/include/soc/reg_base.h
+++ b/src/target/esp32s3/include/soc/reg_base.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2022 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2021-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s3/include/soc/rtc_cntl_reg.h
+++ b/src/target/esp32s3/include/soc/rtc_cntl_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2015-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s3/include/soc/soc.h
+++ b/src/target/esp32s3/include/soc/soc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s3/include/soc/soc_caps.h
+++ b/src/target/esp32s3/include/soc/soc_caps.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s3/include/soc/spi_mem_reg.h
+++ b/src/target/esp32s3/include/soc/spi_mem_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2020-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2020-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s3/include/soc/system_reg.h
+++ b/src/target/esp32s3/include/soc/system_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2017-2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2017-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s3/include/soc/uart_reg.h
+++ b/src/target/esp32s3/include/soc/uart_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s3/include/soc/usb_reg.h
+++ b/src/target/esp32s3/include/soc/usb_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s3/include/soc/usb_serial_jtag_reg.h
+++ b/src/target/esp32s3/include/soc/usb_serial_jtag_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp32s3/src/aes_xts.c
+++ b/src/target/esp32s3/src/aes_xts.c
@@ -19,10 +19,10 @@
  * 2: encryption calculation is done but the encrypted result is invisible to mspi
  * 3: the encrypted result is visible to mspi
  */
-#define AES_XTS_STATE_IDLE        0x0
-#define AES_XTS_STATE_BUSY        0x1
-#define AES_XTS_STATE_DONE        0x2
-#define AES_XTS_STATE_VISIBLE     0x3
+#define AES_XTS_STATE_IDLE    0x0
+#define AES_XTS_STATE_BUSY    0x1
+#define AES_XTS_STATE_DONE    0x2
+#define AES_XTS_STATE_VISIBLE 0x3
 
 extern void *memcpy(void *dest, const void *src, size_t n);
 

--- a/src/target/esp32s3/src/clock.c
+++ b/src/target/esp32s3/src/clock.c
@@ -42,14 +42,14 @@ uint32_t stub_target_get_apb_freq(void)
 {
     uint32_t clock;
     uint32_t clock_sel = REG_GET_FIELD(SYSTEM_SYSCLK_CONF_REG, SYSTEM_SOC_CLK_SEL);
-    if (clock_sel == 0) {//from xtal, 80MHz, 40MHz, 20MHz, 10MHz, 8MHz,...
+    if (clock_sel == 0) { // from xtal, 80MHz, 40MHz, 20MHz, 10MHz, 8MHz,...
         // Should be also divided by SYSTEM_PRE_DIV_CNT, but setting divider has no effect on ESP32S3.
         clock = esp_rom_get_xtal_freq();
-    } else if (clock_sel == 1) { //from pll, 80MHz
+    } else if (clock_sel == 1) { // from pll, 80MHz
         clock = 80 * MHZ;
-    } else if (clock_sel == 2) { //8M RC, about 8MHz, code will not come here
+    } else if (clock_sel == 2) { // 8M RC, about 8MHz, code will not come here
         clock = 8 * MHZ;
-    } else {//audio pll, code will not come here, just put an different clock here.
+    } else { // audio pll, code will not come here, just put an different clock here.
         clock = 16 * MHZ;
     }
     return clock;

--- a/src/target/esp32s3/src/flash.c
+++ b/src/target/esp32s3/src/flash.c
@@ -14,17 +14,22 @@
 #include <esp-stub-lib/soc_utils.h>
 #include <soc/spi_mem_reg.h>
 
-#define SPI_NUM 1
+#define SPI_NUM         1
 #define STATUS_BUSY_BIT BIT(0)
 
 extern uint32_t ets_efuse_get_spiconfig(void);
 extern esp_rom_spiflash_legacy_funcs_t *rom_spiflash_legacy_funcs;
-extern void esp_rom_opiflash_exec_cmd(int spi_num, spi_flash_mode_t mode,
-                                      uint32_t cmd, int cmd_bit_len,
-                                      uint32_t addr, int addr_bit_len,
+extern void esp_rom_opiflash_exec_cmd(int spi_num,
+                                      spi_flash_mode_t mode,
+                                      uint32_t cmd,
+                                      int cmd_bit_len,
+                                      uint32_t addr,
+                                      int addr_bit_len,
                                       int dummy_bits,
-                                      const uint8_t *mosi_data, int mosi_bit_len,
-                                      uint8_t *miso_data, int miso_bit_len,
+                                      const uint8_t *mosi_data,
+                                      int mosi_bit_len,
+                                      uint8_t *miso_data,
+                                      int miso_bit_len,
                                       uint32_t cs_mask,
                                       bool is_write_erase_operation);
 
@@ -54,11 +59,19 @@ void stub_target_flash_init(void *state)
 
 void stub_target_opiflash_exec_cmd(const opiflash_cmd_params_t *params)
 {
-    esp_rom_opiflash_exec_cmd(params->spi_num, params->mode, params->cmd, params->cmd_bit_len,
-                              params->addr, params->addr_bit_len, params->dummy_bits,
-                              params->mosi_data, params->mosi_bit_len,
-                              params->miso_data, params->miso_bit_len,
-                              params->cs_mask, params->is_write_erase_operation);
+    esp_rom_opiflash_exec_cmd(params->spi_num,
+                              params->mode,
+                              params->cmd,
+                              params->cmd_bit_len,
+                              params->addr,
+                              params->addr_bit_len,
+                              params->dummy_bits,
+                              params->mosi_data,
+                              params->mosi_bit_len,
+                              params->miso_data,
+                              params->miso_bit_len,
+                              params->cs_mask,
+                              params->is_write_erase_operation);
 }
 
 int stub_target_flash_read_buff(uint32_t addr, void *buffer, uint32_t size)
@@ -84,7 +97,8 @@ bool stub_target_flash_is_busy(void)
 
     REG_WRITE(SPI_MEM_RD_STATUS_REG(SPI_NUM), 0);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
     uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(SPI_NUM));
 
     return (status_value & STATUS_BUSY_BIT) != 0;
@@ -97,7 +111,8 @@ void stub_target_flash_erase_sector_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started sector erase at 0x%x\n", addr);
 }
@@ -109,7 +124,8 @@ void stub_target_flash_erase_block_start(uint32_t addr)
 
     REG_WRITE(SPI_MEM_ADDR_REG(SPI_NUM), addr & 0xffffff);
     REG_WRITE(SPI_MEM_CMD_REG(SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) { }
+    while (REG_READ(SPI_MEM_CMD_REG(SPI_NUM)) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32s3/src/trax.c
+++ b/src/target/esp32s3/src/trax.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -21,15 +21,14 @@
 #define TRACEMEM_CORE1_MUX_BLK_BITS(_n_)    (BIT(7UL + ((_n_) - 2UL) / 4UL) | (TRACEMEM_MUX_BLK_ALLOC(_n_) << 16))
 
 void stub_target_trax_mem_enable(void)
-{
-    /* nothing to do for ESP32S3 */
+{ /* nothing to do for ESP32S3 */
 }
 
 void stub_target_trax_select_mem_block(int block)
 {
-    uint32_t block_bits = block ? TRACEMEM_CORE0_MUX_BLK_BITS(TRACEMEM_MUX_BLK0_NUM)
-                          : TRACEMEM_CORE0_MUX_BLK_BITS(TRACEMEM_MUX_BLK1_NUM);
-    block_bits |= block ? TRACEMEM_CORE1_MUX_BLK_BITS(TRACEMEM_MUX_BLK0_NUM)
-                  : TRACEMEM_CORE1_MUX_BLK_BITS(TRACEMEM_MUX_BLK1_NUM);
+    uint32_t block_bits =
+        block ? TRACEMEM_CORE0_MUX_BLK_BITS(TRACEMEM_MUX_BLK0_NUM) : TRACEMEM_CORE0_MUX_BLK_BITS(TRACEMEM_MUX_BLK1_NUM);
+    block_bits |=
+        block ? TRACEMEM_CORE1_MUX_BLK_BITS(TRACEMEM_MUX_BLK0_NUM) : TRACEMEM_CORE1_MUX_BLK_BITS(TRACEMEM_MUX_BLK1_NUM);
     WRITE_PERI_REG(SENSITIVE_INTERNAL_SRAM_USAGE_2_REG, block_bits);
 }

--- a/src/target/esp8266/include/esp_rom_caps.h
+++ b/src/target/esp8266/include/esp_rom_caps.h
@@ -1,11 +1,11 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
 #pragma once
 
-#define ESP_ROM_HAS_VPRINTF_FUNC            (1) // ROM has ets_vprintf
-#define ESP_ROM_USB_SERIAL_DEVICE_NUM       (-1) // No USB-SERIAL-JTAG in the ROM
-#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB-OTG in the ROM
+#define ESP_ROM_HAS_VPRINTF_FUNC      (1)  // ROM has ets_vprintf
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM (-1) // No USB-SERIAL-JTAG in the ROM
+#define ESP_ROM_USB_OTG_NUM           (-1) // No USB-OTG in the ROM

--- a/src/target/esp8266/include/soc/soc.h
+++ b/src/target/esp8266/include/soc/soc.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp8266/include/soc/uart_reg.h
+++ b/src/target/esp8266/include/soc/uart_reg.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */

--- a/src/target/esp8266/src/flash.c
+++ b/src/target/esp8266/src/flash.c
@@ -14,25 +14,25 @@
 #include <esp-stub-lib/soc_utils.h>
 
 // ESP8266 uses SPI0 as the flash interface
-#define SPI_BASE_REG 0x60000200
-#define SPI_EXT2_REG (SPI_BASE_REG + 0xF8)
-#define SPI_CMD_REG (SPI_BASE_REG + 0x00)
+#define SPI_BASE_REG      0x60000200
+#define SPI_EXT2_REG      (SPI_BASE_REG + 0xF8)
+#define SPI_CMD_REG       (SPI_BASE_REG + 0x00)
 #define SPI_RD_STATUS_REG (SPI_BASE_REG + 0x10)
-#define SPI_ADDR_REG (SPI_BASE_REG + 0x04)
+#define SPI_ADDR_REG      (SPI_BASE_REG + 0x04)
 #define SPI_FLASH_WREN    BIT(30)
 #define SPI_FLASH_RDID    BIT(28)
 #define SPI_FLASH_RDSR    BIT(27)
 #define SPI_FLASH_SE      BIT(24)
 #define SPI_FLASH_BE      BIT(23)
-#define SPI_W0     (SPI_BASE_REG + 0x40)
-#define SPI_CMD    (SPI_BASE_REG + 0x0)
+#define SPI_W0            (SPI_BASE_REG + 0x40)
+#define SPI_CMD           (SPI_BASE_REG + 0x0)
 
-#define SPI_ST  0x00000007
-#define SPI_ST_M  ((SPI_ST_V)<<(SPI_ST_S))
-#define SPI_ST_V  0x7
-#define SPI_ST_S  0
+#define SPI_ST            0x00000007
+#define SPI_ST_M          ((SPI_ST_V) << (SPI_ST_S))
+#define SPI_ST_V          0x7
+#define SPI_ST_S          0
 
-#define STATUS_BUSY_BIT BIT(0)
+#define STATUS_BUSY_BIT   BIT(0)
 
 extern struct esp_rom_spiflash_chip g_rom_flashchip;
 extern esp_rom_spiflash_result_t esp_rom_spiflash_write(uint32_t flash_addr, const void *data, uint32_t size);
@@ -46,7 +46,8 @@ static uint32_t get_flash_id(void)
 {
     REG_WRITE(SPI_W0, 0);
     REG_WRITE(SPI_CMD, SPI_FLASH_RDID);
-    while (REG_READ(SPI_CMD) != 0);
+    while (REG_READ(SPI_CMD) != 0)
+        ;
 
     return REG_READ(SPI_W0) & 0xffffff;
 }
@@ -81,7 +82,8 @@ bool stub_target_flash_is_busy(void)
 
     REG_WRITE(SPI_RD_STATUS_REG, 0);
     REG_WRITE(SPI_CMD_REG, SPI_FLASH_RDSR);
-    while (REG_READ(SPI_CMD_REG) != 0) { }
+    while (REG_READ(SPI_CMD_REG) != 0) {
+    }
     uint32_t status_value = REG_READ(SPI_RD_STATUS_REG);
 
     return (status_value & STATUS_BUSY_BIT) != 0;
@@ -94,7 +96,8 @@ void stub_target_flash_erase_sector_start(uint32_t addr)
 
     REG_WRITE(SPI_ADDR_REG, addr & 0xffffff);
     REG_WRITE(SPI_CMD_REG, SPI_FLASH_SE);
-    while (REG_READ(SPI_CMD_REG) != 0) { }
+    while (REG_READ(SPI_CMD_REG) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started sector erase at 0x%x\n", addr);
 }
@@ -106,7 +109,8 @@ void stub_target_flash_erase_block_start(uint32_t addr)
 
     REG_WRITE(SPI_ADDR_REG, addr & 0xffffff);
     REG_WRITE(SPI_CMD_REG, SPI_FLASH_BE);
-    while (REG_READ(SPI_CMD_REG) != 0) { }
+    while (REG_READ(SPI_CMD_REG) != 0) {
+    }
 
     STUB_LOG_TRACEF("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp8266/src/rom-patched.c
+++ b/src/target/esp8266/src/rom-patched.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -7,10 +7,8 @@
 
 int32_t __bswapsi2(int32_t u)
 {
-    return (int32_t)(((((uint32_t)u) & 0xff000000) >> 24)
-                     | ((((uint32_t)u) & 0x00ff0000) >>  8)
-                     | ((((uint32_t)u) & 0x0000ff00) <<  8)
-                     | ((((uint32_t)u) & 0x000000ff) << 24));
+    return (int32_t)(((((uint32_t)u) & 0xff000000) >> 24) | ((((uint32_t)u) & 0x00ff0000) >> 8) |
+                     ((((uint32_t)u) & 0x0000ff00) << 8) | ((((uint32_t)u) & 0x000000ff) << 24));
 }
 
 int64_t __ashldi3(int64_t a, int b)

--- a/src/target/esp8266/src/uart.c
+++ b/src/target/esp8266/src/uart.c
@@ -1,8 +1,8 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
-*
-* SPDX-License-Identifier: Apache-2.0 OR MIT
-*/
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
 
 #include <stdint.h>
 #include <stddef.h>
@@ -23,7 +23,7 @@ extern uint32_t esp_rom_get_xtal_freq(void);
 
 void stub_target_rom_uart_attach(void *rxBuffer)
 {
-    (void)rxBuffer;  // ESP8266 ROM doesn't take parameter
+    (void)rxBuffer; // ESP8266 ROM doesn't take parameter
     esp_rom_uart_attach();
 }
 
@@ -39,8 +39,7 @@ void stub_target_uart_wait_idle(uint8_t uart_num)
     do {
         status = READ_PERI_REG(UART_STATUS_REG(uart_num));
         // Check if TX FIFO is empty (TXFIFO_CNT == 0) and TX is idle (!TXD)
-    } while (((status >> UART_TXFIFO_CNT_S) & UART_TXFIFO_CNT_V) != 0 ||
-             (status & UART_TXD) != 0);
+    } while (((status >> UART_TXFIFO_CNT_S) & UART_TXFIFO_CNT_V) != 0 || (status & UART_TXD) != 0);
 }
 
 void stub_target_uart_init(uint8_t uart_num)

--- a/src/usb_otg.c
+++ b/src/usb_otg.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -31,10 +31,10 @@ typedef struct {
 } uart_device_t;
 
 // Constants
-#define ACM_BYTES_PER_TX 64
-#define LINE_CTRL_RTS (1 << 1)
+#define ACM_BYTES_PER_TX             64
+#define LINE_CTRL_RTS                (1 << 1)
 #define ACM_STATUS_LINESTATE_CHANGED -1
-#define ACM_STATUS_RX -4
+#define ACM_STATUS_RX                -4
 
 // State
 static int s_usb_int_num = 0;


### PR DESCRIPTION
- Replace `astyle_py` with `clang-format` in `.pre-commit-config.yaml`
- Exclude `include/esp-stub-lib/miniz.[h|c]` from clang-format hook
- Reformat codebase to conform to the new style