### PR TITLE
ESP32 save flash state

### DIFF
--- a/include/esp-stub-lib/flash.h
+++ b/include/esp-stub-lib/flash.h
@@ -47,7 +47,7 @@ void stub_lib_flash_attach(uint32_t ishspi, bool legacy);
  *
  * Configure SPI, Flash ID, flash size, and the internal ROM's config
  *
- * @param state Unused
+ * @param state If non-NULL, the state is saved to this pointer to be restored later.
  *
  * @return Error code:
  * - STUB_LIB_OK
@@ -58,7 +58,7 @@ int stub_lib_flash_init(void **state);
 /**
  * @brief Restore flash state at the end of the stub.
  *
- * @param state Unused.
+ * @param state If non-NULL, the state is restored from the state that was saved by stub_lib_flash_init().
  */
 void stub_lib_flash_deinit(const void *state);
 

--- a/src/target/base/include/target/flash.h
+++ b/src/target/base/include/target/flash.h
@@ -53,16 +53,30 @@ void stub_target_reset_default_spi_pins(void);
  *
  * Configure SPI pins, registers, mode, etc.
  *
- * @param state Unused.
+ * @param state If non-NULL, the state is saved.
  */
-void stub_target_flash_init(void *state);
+void stub_target_flash_init(void **state);
 
 /**
- * @brief Not implemented. Intended for restoring the state
+ * @brief Restore SPI Flash hardware state.
  *
- * @param state Unused.
+ * @param state If non-NULL, the state is restored.
  */
 void stub_target_flash_deinit(const void *state);
+
+/**
+ * @brief Save SPI Flash hardware state before sending any command.
+ *
+ * @param state If non-NULL, the state is saved.
+ */
+void stub_target_flash_state_save(void **state);
+
+/**
+ * @brief Restore SPI Flash hardware state before leaving the stub.
+ *
+ * @param state If non-NULL, the state is restored.
+ */
+void stub_target_flash_state_restore(const void *state);
 
 /**
  * @brief Retrieve Flash ID (aka flash device id, aka flash chip id) from internal hw.

--- a/src/target/common/src/flash.c
+++ b/src/target/common/src/flash.c
@@ -95,7 +95,17 @@ uint32_t __attribute__((weak)) stub_target_flash_get_spiconfig_efuse(void)
     return 0;
 }
 
-void __attribute__((weak)) stub_target_flash_init(void *state)
+void __attribute__((weak)) stub_target_flash_state_save(void **state)
+{
+    (void)state;
+}
+
+void __attribute__((weak)) stub_target_flash_state_restore(const void *state)
+{
+    (void)state;
+}
+
+void __attribute__((weak)) stub_target_flash_init(void **state)
 {
     (void)state;
     uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();
@@ -121,7 +131,7 @@ uint32_t __attribute__((weak)) stub_target_flash_get_flash_id(void)
 
 void __attribute__((weak)) stub_target_flash_deinit(const void *state)
 {
-    (void)state;
+    stub_target_flash_state_restore(state);
 }
 
 void __attribute__((weak)) stub_target_flash_write_enable(void)

--- a/src/target/esp32/src/flash.c
+++ b/src/target/esp32/src/flash.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <esp-stub-lib/log.h>
 #include <esp-stub-lib/soc_utils.h>
 
 #include <target/flash.h>
@@ -17,6 +18,18 @@
 
 extern esp_rom_spiflash_chip_t g_rom_flashchip;
 extern uint32_t esp_rom_efuse_get_flash_gpio_info(void);
+
+/* Save/restore SPI registers. Can be extended to more registers if needed. */
+enum {
+    SPI_USER_REG_ID = 0,
+    SPI_REGS_NUM,
+};
+
+typedef struct {
+    uint32_t spi_regs[SPI_REGS_NUM];
+} stub_esp32_flash_state_t;
+
+static stub_esp32_flash_state_t s_flash_state;
 
 uint32_t stub_target_flash_get_spiconfig_efuse(void)
 {
@@ -44,4 +57,48 @@ void stub_target_spi_wait_ready(void)
     while (REG_GET_FIELD(SPI_EXT2_REG(FLASH_SPI_NUM), SPI_ST)) {
         /* busy wait */
     }
+}
+
+void stub_target_flash_state_save(void **state)
+{
+    if (!state) {
+        return;
+    }
+
+    s_flash_state.spi_regs[SPI_USER_REG_ID] = READ_PERI_REG(SPI_USER_REG(FLASH_SPI_NUM));
+
+    *state = &s_flash_state;
+}
+
+void stub_target_flash_state_restore(const void *state)
+{
+    if (!state) {
+        return;
+    }
+
+    const stub_esp32_flash_state_t *s = state;
+
+    STUB_LOGD("SPI_USER_REG(1) was:0x%x, restored to:0x%x\n",
+              READ_PERI_REG(SPI_USER_REG(1)),
+              s->spi_regs[SPI_USER_REG_ID]);
+
+    WRITE_PERI_REG(SPI_USER_REG(FLASH_SPI_NUM), s->spi_regs[SPI_USER_REG_ID]);
+}
+
+void stub_target_flash_init(void **state)
+{
+    uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();
+
+    if (state) {
+        stub_target_flash_state_save(state);
+    }
+
+    stub_target_flash_attach(spiconfig, 0);
+
+    /*
+     * Command phase is always set in download mode.
+     * But in reset-run case, it seems to be not set.
+     * So we need to set it here before sending any command.
+     */
+    REG_SET_BIT(SPI_USER_REG(1), SPI_USR_COMMAND);
 }

--- a/src/target/esp32s3/src/flash.c
+++ b/src/target/esp32s3/src/flash.c
@@ -56,7 +56,7 @@ static void stub_target_flash_init_funcs(void)
     rom_spiflash_legacy_funcs = &funcs;
 }
 
-void stub_target_flash_init(void *state)
+void stub_target_flash_init(void **state)
 {
     (void)state;
     uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();


### PR DESCRIPTION
The ROM's spi_flash_attach() only configures SPI0 (cache controller) but not SPI1 (flash command controller). The SPI_USR_COMMAND bit must be set on SPI1 for flash commands to include an opcode byte on the bus.

Save the original SPI_USER_REG(1) value before modifying it, and restore it in stub_target_flash_state_restore() so the application's SPI1 configuration is not disturbed after the stub returns.
