### PR TITLE
fix(esp32s2): wait for SPI0 idle using correct peripheral index

### DIFF
--- a/src/target/esp32s2/src/flash.c
+++ b/src/target/esp32s2/src/flash.c
@@ -15,6 +15,8 @@
 
 #include <soc/spi_mem_compat.h>
 
+#define SPI_INTERNAL 0
+
 extern esp_rom_spiflash_chip_t g_rom_flashchip;
 extern uint32_t esp_rom_efuse_get_flash_gpio_info(void);
 
@@ -30,11 +32,12 @@ esp_rom_spiflash_chip_t *stub_target_flash_get_config(void)
 
 void stub_target_spi_wait_ready(void)
 {
-    while (REG_GET_FIELD(SPI_MEM_FSM_REG(FLASH_SPI_NUM), SPI_MEM_ST)) {
+    while ((REG_READ(SPI_MEM_FSM_REG(FLASH_SPI_NUM)) & SPI_MEM_ST)) {
         /* busy wait */
     }
+
     /* There is no HW arbiter on SPI0, so we need to wait for it to be ready */
-    while ((REG_READ(SPI_MEM_FSM_REG(FLASH_SPI_NUM)) & SPI_MEM_ST)) {
+    while ((REG_READ(SPI_MEM_FSM_REG(SPI_INTERNAL)) & SPI_MEM_ST)) {
         /* busy wait */
     }
 }


### PR DESCRIPTION
The second busy-wait loop in stub_target_spi_wait_ready should poll SPI0 (internal flash cache bus) not SPI1 (flash controller). Also replace REG_GET_FIELD with REG_READ for the first loop to match the bitmask check style.
