### PR TITLE
feat(esp32c61): Add large flash support

### DIFF
--- a/src/target/esp32c61/CMakeLists.txt
+++ b/src/target/esp32c61/CMakeLists.txt
@@ -12,4 +12,5 @@ target_link_options(${ESP_TARGET_LIB}
     PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c61.rom.api.ld
     PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c61.rom.libc.ld
     PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c61.rom.libgcc.ld
+    PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c61.rom.extra.ld
 )

--- a/src/target/esp32c61/ld/esp32c61.rom.extra.ld
+++ b/src/target/esp32c61/ld/esp32c61.rom.extra.ld
@@ -1,0 +1,7 @@
+/***************************************
+ * Manually added ROM symbols for esp32c61
+ * These symbols are not in the auto-generated ROM linker scripts
+ * but are needed for ECO version handling
+ ***************************************/
+
+esp_rom_opiflash_exec_cmd = 0x4002acea;

--- a/src/target/esp32c61/ld/esp32c61.rom.ld
+++ b/src/target/esp32c61/ld/esp32c61.rom.ld
@@ -173,7 +173,6 @@ rom_spiflash_legacy_funcs = 0x4084fff0;
 rom_spiflash_legacy_data = 0x4084ffec;
 g_flash_guard_ops = 0x4084fff4;
 
-
 /***************************************
  Group cache
  ***************************************/

--- a/src/target/esp32c61/src/flash.c
+++ b/src/target/esp32c61/src/flash.c
@@ -13,10 +13,47 @@
 
 #include <soc/spi_mem_compat.h>
 
+extern void esp_rom_opiflash_exec_cmd(int spi_num,
+                                      spi_flash_mode_t mode,
+                                      uint32_t cmd,
+                                      int cmd_bit_len,
+                                      uint32_t addr,
+                                      int addr_bit_len,
+                                      int dummy_bits,
+                                      const uint8_t *mosi_data,
+                                      int mosi_bit_len,
+                                      uint8_t *miso_data,
+                                      int miso_bit_len,
+                                      uint32_t cs_mask,
+                                      bool is_write_erase_operation);
+
+void stub_target_opiflash_exec_cmd(const opiflash_cmd_params_t *params)
+{
+    esp_rom_opiflash_exec_cmd(params->spi_num,
+                              params->mode,
+                              params->cmd,
+                              params->cmd_bit_len,
+                              params->addr,
+                              params->addr_bit_len,
+                              params->dummy_bits,
+                              params->mosi_data,
+                              params->mosi_bit_len,
+                              params->miso_data,
+                              params->miso_bit_len,
+                              params->cs_mask,
+                              params->is_write_erase_operation);
+}
+
 void stub_target_spi_wait_ready(void)
 {
     while (REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_MST_ST) ||
            REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_SLV_ST)) {
         /* busy wait */
     }
+}
+
+uint32_t stub_target_get_max_supported_flash_size(void)
+{
+    /* ESP32-C61 supports up to 32MB with 4-byte addressing */
+    return MIB(32);
 }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Support for large flash for ESP32-C61, tested on V1.0

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
