### PR TITLE
Refactor/flash targets

### DIFF
--- a/include/esp-stub-lib/bit_utils.h
+++ b/include/esp-stub-lib/bit_utils.h
@@ -54,6 +54,10 @@ extern "C" {
 #define MIB(x) ((uint32_t)(x) * 1024U * 1024U)
 #endif
 
+#ifndef GIB
+#define GIB(x) ((uint64_t)(x) * 1024U * 1024U * 1024U)
+#endif
+
 #ifndef BYTES_TO_KIB
 #define BYTES_TO_KIB(x) ((x) / 1024U)
 #endif

--- a/src/flash.c
+++ b/src/flash.c
@@ -18,8 +18,6 @@
 // For flash size > 16MB, we use 4-byte addressing, only some targets support this.
 static bool large_flash_mode = false;
 
-#define FLASH_SPI_NUM 1
-
 int stub_lib_flash_update_config(stub_lib_flash_config_t *config)
 {
     if (config == NULL) {

--- a/src/target/base/include/target/flash.h
+++ b/src/target/base/include/target/flash.h
@@ -37,6 +37,8 @@ typedef enum {
     SPI_FLASH_QPI_MODE,
 } spi_flash_mode_t;
 
+#define FLASH_SPI_NUM 1
+
 /**
  * @brief Reset default SPI IOMUX pins to GPIO mode
  *
@@ -176,6 +178,8 @@ void stub_target_flash_attach(uint32_t ishspi, bool legacy);
  * @return true if flash is busy, false if ready
  */
 bool stub_target_flash_is_busy(void);
+
+void stub_target_spi_wait_ready(void);
 
 /**
  * @brief Start erasing a 4KB sector without blocking

--- a/src/target/esp32/include/soc/spi_mem_compat.h
+++ b/src/target/esp32/include/soc/spi_mem_compat.h
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "spi_reg.h"
+
+#define SPI_MEM_ADDR_REG(i)       SPI_ADDR_REG(i)
+#define SPI_MEM_CMD_REG(i)        SPI_CMD_REG(i)
+#define SPI_MEM_RD_STATUS_REG(i)  SPI_RD_STATUS_REG(i)
+#define SPI_MEM_FLASH_SE          SPI_FLASH_SE
+#define SPI_MEM_FLASH_BE          SPI_FLASH_BE
+#define SPI_MEM_FLASH_RDSR        SPI_FLASH_RDSR

--- a/src/target/esp32/src/flash.c
+++ b/src/target/esp32/src/flash.c
@@ -7,28 +7,16 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <target/flash.h>
-#include <esp-stub-lib/log.h>
-#include <esp-stub-lib/bit_utils.h>
 #include <esp-stub-lib/soc_utils.h>
-#include <esp-stub-lib/err.h>
-#include <soc/spi_reg.h>
+#include <soc/spi_mem_compat.h>
 #include <private/rom_flash.h>
-
-#define FLASH_SPI_NUM   1
-#define STATUS_BUSY_BIT BIT(0)
 
 extern esp_rom_spiflash_chip_t g_rom_flashchip;
 extern uint32_t esp_rom_efuse_get_flash_gpio_info(void);
-extern void esp_rom_spiflash_attach(uint32_t ishspi, bool legacy);
 
 uint32_t stub_target_flash_get_spiconfig_efuse(void)
 {
     return esp_rom_efuse_get_flash_gpio_info();
-}
-
-void stub_target_flash_attach(uint32_t ishspi, bool legacy)
-{
-    esp_rom_spiflash_attach(ishspi, legacy);
 }
 
 esp_rom_spiflash_chip_t *stub_target_flash_get_config(void)
@@ -41,53 +29,15 @@ uint32_t stub_target_flash_get_flash_id(void)
     WRITE_PERI_REG(SPI_W0_REG(FLASH_SPI_NUM), 0); // clear register
     WRITE_PERI_REG(SPI_CMD_REG(FLASH_SPI_NUM), SPI_FLASH_RDID);
     while (READ_PERI_REG(SPI_CMD_REG(FLASH_SPI_NUM)) != 0) {
+        /* busy wait */
     }
     return (REG_READ(SPI_W0_REG(FLASH_SPI_NUM)) & 0xffffff) >> 16;
 }
 
-static void spi_wait_ready(void)
+void stub_target_spi_wait_ready(void)
 {
     // No need to wait for SPI0 as there is a hardware arbiter between SPI0 and SPI1
     while (REG_GET_FIELD(SPI_EXT2_REG(FLASH_SPI_NUM), SPI_ST)) {
         /* busy wait */
     }
-}
-
-bool stub_target_flash_is_busy(void)
-{
-    spi_wait_ready();
-
-    REG_WRITE(SPI_RD_STATUS_REG(FLASH_SPI_NUM), 0);
-    REG_WRITE(SPI_CMD_REG(FLASH_SPI_NUM), SPI_FLASH_RDSR);
-    while (REG_READ(SPI_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-    uint32_t status_value = REG_READ(SPI_RD_STATUS_REG(FLASH_SPI_NUM));
-
-    return (status_value & STATUS_BUSY_BIT) != 0;
-}
-
-void stub_target_flash_erase_sector_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_CMD_REG(FLASH_SPI_NUM), SPI_FLASH_SE);
-    while (REG_READ(SPI_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started sector erase at 0x%x\n", addr);
-}
-
-void stub_target_flash_erase_block_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_CMD_REG(FLASH_SPI_NUM), SPI_FLASH_BE);
-    while (REG_READ(SPI_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32c2/include/soc/spi_mem_compat.h
+++ b/src/target/esp32c2/include/soc/spi_mem_compat.h
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "spi_mem_reg.h"

--- a/src/target/esp32c2/src/flash.c
+++ b/src/target/esp32c2/src/flash.c
@@ -7,64 +7,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <target/flash.h>
-#include <esp-stub-lib/log.h>
-#include <esp-stub-lib/bit_utils.h>
 #include <esp-stub-lib/soc_utils.h>
-#include <esp-stub-lib/err.h>
-#include <soc/spi_mem_reg.h>
+#include <soc/spi_mem_compat.h>
 
-#define FLASH_SPI_NUM   1
-#define STATUS_BUSY_BIT BIT(0)
-
-extern void esp_rom_spiflash_attach(uint32_t ishspi, bool legacy);
-
-void stub_target_flash_attach(uint32_t ishspi, bool legacy)
-{
-    esp_rom_spiflash_attach(ishspi, legacy);
-}
-
-static void spi_wait_ready(void)
+void stub_target_spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_MST_ST)) {
         /* busy wait */
     }
-}
-
-bool stub_target_flash_is_busy(void)
-{
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM), 0);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-    uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM));
-
-    return (status_value & STATUS_BUSY_BIT) != 0;
-}
-
-void stub_target_flash_erase_sector_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started sector erase at 0x%x\n", addr);
-}
-
-void stub_target_flash_erase_block_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32c3/include/soc/spi_mem_compat.h
+++ b/src/target/esp32c3/include/soc/spi_mem_compat.h
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "spi_mem_reg.h"

--- a/src/target/esp32c3/src/flash.c
+++ b/src/target/esp32c3/src/flash.c
@@ -7,30 +7,19 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <target/flash.h>
-#include <esp-stub-lib/log.h>
-#include <esp-stub-lib/bit_utils.h>
 #include <esp-stub-lib/soc_utils.h>
-#include <esp-stub-lib/err.h>
-#include <soc/spi_mem_reg.h>
+#include <soc/spi_mem_compat.h>
 
-#define SPI_INTERNAL    0
-#define FLASH_SPI_NUM   1
-#define STATUS_BUSY_BIT BIT(0)
+#define SPI_INTERNAL 0
 
 extern uint32_t esp_rom_efuse_get_flash_gpio_info(void);
-extern void esp_rom_spiflash_attach(uint32_t ishspi, bool legacy);
 
 uint32_t stub_target_flash_get_spiconfig_efuse(void)
 {
     return esp_rom_efuse_get_flash_gpio_info();
 }
 
-void stub_target_flash_attach(uint32_t ishspi, bool legacy)
-{
-    esp_rom_spiflash_attach(ishspi, legacy);
-}
-
-static void spi_wait_ready(void)
+void stub_target_spi_wait_ready(void)
 {
     /* There is no HW arbiter on SPI0, so we need to wait for it to be ready */
     while (REG_GET_FIELD(SPI_MEM_FSM_REG(SPI_INTERNAL), SPI_MEM_EM_ST)) {
@@ -39,43 +28,4 @@ static void spi_wait_ready(void)
     while (REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_MST_ST)) {
         /* busy wait */
     }
-}
-
-bool stub_target_flash_is_busy(void)
-{
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM), 0);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-    uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM));
-
-    return (status_value & STATUS_BUSY_BIT) != 0;
-}
-
-void stub_target_flash_erase_sector_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started sector erase at 0x%x\n", addr);
-}
-
-void stub_target_flash_erase_block_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32c5/include/soc/spi_mem_compat.h
+++ b/src/target/esp32c5/include/soc/spi_mem_compat.h
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "spi1_mem_reg.h"

--- a/src/target/esp32c5/src/flash.c
+++ b/src/target/esp32c5/src/flash.c
@@ -7,25 +7,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <target/flash.h>
-#include <esp-stub-lib/log.h>
 #include <esp-stub-lib/bit_utils.h>
 #include <esp-stub-lib/soc_utils.h>
-#include <esp-stub-lib/err.h>
 #include <private/rom_flash.h>
-#include <soc/spi1_mem_reg.h>
-
-#define FLASH_SPI_NUM   1
-#define STATUS_BUSY_BIT BIT(0)
+#include <soc/spi_mem_compat.h>
 
 /* ECO version from ROM - used to route to correct ROM functions */
 extern uint32_t _rom_eco_version;
-extern void esp_rom_spiflash_attach(uint32_t ishspi, bool legacy);
-
-void stub_target_flash_attach(uint32_t ishspi, bool legacy)
-{
-    esp_rom_spiflash_attach(ishspi, legacy);
-}
-
 /* ECO-specific ROM function declarations */
 extern void esp_rom_opiflash_exec_cmd_eco2(int spi_num,
                                            spi_flash_mode_t mode,
@@ -88,52 +76,15 @@ void stub_target_opiflash_exec_cmd(const opiflash_cmd_params_t *params)
     }
 }
 
-static void spi_wait_ready(void)
+void stub_target_spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_MST_ST)) {
         /* busy wait */
     }
 }
 
-bool stub_target_flash_is_busy(void)
-{
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM), 0);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-    uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM));
-
-    return (status_value & STATUS_BUSY_BIT) != 0;
-}
-
-void stub_target_flash_erase_sector_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started sector erase at 0x%x\n", addr);
-}
-
-void stub_target_flash_erase_block_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started block erase at 0x%x\n", addr);
-}
-
 uint32_t stub_target_get_max_supported_flash_size(void)
 {
     /* ESP32-C5 supports up to 32MB with 4-byte addressing */
-    return 32 * 1024 * 1024;
+    return MIB(32);
 }

--- a/src/target/esp32c6/include/soc/spi_mem_compat.h
+++ b/src/target/esp32c6/include/soc/spi_mem_compat.h
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "spi_mem_reg.h"

--- a/src/target/esp32c6/src/flash.c
+++ b/src/target/esp32c6/src/flash.c
@@ -7,65 +7,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <target/flash.h>
-#include <esp-stub-lib/log.h>
-#include <esp-stub-lib/bit_utils.h>
 #include <esp-stub-lib/soc_utils.h>
-#include <esp-stub-lib/err.h>
-#include <soc/spi_mem_reg.h>
+#include <soc/spi_mem_compat.h>
 
-#define FLASH_SPI_NUM   1
-#define STATUS_BUSY_BIT BIT(0)
-
-extern void esp_rom_spiflash_attach(uint32_t ishspi, bool legacy);
-
-void stub_target_flash_attach(uint32_t ishspi, bool legacy)
-{
-    esp_rom_spiflash_attach(ishspi, legacy);
-}
-
-static void spi_wait_ready(void)
+void stub_target_spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_MST_ST) ||
            REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_SLV_ST)) {
         /* busy wait */
     }
-}
-
-bool stub_target_flash_is_busy(void)
-{
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM), 0);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-    uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM));
-
-    return (status_value & STATUS_BUSY_BIT) != 0;
-}
-
-void stub_target_flash_erase_sector_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started sector erase at 0x%x\n", addr);
-}
-
-void stub_target_flash_erase_block_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32c61/include/soc/spi_mem_compat.h
+++ b/src/target/esp32c61/include/soc/spi_mem_compat.h
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "spi1_mem_reg.h"

--- a/src/target/esp32c61/src/flash.c
+++ b/src/target/esp32c61/src/flash.c
@@ -7,65 +7,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <target/flash.h>
-#include <esp-stub-lib/log.h>
-#include <esp-stub-lib/bit_utils.h>
 #include <esp-stub-lib/soc_utils.h>
-#include <esp-stub-lib/err.h>
-#include <soc/spi1_mem_reg.h>
+#include <soc/spi_mem_compat.h>
 
-#define FLASH_SPI_NUM   1
-#define STATUS_BUSY_BIT BIT(0)
-
-extern void esp_rom_spiflash_attach(uint32_t ishspi, bool legacy);
-
-void stub_target_flash_attach(uint32_t ishspi, bool legacy)
-{
-    esp_rom_spiflash_attach(ishspi, legacy);
-}
-
-static void spi_wait_ready(void)
+void stub_target_spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_MST_ST) ||
            REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_SLV_ST)) {
         /* busy wait */
     }
-}
-
-bool stub_target_flash_is_busy(void)
-{
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM), 0);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-    uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM));
-
-    return (status_value & STATUS_BUSY_BIT) != 0;
-}
-
-void stub_target_flash_erase_sector_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started sector erase at 0x%x\n", addr);
-}
-
-void stub_target_flash_erase_block_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32h2/include/soc/spi_mem_compat.h
+++ b/src/target/esp32h2/include/soc/spi_mem_compat.h
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "spi_mem_reg.h"

--- a/src/target/esp32h2/src/flash.c
+++ b/src/target/esp32h2/src/flash.c
@@ -7,65 +7,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <target/flash.h>
-#include <esp-stub-lib/log.h>
-#include <esp-stub-lib/bit_utils.h>
 #include <esp-stub-lib/soc_utils.h>
-#include <esp-stub-lib/err.h>
-#include <soc/spi_mem_reg.h>
+#include <soc/spi_mem_compat.h>
 
-#define FLASH_SPI_NUM   1
-#define STATUS_BUSY_BIT BIT(0)
-
-extern void esp_rom_spiflash_attach(uint32_t ishspi, bool legacy);
-
-void stub_target_flash_attach(uint32_t ishspi, bool legacy)
-{
-    esp_rom_spiflash_attach(ishspi, legacy);
-}
-
-static void spi_wait_ready(void)
+void stub_target_spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_MST_ST) ||
            REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_SLV_ST)) {
         /* busy wait */
     }
-}
-
-bool stub_target_flash_is_busy(void)
-{
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM), 0);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-    uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM));
-
-    return (status_value & STATUS_BUSY_BIT) != 0;
-}
-
-void stub_target_flash_erase_sector_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started sector erase at 0x%x\n", addr);
-}
-
-void stub_target_flash_erase_block_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32h21/include/soc/spi_mem_compat.h
+++ b/src/target/esp32h21/include/soc/spi_mem_compat.h
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "spi1_mem_reg.h"

--- a/src/target/esp32h21/src/flash.c
+++ b/src/target/esp32h21/src/flash.c
@@ -7,65 +7,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <target/flash.h>
-#include <esp-stub-lib/log.h>
-#include <esp-stub-lib/bit_utils.h>
 #include <esp-stub-lib/soc_utils.h>
-#include <esp-stub-lib/err.h>
-#include <soc/spi1_mem_reg.h>
+#include <soc/spi_mem_compat.h>
 
-#define FLASH_SPI_NUM   1
-#define STATUS_BUSY_BIT BIT(0)
-
-extern void esp_rom_spiflash_attach(uint32_t ishspi, bool legacy);
-
-void stub_target_flash_attach(uint32_t ishspi, bool legacy)
-{
-    esp_rom_spiflash_attach(ishspi, legacy);
-}
-
-static void spi_wait_ready(void)
+void stub_target_spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_MST_ST) ||
            REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_SLV_ST)) {
         /* busy wait */
     }
-}
-
-bool stub_target_flash_is_busy(void)
-{
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM), 0);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-    uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM));
-
-    return (status_value & STATUS_BUSY_BIT) != 0;
-}
-
-void stub_target_flash_erase_sector_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started sector erase at 0x%x\n", addr);
-}
-
-void stub_target_flash_erase_block_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32h4/include/soc/spi_mem_compat.h
+++ b/src/target/esp32h4/include/soc/spi_mem_compat.h
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "spi1_mem_reg.h"

--- a/src/target/esp32h4/src/flash.c
+++ b/src/target/esp32h4/src/flash.c
@@ -7,65 +7,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <target/flash.h>
-#include <esp-stub-lib/log.h>
-#include <esp-stub-lib/bit_utils.h>
 #include <esp-stub-lib/soc_utils.h>
-#include <esp-stub-lib/err.h>
-#include <soc/spi1_mem_reg.h>
+#include <soc/spi_mem_compat.h>
 
-#define FLASH_SPI_NUM   1
-#define STATUS_BUSY_BIT BIT(0)
-
-extern void esp_rom_spiflash_attach(uint32_t ishspi, bool legacy);
-
-void stub_target_flash_attach(uint32_t ishspi, bool legacy)
-{
-    esp_rom_spiflash_attach(ishspi, legacy);
-}
-
-static void spi_wait_ready(void)
+void stub_target_spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_MST_ST) ||
            REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_SLV_ST)) {
         /* busy wait */
     }
-}
-
-bool stub_target_flash_is_busy(void)
-{
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM), 0);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-    uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM));
-
-    return (status_value & STATUS_BUSY_BIT) != 0;
-}
-
-void stub_target_flash_erase_sector_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started sector erase at 0x%x\n", addr);
-}
-
-void stub_target_flash_erase_block_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32p4/include/soc/spi_mem_compat.h
+++ b/src/target/esp32p4/include/soc/spi_mem_compat.h
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "spi1_mem_c_reg.h"
+
+#define SPI_MEM_ADDR_REG(i)       SPI1_MEM_C_ADDR_REG
+#define SPI_MEM_CMD_REG(i)        SPI1_MEM_C_CMD_REG
+#define SPI_MEM_RD_STATUS_REG(i)  SPI1_MEM_C_RD_STATUS_REG
+#define SPI_MEM_FLASH_SE          SPI1_MEM_C_FLASH_SE
+#define SPI_MEM_FLASH_BE          SPI1_MEM_C_FLASH_BE
+#define SPI_MEM_FLASH_RDSR        SPI1_MEM_C_FLASH_RDSR

--- a/src/target/esp32s2/include/soc/spi_mem_compat.h
+++ b/src/target/esp32s2/include/soc/spi_mem_compat.h
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "spi_mem_reg.h"

--- a/src/target/esp32s2/src/flash.c
+++ b/src/target/esp32s2/src/flash.c
@@ -8,27 +8,15 @@
 #include <stdbool.h>
 #include <private/rom_flash.h>
 #include <target/flash.h>
-#include <esp-stub-lib/log.h>
-#include <esp-stub-lib/bit_utils.h>
 #include <esp-stub-lib/soc_utils.h>
-#include <esp-stub-lib/err.h>
-#include <soc/spi_mem_reg.h>
-
-#define FLASH_SPI_NUM   1
-#define STATUS_BUSY_BIT BIT(0)
+#include <soc/spi_mem_compat.h>
 
 extern esp_rom_spiflash_chip_t g_rom_flashchip;
 extern uint32_t esp_rom_efuse_get_flash_gpio_info(void);
-extern void esp_rom_spiflash_attach(uint32_t ishspi, bool legacy);
 
 uint32_t stub_target_flash_get_spiconfig_efuse(void)
 {
     return esp_rom_efuse_get_flash_gpio_info();
-}
-
-void stub_target_flash_attach(uint32_t ishspi, bool legacy)
-{
-    esp_rom_spiflash_attach(ishspi, legacy);
 }
 
 esp_rom_spiflash_chip_t *stub_target_flash_get_config(void)
@@ -36,7 +24,7 @@ esp_rom_spiflash_chip_t *stub_target_flash_get_config(void)
     return &g_rom_flashchip;
 }
 
-static void spi_wait_ready(void)
+void stub_target_spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_FSM_REG(FLASH_SPI_NUM), SPI_MEM_ST)) {
         /* busy wait */
@@ -45,43 +33,4 @@ static void spi_wait_ready(void)
     while ((REG_READ(SPI_MEM_FSM_REG(FLASH_SPI_NUM)) & SPI_MEM_ST)) {
         /* busy wait */
     }
-}
-
-bool stub_target_flash_is_busy(void)
-{
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM), 0);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-    uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM));
-
-    return (status_value & STATUS_BUSY_BIT) != 0;
-}
-
-void stub_target_flash_erase_sector_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started sector erase at 0x%x\n", addr);
-}
-
-void stub_target_flash_erase_block_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started block erase at 0x%x\n", addr);
 }

--- a/src/target/esp32s3/include/soc/spi_mem_compat.h
+++ b/src/target/esp32s3/include/soc/spi_mem_compat.h
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "spi_mem_reg.h"

--- a/src/target/esp32s3/src/flash.c
+++ b/src/target/esp32s3/src/flash.c
@@ -6,24 +6,20 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <log.h>
-#include <err.h>
 #include <target/flash.h>
 #include <private/rom_flash.h>
 #include <private/rom_flash_config.h>
+#include <esp-stub-lib/log.h>
 #include <esp-stub-lib/bit_utils.h>
 #include <esp-stub-lib/soc_utils.h>
-#include <soc/spi_mem_reg.h>
+#include <soc/spi_mem_compat.h>
 #include <soc/io_mux_reg.h>
 
-#define SPI_INTERNAL    0
-#define FLASH_SPI_NUM   1
-#define STATUS_BUSY_BIT BIT(0)
+#define SPI_INTERNAL 0
 
 extern uint32_t ets_efuse_get_spiconfig(void);
 extern esp_rom_spiflash_legacy_funcs_t *rom_spiflash_legacy_funcs;
 extern uint32_t esp_rom_efuse_get_flash_gpio_info(void);
-extern void esp_rom_spiflash_attach(uint32_t spiconfig, bool legacy);
 extern void esp_rom_opiflash_exec_cmd(int spi_num,
                                       spi_flash_mode_t mode,
                                       uint32_t cmd,
@@ -37,11 +33,6 @@ extern void esp_rom_opiflash_exec_cmd(int spi_num,
                                       int miso_bit_len,
                                       uint32_t cs_mask,
                                       bool is_write_erase_operation);
-
-void stub_target_flash_attach(uint32_t ishspi, bool legacy)
-{
-    esp_rom_spiflash_attach(ishspi, legacy);
-}
 
 uint32_t stub_target_flash_get_spiconfig_efuse(void)
 {
@@ -65,7 +56,7 @@ void stub_target_flash_init(void *state)
 {
     (void)state;
     uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();
-    esp_rom_spiflash_attach(spiconfig, 0);
+    stub_target_flash_attach(spiconfig, 0);
     if (ets_efuse_flash_octal_mode()) {
         STUB_LOGD("octal mode is on\n");
         stub_target_flash_init_funcs();
@@ -89,7 +80,7 @@ void stub_target_opiflash_exec_cmd(const opiflash_cmd_params_t *params)
                               params->is_write_erase_operation);
 }
 
-static void spi_wait_ready(void)
+void stub_target_spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_FSM_REG(FLASH_SPI_NUM), SPI_MEM_ST)) {
         /* busy wait */
@@ -100,47 +91,8 @@ static void spi_wait_ready(void)
     }
 }
 
-bool stub_target_flash_is_busy(void)
-{
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM), 0);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_RDSR);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-    uint32_t status_value = REG_READ(SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM));
-
-    return (status_value & STATUS_BUSY_BIT) != 0;
-}
-
-void stub_target_flash_erase_sector_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_SE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started sector erase at 0x%x\n", addr);
-}
-
-void stub_target_flash_erase_block_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_MEM_ADDR_REG(FLASH_SPI_NUM), addr & 0xffffff);
-    REG_WRITE(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_FLASH_BE);
-    while (REG_READ(SPI_MEM_CMD_REG(FLASH_SPI_NUM)) != 0) {
-    }
-
-    STUB_LOGV("Started block erase at 0x%x\n", addr);
-}
-
 uint32_t stub_target_get_max_supported_flash_size(void)
 {
     /* ESP32-S3 supports up to 1GB with 4-byte addressing */
-    return 1024 * 1024 * 1024;
+    return GIB(1);
 }

--- a/src/target/esp8266/include/soc/spi_mem_compat.h
+++ b/src/target/esp8266/include/soc/spi_mem_compat.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include <esp-stub-lib/bit_utils.h>
+
+// ESP8266 uses SPI0 as the flash interface
+#define SPI_BASE_REG      0x60000200
+#define SPI_EXT2_REG      (SPI_BASE_REG + 0xF8)
+#define SPI_CMD_REG       (SPI_BASE_REG + 0x00)
+#define SPI_RD_STATUS_REG (SPI_BASE_REG + 0x10)
+#define SPI_ADDR_REG      (SPI_BASE_REG + 0x04)
+#define SPI_FLASH_WREN    BIT(30)
+#define SPI_FLASH_RDID    BIT(28)
+#define SPI_FLASH_RDSR    BIT(27)
+#define SPI_FLASH_SE      BIT(24)
+#define SPI_FLASH_BE      BIT(23)
+#define SPI_W0            (SPI_BASE_REG + 0x40)
+#define SPI_CMD           (SPI_BASE_REG + 0x0)
+
+#define SPI_ST            0x00000007
+#define SPI_ST_M          ((SPI_ST_V) << (SPI_ST_S))
+#define SPI_ST_V          0x7
+#define SPI_ST_S          0
+
+#define SPI_MEM_ADDR_REG(i)       SPI_ADDR_REG
+#define SPI_MEM_CMD_REG(i)        SPI_CMD_REG
+#define SPI_MEM_RD_STATUS_REG(i)  SPI_RD_STATUS_REG
+#define SPI_MEM_FLASH_SE          SPI_FLASH_SE
+#define SPI_MEM_FLASH_BE          SPI_FLASH_BE
+#define SPI_MEM_FLASH_RDSR        SPI_FLASH_RDSR

--- a/src/target/esp8266/src/flash.c
+++ b/src/target/esp8266/src/flash.c
@@ -8,31 +8,9 @@
 #include <stdbool.h>
 #include <target/flash.h>
 #include <private/rom_flash.h>
-#include <esp-stub-lib/log.h>
 #include <esp-stub-lib/err.h>
-#include <esp-stub-lib/bit_utils.h>
 #include <esp-stub-lib/soc_utils.h>
-
-// ESP8266 uses SPI0 as the flash interface
-#define SPI_BASE_REG      0x60000200
-#define SPI_EXT2_REG      (SPI_BASE_REG + 0xF8)
-#define SPI_CMD_REG       (SPI_BASE_REG + 0x00)
-#define SPI_RD_STATUS_REG (SPI_BASE_REG + 0x10)
-#define SPI_ADDR_REG      (SPI_BASE_REG + 0x04)
-#define SPI_FLASH_WREN    BIT(30)
-#define SPI_FLASH_RDID    BIT(28)
-#define SPI_FLASH_RDSR    BIT(27)
-#define SPI_FLASH_SE      BIT(24)
-#define SPI_FLASH_BE      BIT(23)
-#define SPI_W0            (SPI_BASE_REG + 0x40)
-#define SPI_CMD           (SPI_BASE_REG + 0x0)
-
-#define SPI_ST            0x00000007
-#define SPI_ST_M          ((SPI_ST_V) << (SPI_ST_S))
-#define SPI_ST_V          0x7
-#define SPI_ST_S          0
-
-#define STATUS_BUSY_BIT   BIT(0)
+#include <soc/spi_mem_compat.h>
 
 extern esp_rom_spiflash_chip_t g_rom_flashchip;
 extern int esp_rom_spiflash_write(uint32_t flash_addr, const void *data, uint32_t size);
@@ -78,59 +56,20 @@ int stub_target_flash_write_buff(uint32_t addr, const void *buffer, uint32_t siz
     return res == ESP_ROM_SPIFLASH_RESULT_OK ? STUB_LIB_OK : STUB_LIB_FAIL;
 }
 
-static void spi_wait_ready(void)
+void stub_target_spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_EXT2_REG, SPI_ST)) {
         /* busy wait */
     }
 }
 
-bool stub_target_flash_is_busy(void)
-{
-    spi_wait_ready();
-
-    REG_WRITE(SPI_RD_STATUS_REG, 0);
-    REG_WRITE(SPI_CMD_REG, SPI_FLASH_RDSR);
-    while (REG_READ(SPI_CMD_REG) != 0) {
-    }
-    uint32_t status_value = REG_READ(SPI_RD_STATUS_REG);
-
-    return (status_value & STATUS_BUSY_BIT) != 0;
-}
-
 void stub_target_flash_write_enable(void)
 {
     // ROM SPI_write_enable() does not work for ESP8266, so we use our own implementation
-    spi_wait_ready();
+    stub_target_spi_wait_ready();
     REG_WRITE(SPI_CMD_REG, SPI_FLASH_WREN);
     while (REG_READ(SPI_CMD_REG) != 0)
         ;
-}
-
-void stub_target_flash_erase_sector_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_ADDR_REG, addr & 0xffffff);
-    REG_WRITE(SPI_CMD_REG, SPI_FLASH_SE);
-    while (REG_READ(SPI_CMD_REG) != 0) {
-    }
-
-    STUB_LOGV("Started sector erase at 0x%x\n", addr);
-}
-
-void stub_target_flash_erase_block_start(uint32_t addr)
-{
-    stub_target_flash_write_enable();
-    spi_wait_ready();
-
-    REG_WRITE(SPI_ADDR_REG, addr & 0xffffff);
-    REG_WRITE(SPI_CMD_REG, SPI_FLASH_BE);
-    while (REG_READ(SPI_CMD_REG) != 0) {
-    }
-
-    STUB_LOGV("Started block erase at 0x%x\n", addr);
 }
 
 void stub_target_flash_write_encrypted_enable(void)


### PR DESCRIPTION
- Move duplicated flash functions (stub_target_flash_erase_sector_start, stub_target_flash_erase_block_start, stub_target_flash_is_busy, stub_target_flash_attach) into `common/flash.c` as weak defaults
- Introduce per target `spi_mem_compat.h` adapter headers that unify SPI register naming differences behind a common SPI_MEM_* interface
