### PR TITLE
fix(flash): wait for erase complete before returning from erase_area

### DIFF
--- a/src/flash.c
+++ b/src/flash.c
@@ -222,5 +222,5 @@ int stub_lib_flash_erase_area(uint32_t addr, uint32_t size)
         }
     }
 
-    return STUB_LIB_OK;
+    return stub_lib_flash_wait_ready(timeout_us);
 }


### PR DESCRIPTION
stub_lib_flash_erase_area returned STUB_LIB_OK immediately after issuing the last erase command without waiting for it to finish. This could cause subsequent flash operations to fail if the erase was still in progress.

Wait for flash ready state after the erase loop completes.
