### PR TITLE
change: generate compiler_commands.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 example/build/
 example/toolchain/
+
+# A compile_commands.json can be generated for helping tools such
+# as clangd to locate header files and use correct $CFLAGS
+compile_commands.json

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -17,6 +17,8 @@ add_link_options(${COMMON_LINKER_FLAGS})
 set(APP_NAME stub_${ESP_TARGET})
 project(${APP_NAME}.elf LANGUAGES C CXX ASM)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Source and linker configuration
 set(SRC_DIR .)
 set(LINKER_SCRIPTS

--- a/example/build.sh
+++ b/example/build.sh
@@ -68,6 +68,10 @@ build_target() {
 
     cmake $cmake_args ../..
     ninja
+
+    # Symlink compile_commands.json to the esp-stub-lib root for IDE support (clangd)
+    ln -sf "$PWD/compile_commands.json" ../../../compile_commands.json
+
     cd ../..
 }
 


### PR DESCRIPTION
A compile_commands.json can be generated for helping tools such as clangd to locate header files and use correct $CFLAGS compile_commands.json