### PR TITLE
feat: add esp32s31 base support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@
 **esp-stub-lib** is an experimental C library for creating flash stubs that can be loaded onto Espressif ESP chips. It uses a three-layer architecture to maximize code reuse across multiple ESP chip targets while eliminating circular dependencies.
 
 **Language/Tools:** C (C17), CMake, Ninja, Python, pre-commit hooks
-**Supported Targets:** ESP8266, ESP32, ESP32-S2, ESP32-S3, ESP32-C2, ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, ESP32-H21, ESP32-H4, ESP32-P4 (including P4-rev1)
+**Supported Targets:** ESP8266, ESP32, ESP32-S2, ESP32-S3, ESP32-C2, ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, ESP32-H21, ESP32-H4, ESP32-P4 (including P4-rev1), ESP32-S31
 
 ## Three-Layer Architecture
 
@@ -65,7 +65,7 @@ src/                        # Implementation sources
 **IMPORTANT:** Building requires ESP-IDF toolchains to be installed and available in PATH. The build system expects target-specific cross-compilers:
 
 - **Xtensa targets** (esp32, esp32s2, esp32s3): `xtensa-{target}-elf-gcc`
-- **RISC-V targets** (esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32h21, esp32h4, esp32p4): `riscv32-esp-elf-gcc`
+- **RISC-V targets** (esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32h21, esp32h4, esp32p4, esp32s31): `riscv32-esp-elf-gcc`
 - **ESP8266**: `xtensa-lx106-elf-gcc` (auto-downloaded by build.sh)
 
 **Setup:** Follow https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html to install ESP-IDF and export the environment (`. $IDF_PATH/export.sh`).
@@ -83,7 +83,7 @@ cd example
 ./build.sh clean            # Clean all builds
 ```
 
-**Supported targets in build.sh:** esp8266, esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32h21, esp32h4, esp32p4, esp32p4-rev1
+**Supported targets in build.sh:** esp8266, esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32h21, esp32h4, esp32p4, esp32p4-rev1, esp32s31
 
 **Manual build:**
 ```bash
@@ -197,7 +197,7 @@ body (optional)
 
 **Workflows:**
 1. **build_example.yml** - Builds example for all targets on PR/push to non-master branches
-   - Builds all ESP-IDF targets (esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32h21, esp32h4, esp32p4, esp32p4-rev1) using `espressif/esp-idf-ci-action@v1` with latest ESP-IDF
+   - Builds all ESP-IDF targets (esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32h21, esp32h4, esp32p4, esp32p4-rev1, esp32s31) using `espressif/esp-idf-ci-action@v1` with latest ESP-IDF
    - Builds ESP8266 separately using `./build.sh esp8266` (requires custom toolchain)
    - Uploads build artifacts from `example/build/{target}/` (.elf, .map, .asm files)
    - **Failure means:** Build errors, missing toolchain, or incorrect CMake configuration

--- a/.github/workflows/build_example.yml
+++ b/.github/workflows/build_example.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         espidf_target: [esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32h21, esp32h4,
-          esp32p4, esp32p4-rev1]
+          esp32p4, esp32p4-rev1, esp32s31]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@ If something is unclear or missing, feel free to open a PR to improve this docum
     - [Per-target CMakeLists.txt](#per-target-cmakeliststxt)
     - [Symbol override](#symbol-override)
   - [Adding a New Chip](#adding-a-new-chip)
+    - [SPI register naming](#spi-register-naming)
+    - [ROM function signature mismatches](#rom-function-signature-mismatches)
   - [Testing](#testing)
   - [Code Style](#code-style)
     - [License header](#license-header)
@@ -342,12 +344,13 @@ these flags.
 src/target/<chip>/
 ├── CMakeLists.txt
 ├── include/
+│   ├── esp_rom_caps.h
 │   └── soc/
 │       ├── soc.h
 │       ├── soc_caps.h
 │       ├── reg_base.h
 │       ├── spi_mem_compat.h
-│       ├── spi_mem_reg.h
+│       ├── spi_mem_reg.h       ← may be split: spi_mem_c_reg.h + spi1_mem_c_reg.h on some chips
 │       ├── uart_reg.h
 │       └── io_mux_reg.h
 ├── ld/
@@ -365,13 +368,51 @@ src/target/<chip>/
    `components/hal/<chip>/include/hal/`).
 2. Create the directory tree.
 3. Pull SOC headers from ESP-IDF. Only what you need.
-4. Pull ROM linker scripts from ESP-IDF
+4. Pull `esp_rom_caps.h` from ESP-IDF (`components/esp_rom/<chip>/`). If a capability is
+   not yet supported, set it to `-1` as a placeholder to unblock the build, and add a
+   `/* TODO */` comment.
+5. Pull ROM linker scripts from ESP-IDF
    (`components/esp_rom/<chip>/ld/`). Check that function names match.
-5. Write overrides. Start from the closest existing chip:
+6. Write overrides. Start from the closest existing chip:
    - RISC-V single-core (C6, H2, H21, C61): start from `esp32c6`
-   - Multi-level cache (P4): start from `esp32p4`
-6. Write `CMakeLists.txt`.
-7. Build with `-DESP_TARGET=<chip>` and test.
+   - RISC-V multi-core (P4, H4, S31): start from `esp32p4`
+7. Write `CMakeLists.txt`.
+8. Build with `-DESP_TARGET=<chip>` and fix any remaining errors. It is fine to start
+   with only `flash.c` and `uart.c` to get a working build, and add other overrides
+   incrementally.
+
+### SPI register naming
+
+On some chips (e.g. esp32s31) the SPI memory register headers are split or use a
+different naming scheme (`SPI1_MEM_C_*` instead of `SPI_MEM_*`). Use `spi_mem_compat.h`
+to map the generic names the common code uses to the chip-specific register names:
+
+```c
+/* spi_mem_compat.h — esp32s31 example */
+#define SPI_MEM_CMD_REG(n)   SPI1_MEM_C_CMD_REG
+#define SPI_MEM_MST_ST       SPI1_MEM_C_MST_ST
+```
+
+If the chip splits the register file (e.g. `spi_mem_c_reg.h` and `spi1_mem_c_reg.h`),
+include both in `spi_mem_compat.h` so callers only need one include.
+
+### ROM function signature mismatches
+
+ROM functions sometimes take fewer parameters than the `stub_target_*` interface
+expects. Write a strong override that accepts the full interface signature and silences
+the unused parameter with `(void)`:
+
+```c
+/* ROM on this chip only takes uart_no — clock is baked in */
+void stub_target_rom_uart_init(uint8_t uart_no, uint32_t clock)
+{
+    (void)clock;
+    esp_rom_uart_init(uart_no);
+}
+```
+
+Add a short comment explaining why the parameter is ignored, so reviewers don't flag
+it as a bug.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This project is experimental and not yet ready for production use.
 - ESP32-H21
 - ESP32-H4
 - ESP32-P4 (including P4-rev1)
+- ESP32-S31
 
 ## How to use
 

--- a/example/build.sh
+++ b/example/build.sh
@@ -2,7 +2,8 @@
 
 set -eo pipefail
 
-TARGETS="esp8266 esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32h21 esp32h4 esp32p4 esp32p4-rev1"
+TARGETS="esp8266 esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32h21 esp32h4 \
+        esp32p4 esp32p4-rev1 esp32s31"
 
 ESP8266_LINUX_TOOLCHAIN_URL="https://dl.espressif.com/dl/xtensa-lx106-elf-gcc8_4_0-esp-2020r3-linux-amd64.tar.gz"
 ESP8266_MACOS_TOOLCHAIN_URL="https://dl.espressif.com/dl/xtensa-lx106-elf-gcc8_4_0-esp-2020r3-macos.tar.gz"

--- a/example/cmake/util.cmake
+++ b/example/cmake/util.cmake
@@ -5,7 +5,7 @@ function(validate_esp_target ESP_TARGET)
 
     set(ESP8266_TARGET esp8266)
     set(XTENSA_TARGETS esp32 esp32s2 esp32s3)
-    set(RISCV_TARGETS esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32h21 esp32h4 esp32p4)
+    set(RISCV_TARGETS esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32h21 esp32h4 esp32p4 esp32s31)
     set(VALID_TARGETS ${ESP8266_TARGET} ${XTENSA_TARGETS} ${RISCV_TARGETS})
 
     if(NOT ESP_TARGET IN_LIST VALID_TARGETS)

--- a/example/ld/esp32s31.ld
+++ b/example/ld/esp32s31.ld
@@ -1,0 +1,4 @@
+MEMORY {
+	iram : org = 0x2F000000, len = 0x4000
+	dram : org = 0x2F004000, len = 0x20000
+}

--- a/src/target/common/CMakeLists.txt
+++ b/src/target/common/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(common_srcs
     src/aes_xts.c
+    src/clock.c
     src/flash.c
     src/flash_4byte.c
     src/mem_utils.c

--- a/src/target/common/src/clock.c
+++ b/src/target/common/src/clock.c
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stdint.h>
+
+__attribute__((weak)) void stub_target_clock_init(void)
+{
+}
+
+__attribute__((weak)) uint32_t stub_target_get_cpu_freq(void)
+{
+    return 0;
+}
+
+__attribute__((weak)) uint32_t stub_target_get_apb_freq(void)
+{
+    return 0;
+}
+
+__attribute__((weak)) void stub_target_clock_disable_watchdogs(void)
+{
+}

--- a/src/target/esp32s31/CMakeLists.txt
+++ b/src/target/esp32s31/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(srcs
+    src/flash.c
+    src/uart.c
+)
+
+add_library(${ESP_TARGET_LIB} STATIC ${srcs})
+
+target_link_options(${ESP_TARGET_LIB}
+    PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32s31.rom.ld
+    PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32s31.rom.api.ld
+    PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32s31.rom.libc.ld
+    PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32s31.rom.libgcc.ld
+)

--- a/src/target/esp32s31/include/esp_rom_caps.h
+++ b/src/target/esp32s31/include/esp_rom_caps.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define ESP_ROM_HAS_CRC_LE               (1) // ROM CRC library supports Little Endian
+#define ESP_ROM_HAS_CRC_BE               (1) // ROM CRC library supports Big Endian
+#define ESP_ROM_HAS_JPEG_DECODE          (1) // ROM has JPEG decode library
+#define ESP_ROM_UART_CLK_IS_XTAL         (1) // UART clock source is selected to XTAL in ROM
+
+// TODO: Set -1 to skip build error in esp32s31 target
+#define ESP_ROM_USB_SERIAL_DEVICE_NUM    (-1) //(5) // The serial port ID (UART, USB, ...) of USB_SERIAL_JTAG in the ROM.
+
+#define ESP_ROM_USB_OTG_NUM              (4) // The serial port ID (UART, USB, ...) of USB_OTG_CDC in the ROM.
+#define ESP_ROM_HAS_RETARGETABLE_LOCKING (1) // ROM was built with retargetable locking
+#define ESP_ROM_GET_CLK_FREQ             (1) // Get clk frequency with rom function `ets_get_cpu_frequency`
+#define ESP_ROM_HAS_RVFPLIB              (1) // ROM has the rvfplib
+#define ESP_ROM_HAS_HAL_WDT              (1) // ROM has the implementation of Watchdog HAL driver
+#define ESP_ROM_HAS_HAL_SYSTIMER         (1) // ROM has the implementation of Systimer HAL driver
+#define ESP_ROM_HAS_LAYOUT_TABLE         (1) // ROM has the layout table
+#define ESP_ROM_WDT_INIT_PATCH           (1) // ROM version does not configure the clock
+#define ESP_ROM_HAS_HEAP_TLSF            (1) // ROM has the implementation of the tlsf and multi-heap library
+#define ESP_ROM_HAS_NEWLIB               (1) // ROM has newlib (at least parts of it) functions included
+#define ESP_ROM_HAS_NEWLIB_NANO_FORMAT   (1) // ROM has the newlib nano version of formatting functions
+#define ESP_ROM_HAS_VERSION              (1) // ROM has version/eco information
+#define ESP_ROM_MULTI_HEAP_WALK_PATCH    (1) // ROM does not contain the patch of multi_heap_walk()

--- a/src/target/esp32s31/include/soc/io_mux_reg.h
+++ b/src/target/esp32s31/include/soc/io_mux_reg.h
@@ -1,0 +1,514 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+#include "soc/soc.h"
+
+/* The following are the bit fields for PERIPHS_IO_MUX_x_U registers */
+/* Output enable in sleep mode */
+#define SLP_OE (BIT(0))
+#define SLP_OE_M (BIT(0))
+#define SLP_OE_V 1
+#define SLP_OE_S 0
+/* Pin used for wakeup from sleep */
+#define SLP_SEL (BIT(1))
+#define SLP_SEL_M (BIT(1))
+#define SLP_SEL_V 1
+#define SLP_SEL_S 1
+/* Pulldown enable in sleep mode */
+#define SLP_PD (BIT(2))
+#define SLP_PD_M (BIT(2))
+#define SLP_PD_V 1
+#define SLP_PD_S 2
+/* Pullup enable in sleep mode */
+#define SLP_PU (BIT(3))
+#define SLP_PU_M (BIT(3))
+#define SLP_PU_V 1
+#define SLP_PU_S 3
+/* Input enable in sleep mode */
+#define SLP_IE (BIT(4))
+#define SLP_IE_M (BIT(4))
+#define SLP_IE_V 1
+#define SLP_IE_S 4
+/* Drive strength in sleep mode */
+#define SLP_DRV 0x3
+#define SLP_DRV_M (SLP_DRV_V << SLP_DRV_S)
+#define SLP_DRV_V 0x3
+#define SLP_DRV_S 5
+/* Pulldown enable */
+#define FUN_PD (BIT(7))
+#define FUN_PD_M (BIT(7))
+#define FUN_PD_V 1
+#define FUN_PD_S 7
+/* Pullup enable */
+#define FUN_PU (BIT(8))
+#define FUN_PU_M (BIT(8))
+#define FUN_PU_V 1
+#define FUN_PU_S 8
+/* Input enable */
+#define FUN_IE (BIT(9))
+#define FUN_IE_M (FUN_IE_V << FUN_IE_S)
+#define FUN_IE_V 1
+#define FUN_IE_S 9
+/* Drive strength */
+#define FUN_DRV 0x3
+#define FUN_DRV_M (FUN_DRV_V << FUN_DRV_S)
+#define FUN_DRV_V 0x3
+#define FUN_DRV_S 10
+/* Function select (possible values are defined for each pin as FUNC_pinname_function below) */
+#define MCU_SEL 0x7
+#define MCU_SEL_M (MCU_SEL_V << MCU_SEL_S)
+#define MCU_SEL_V 0x7
+#define MCU_SEL_S 12
+
+#define PIN_INPUT_ENABLE(PIN_NAME)               SET_PERI_REG_MASK(PIN_NAME,FUN_IE)
+#define PIN_INPUT_DISABLE(PIN_NAME)              CLEAR_PERI_REG_MASK(PIN_NAME,FUN_IE)
+#define PIN_SET_DRV(PIN_NAME, drv)            REG_SET_FIELD(PIN_NAME, FUN_DRV, (drv));
+#define PIN_PULLUP_DIS(PIN_NAME)                 REG_CLR_BIT(PIN_NAME, FUN_PU)
+#define PIN_PULLUP_EN(PIN_NAME)                  REG_SET_BIT(PIN_NAME, FUN_PU)
+#define PIN_PULLDWN_DIS(PIN_NAME)             REG_CLR_BIT(PIN_NAME, FUN_PD)
+#define PIN_PULLDWN_EN(PIN_NAME)              REG_SET_BIT(PIN_NAME, FUN_PD)
+#define PIN_FUNC_SELECT(PIN_NAME, FUNC)      REG_SET_FIELD(PIN_NAME, MCU_SEL, FUNC)
+
+#define IO_MUX_GPIO0_REG                    PERIPHS_IO_MUX_U_XTAL32K_HYS_P
+#define IO_MUX_GPIO1_REG                    PERIPHS_IO_MUX_U_XTAL32K_HYS_N
+#define IO_MUX_GPIO2_REG                    PERIPHS_IO_MUX_U_GPIO2
+#define IO_MUX_GPIO3_REG                    PERIPHS_IO_MUX_U_GPIO3
+#define IO_MUX_GPIO4_REG                    PERIPHS_IO_MUX_U_GPIO4
+#define IO_MUX_GPIO5_REG                    PERIPHS_IO_MUX_U_GPIO5
+#define IO_MUX_GPIO6_REG                    PERIPHS_IO_MUX_U_TOUCH_GPIO6
+#define IO_MUX_GPIO7_REG                    PERIPHS_IO_MUX_U_TOUCH_GPIO7
+#define IO_MUX_GPIO8_REG                    PERIPHS_IO_MUX_U_TOUCH_GPIO8
+#define IO_MUX_GPIO9_REG                    PERIPHS_IO_MUX_U_TOUCH_GPIO9
+#define IO_MUX_GPIO10_REG                   PERIPHS_IO_MUX_U_TOUCH_GPIO10
+#define IO_MUX_GPIO11_REG                   PERIPHS_IO_MUX_U_TOUCH_GPIO11
+#define IO_MUX_GPIO12_REG                   PERIPHS_IO_MUX_U_TOUCH_GPIO12
+#define IO_MUX_GPIO13_REG                   PERIPHS_IO_MUX_U_TOUCH_GPIO13
+#define IO_MUX_GPIO14_REG                   PERIPHS_IO_MUX_U_TOUCH_GPIO14
+#define IO_MUX_GPIO15_REG                   PERIPHS_IO_MUX_U_TOUCH_GPIO15
+#define IO_MUX_GPIO16_REG                   PERIPHS_IO_MUX_U_TOUCH_GPIO16
+#define IO_MUX_GPIO17_REG                   PERIPHS_IO_MUX_U_TOUCH_GPIO17
+#define IO_MUX_GPIO18_REG                   PERIPHS_IO_MUX_U_TOUCH_GPIO18
+#define IO_MUX_GPIO19_REG                   PERIPHS_IO_MUX_U_TOUCH_GPIO19
+#define IO_MUX_GPIO20_REG                   PERIPHS_IO_MUX_U_GPIO20
+#define IO_MUX_GPIO21_REG                   PERIPHS_IO_MUX_U_GPIO21
+#define IO_MUX_GPIO22_REG                   PERIPHS_IO_MUX_U_GPIO22
+#define IO_MUX_GPIO23_REG                   PERIPHS_IO_MUX_U_GPIO23
+#define IO_MUX_GPIO24_REG                   PERIPHS_IO_MUX_U_GPIO24
+#define IO_MUX_GPIO25_REG                   PERIPHS_IO_MUX_U_GPIO25
+#define IO_MUX_GPIO26_REG                   PERIPHS_IO_MUX_U_GPIO26
+#define IO_MUX_GPIO27_REG                   PERIPHS_IO_MUX_U_GPIO27
+#define IO_MUX_GPIO28_REG                   PERIPHS_IO_MUX_U_GPIO28
+#define IO_MUX_GPIO29_REG                   PERIPHS_IO_MUX_U_GPIO29
+#define IO_MUX_GPIO30_REG                   PERIPHS_IO_MUX_U_GPIO30
+#define IO_MUX_GPIO31_REG                   PERIPHS_IO_MUX_U_GPIO31
+#define IO_MUX_GPIO32_REG                   PERIPHS_IO_MUX_U_GPIO32
+#define IO_MUX_GPIO33_REG                   PERIPHS_IO_MUX_U_USB_GPIO33
+#define IO_MUX_GPIO34_REG                   PERIPHS_IO_MUX_U_USB_GPIO34
+#define IO_MUX_GPIO35_REG                   PERIPHS_IO_MUX_U_GPIO35
+#define IO_MUX_GPIO36_REG                   PERIPHS_IO_MUX_U_GPIO36
+#define IO_MUX_GPIO37_REG                   PERIPHS_IO_MUX_U_GPIO37
+#define IO_MUX_GPIO38_REG                   PERIPHS_IO_MUX_U_GPIO38
+#define IO_MUX_GPIO39_REG                   PERIPHS_IO_MUX_U_GPIO39
+#define IO_MUX_GPIO40_REG                   PERIPHS_IO_MUX_U_GPIO40
+#define IO_MUX_GPIO41_REG                   PERIPHS_IO_MUX_U_GPIO41
+#define IO_MUX_GPIO42_REG                   PERIPHS_IO_MUX_U_ADC_GPIO42
+#define IO_MUX_GPIO43_REG                   PERIPHS_IO_MUX_U_ADC_GPIO43
+#define IO_MUX_GPIO44_REG                   PERIPHS_IO_MUX_U_ADC_GPIO44
+#define IO_MUX_GPIO45_REG                   PERIPHS_IO_MUX_U_ADC_GPIO45
+#define IO_MUX_GPIO46_REG                   PERIPHS_IO_MUX_U_ADC_GPIO46
+#define IO_MUX_GPIO47_REG                   PERIPHS_IO_MUX_U_ADC_GPIO47
+#define IO_MUX_GPIO48_REG                   PERIPHS_IO_MUX_U_ADC_GPIO48
+#define IO_MUX_GPIO49_REG                   PERIPHS_IO_MUX_U_ADC_GPIO49
+#define IO_MUX_GPIO50_REG                   PERIPHS_IO_MUX_U_ADC_GPIO50
+#define IO_MUX_GPIO51_REG                   PERIPHS_IO_MUX_U_ADC_GPIO51
+#define IO_MUX_GPIO52_REG                   PERIPHS_IO_MUX_U_ADC_GPIO52
+#define IO_MUX_GPIO53_REG                   PERIPHS_IO_MUX_U_ADC_GPIO53
+#define IO_MUX_GPIO54_REG                   PERIPHS_IO_MUX_U_ADC_GPIO54
+#define IO_MUX_GPIO55_REG                   PERIPHS_IO_MUX_U_ADC_GPIO55
+#define IO_MUX_GPIO56_REG                   PERIPHS_IO_MUX_U_ADC_GPIO56
+#define IO_MUX_GPIO57_REG                   PERIPHS_IO_MUX_U_ADC_GPIO57
+#define IO_MUX_GPIO58_REG                   PERIPHS_IO_MUX_U_GPIO58
+#define IO_MUX_GPIO59_REG                   PERIPHS_IO_MUX_U_GPIO59
+#define IO_MUX_GPIO60_REG                   PERIPHS_IO_MUX_U_GPIO60
+#define IO_MUX_GPIO61_REG                   PERIPHS_IO_MUX_U_GPIO61
+#define IO_MUX_GPIO62_REG                   PERIPHS_IO_MUX_U_GPIO62
+
+#define PIN_FUNC_GPIO								1
+
+#define USB_INT_PHY0_DM_GPIO_NUM     33
+#define USB_INT_PHY0_DP_GPIO_NUM     34
+
+#define REG_IO_MUX_BASE                              DR_REG_IO_MUX_BASE
+
+// definitions below are generated from pin_txt.csv
+#define PERIPHS_IO_MUX_U_XTAL32K_HYS_P               (REG_IO_MUX_BASE + 0x0)
+#define FUNC_XTAL_32K_N_GPIO0_0                                            0
+#define FUNC_XTAL_32K_N_GPIO0                                              1
+
+#define PERIPHS_IO_MUX_U_XTAL32K_HYS_N               (REG_IO_MUX_BASE + 0x4)
+#define FUNC_XTAL_32K_P_GPIO1_0                                            0
+#define FUNC_XTAL_32K_P_GPIO1                                              1
+
+#define PERIPHS_IO_MUX_U_GPIO2                       (REG_IO_MUX_BASE + 0x8)
+#define FUNC_GPIO2_GPIO2_0                                                 0
+#define FUNC_GPIO2_GPIO2                                                   1
+#define FUNC_GPIO2_LCD_DATA19_OUT_PAD                                      3
+
+#define PERIPHS_IO_MUX_U_GPIO3                       (REG_IO_MUX_BASE + 0xc)
+#define FUNC_GPIO3_GPIO3_0                                                 0
+#define FUNC_GPIO3_GPIO3                                                   1
+#define FUNC_GPIO3_LCD_DATA20_OUT_PAD                                      3
+
+#define PERIPHS_IO_MUX_U_GPIO4                      (REG_IO_MUX_BASE + 0x10)
+#define FUNC_GPIO4_GPIO4_0                                                 0
+#define FUNC_GPIO4_GPIO4                                                   1
+#define FUNC_GPIO4_LCD_DATA21_OUT_PAD                                      3
+
+#define PERIPHS_IO_MUX_U_GPIO5                      (REG_IO_MUX_BASE + 0x14)
+#define FUNC_GPIO5_GPIO5_0                                                 0
+#define FUNC_GPIO5_GPIO5                                                   1
+#define FUNC_GPIO5_LCD_DATA22_OUT_PAD                                      3
+
+#define PERIPHS_IO_MUX_U_TOUCH_GPIO6                (REG_IO_MUX_BASE + 0x18)
+#define FUNC_GPIO6_GPIO6_0                                                 0
+#define FUNC_GPIO6_GPIO6                                                   1
+
+#define PERIPHS_IO_MUX_U_TOUCH_GPIO7                (REG_IO_MUX_BASE + 0x1c)
+#define FUNC_GPIO7_GPIO7_0                                                 0
+#define FUNC_GPIO7_GPIO7                                                   1
+#define FUNC_GPIO7_LCD_DATA23_OUT_PAD                                      3
+
+#define PERIPHS_IO_MUX_U_TOUCH_GPIO8                (REG_IO_MUX_BASE + 0x20)
+#define FUNC_GPIO8_GPIO8_0                                                 0
+#define FUNC_GPIO8_GPIO8                                                   1
+#define FUNC_GPIO8_GMAC_PHY_TXD0_PAD                                       2
+#define FUNC_GPIO8_LCD_DATA0_OUT_PAD                                       3
+
+#define PERIPHS_IO_MUX_U_TOUCH_GPIO9                (REG_IO_MUX_BASE + 0x24)
+#define FUNC_GPIO9_SPI2_HOLD_PAD                                           0
+#define FUNC_GPIO9_GPIO9                                                   1
+#define FUNC_GPIO9_GMAC_PHY_TXD1_PAD                                       2
+#define FUNC_GPIO9_LCD_DATA1_OUT_PAD                                       3
+#define FUNC_GPIO9_DBG_PSRAM_CK_PAD                                        4
+
+#define PERIPHS_IO_MUX_U_TOUCH_GPIO10               (REG_IO_MUX_BASE + 0x28)
+#define FUNC_GPIO10_SPI2_CS_PAD                                            0
+#define FUNC_GPIO10_GPIO10                                                 1
+#define FUNC_GPIO10_GMAC_PHY_TXD2_PAD                                      2
+#define FUNC_GPIO10_LCD_DATA2_OUT_PAD                                      3
+#define FUNC_GPIO10_DBG_PSRAM_CS_PAD                                       4
+
+#define PERIPHS_IO_MUX_U_TOUCH_GPIO11               (REG_IO_MUX_BASE + 0x2c)
+#define FUNC_GPIO11_SPI2_D_PAD                                             0
+#define FUNC_GPIO11_GPIO11                                                 1
+#define FUNC_GPIO11_GMAC_PHY_TXD3_PAD                                      2
+#define FUNC_GPIO11_LCD_DATA3_OUT_PAD                                      3
+#define FUNC_GPIO11_DBG_PSRAM_D_PAD                                        4
+
+#define PERIPHS_IO_MUX_U_TOUCH_GPIO12               (REG_IO_MUX_BASE + 0x30)
+#define FUNC_GPIO12_SPI2_CK_PAD                                            0
+#define FUNC_GPIO12_GPIO12                                                 1
+#define FUNC_GPIO12_GMAC_PHY_TXEN_PAD                                      2
+#define FUNC_GPIO12_LCD_DATA4_OUT_PAD                                      3
+#define FUNC_GPIO12_DBG_PSRAM_Q_PAD                                        4
+
+#define PERIPHS_IO_MUX_U_TOUCH_GPIO13               (REG_IO_MUX_BASE + 0x34)
+#define FUNC_GPIO13_SPI2_Q_PAD                                             0
+#define FUNC_GPIO13_GPIO13                                                 1
+#define FUNC_GPIO13_GMAC_RMII_CLK_PAD                                      2
+#define FUNC_GPIO13_LCD_DATA5_OUT_PAD                                      3
+#define FUNC_GPIO13_DBG_PSRAM_WP_PAD                                       4
+
+#define PERIPHS_IO_MUX_U_TOUCH_GPIO14               (REG_IO_MUX_BASE + 0x38)
+#define FUNC_GPIO14_SPI2_WP_PAD                                            0
+#define FUNC_GPIO14_GPIO14                                                 1
+#define FUNC_GPIO14_GMAC_RX_CLK_PAD                                        2
+#define FUNC_GPIO14_LCD_DATA6_OUT_PAD                                      3
+#define FUNC_GPIO14_DBG_PSRAM_HOLD_PAD                                     4
+
+#define PERIPHS_IO_MUX_U_TOUCH_GPIO15               (REG_IO_MUX_BASE + 0x3c)
+#define FUNC_GPIO15_SPI2_IO4_PAD                                           0
+#define FUNC_GPIO15_GPIO15                                                 1
+#define FUNC_GPIO15_GMAC_PHY_RXDV_PAD                                      2
+#define FUNC_GPIO15_LCD_DATA7_OUT_PAD                                      3
+#define FUNC_GPIO15_DBG_PSRAM_DQ4_PAD                                      4
+
+#define PERIPHS_IO_MUX_U_TOUCH_GPIO16               (REG_IO_MUX_BASE + 0x40)
+#define FUNC_GPIO16_SPI2_IO5_PAD                                           0
+#define FUNC_GPIO16_GPIO16                                                 1
+#define FUNC_GPIO16_GMAC_PHY_RXD3_PAD                                      2
+#define FUNC_GPIO16_LCD_DATA8_OUT_PAD                                      3
+#define FUNC_GPIO16_DBG_PSRAM_DQ5_PAD                                      4
+
+#define PERIPHS_IO_MUX_U_TOUCH_GPIO17               (REG_IO_MUX_BASE + 0x44)
+#define FUNC_GPIO17_SPI2_IO6_PAD                                           0
+#define FUNC_GPIO17_GPIO17                                                 1
+#define FUNC_GPIO17_GMAC_PHY_RXD2_PAD                                      2
+#define FUNC_GPIO17_LCD_DATA9_OUT_PAD                                      3
+#define FUNC_GPIO17_DBG_PSRAM_DQ6_PAD                                      4
+
+#define PERIPHS_IO_MUX_U_TOUCH_GPIO18               (REG_IO_MUX_BASE + 0x48)
+#define FUNC_GPIO18_SPI2_IO7_PAD                                           0
+#define FUNC_GPIO18_GPIO18                                                 1
+#define FUNC_GPIO18_GMAC_PHY_RXD1_PAD                                      2
+#define FUNC_GPIO18_LCD_DATA10_OUT_PAD                                     3
+#define FUNC_GPIO18_DBG_PSRAM_DQ7_PAD                                      4
+
+#define PERIPHS_IO_MUX_U_TOUCH_GPIO19               (REG_IO_MUX_BASE + 0x4c)
+#define FUNC_GPIO19_SPI2_DQS_PAD                                           0
+#define FUNC_GPIO19_GPIO19                                                 1
+#define FUNC_GPIO19_GMAC_PHY_RXD0_PAD                                      2
+#define FUNC_GPIO19_LCD_DATA11_OUT_PAD                                     3
+#define FUNC_GPIO19_DBG_PSRAM_DQS_0_PAD                                    4
+
+#define PERIPHS_IO_MUX_U_GPIO20                     (REG_IO_MUX_BASE + 0x50)
+#define FUNC_SDIO_DATA0_GPIO20_0                                           0
+#define FUNC_SDIO_DATA0_GPIO20                                             1
+#define FUNC_SDIO_DATA0_SPI2_CK_PAD                                        2
+#define FUNC_SDIO_DATA0_DBG_FLASH_CK_PAD                                   4
+
+#define PERIPHS_IO_MUX_U_GPIO21                     (REG_IO_MUX_BASE + 0x54)
+#define FUNC_SDIO_DATA1_GPIO21_0                                           0
+#define FUNC_SDIO_DATA1_GPIO21                                             1
+#define FUNC_SDIO_DATA1_SPI2_D_PAD                                         2
+#define FUNC_SDIO_DATA1_DBG_FLASH_D_PAD                                    4
+
+#define PERIPHS_IO_MUX_U_GPIO22                     (REG_IO_MUX_BASE + 0x58)
+#define FUNC_SDIO_DATA2_GPIO22_0                                           0
+#define FUNC_SDIO_DATA2_GPIO22                                             1
+#define FUNC_SDIO_DATA2_SPI2_Q_PAD                                         2
+#define FUNC_SDIO_DATA2_DBG_FLASH_CS_PAD                                   4
+
+#define PERIPHS_IO_MUX_U_GPIO23                     (REG_IO_MUX_BASE + 0x5c)
+#define FUNC_SDIO_DATA3_GPIO23_0                                           0
+#define FUNC_SDIO_DATA3_GPIO23                                             1
+#define FUNC_SDIO_DATA3_SPI2_CS_PAD                                        2
+#define FUNC_SDIO_DATA3_DBG_FLASH_Q_PAD                                    4
+
+#define PERIPHS_IO_MUX_U_GPIO24                     (REG_IO_MUX_BASE + 0x60)
+#define FUNC_SDIO_CLK_GPIO24_0                                             0
+#define FUNC_SDIO_CLK_GPIO24                                               1
+#define FUNC_SDIO_CLK_SPI2_HOLD_PAD                                        2
+#define FUNC_SDIO_CLK_DBG_FLASH_WP_PAD                                     4
+
+#define PERIPHS_IO_MUX_U_GPIO25                     (REG_IO_MUX_BASE + 0x64)
+#define FUNC_SDIO_CMD_GPIO25_0                                             0
+#define FUNC_SDIO_CMD_GPIO25                                               1
+#define FUNC_SDIO_CMD_SPI2_WP_PAD                                          2
+#define FUNC_SDIO_CMD_DBG_FLASH_HOLD_PAD                                   4
+
+#define PERIPHS_IO_MUX_U_GPIO26                     (REG_IO_MUX_BASE + 0x68)
+#define FUNC_SPICS_FLASH_CS_PAD                                            0
+#define FUNC_SPICS_GPIO26                                                  1
+
+#define PERIPHS_IO_MUX_U_GPIO27                     (REG_IO_MUX_BASE + 0x6c)
+#define FUNC_SPIQ_FLASH_Q_PAD                                              0
+#define FUNC_SPIQ_GPIO27                                                   1
+
+#define PERIPHS_IO_MUX_U_GPIO28                     (REG_IO_MUX_BASE + 0x70)
+#define FUNC_SPIWP_FLASH_WP_PAD                                            0
+#define FUNC_SPIWP_GPIO28                                                  1
+
+#define PERIPHS_IO_MUX_U_GPIO29                     (REG_IO_MUX_BASE + 0x74)
+#define FUNC_VDD_SPI_GPIO29_0                                              0
+#define FUNC_VDD_SPI_GPIO29                                                1
+
+#define PERIPHS_IO_MUX_U_GPIO30                     (REG_IO_MUX_BASE + 0x78)
+#define FUNC_SPIHD_FLASH_HOLD_PAD                                          0
+#define FUNC_SPIHD_GPIO30                                                  1
+
+#define PERIPHS_IO_MUX_U_GPIO31                     (REG_IO_MUX_BASE + 0x7c)
+#define FUNC_SPICLK_FLASH_CK_PAD                                           0
+#define FUNC_SPICLK_GPIO31                                                 1
+
+#define PERIPHS_IO_MUX_U_GPIO32                     (REG_IO_MUX_BASE + 0x80)
+#define FUNC_SPID_FLASH_D_PAD                                              0
+#define FUNC_SPID_GPIO32                                                   1
+
+#define PERIPHS_IO_MUX_U_USB_GPIO33                 (REG_IO_MUX_BASE + 0x84)
+#define FUNC_GPIO33_GPIO33_0                                               0
+#define FUNC_GPIO33_GPIO33                                                 1
+#define FUNC_GPIO33_LCD_DATA12_OUT_PAD                                     3
+
+#define PERIPHS_IO_MUX_U_USB_GPIO34                 (REG_IO_MUX_BASE + 0x88)
+#define FUNC_GPIO34_GPIO34_0                                               0
+#define FUNC_GPIO34_GPIO34                                                 1
+#define FUNC_GPIO34_LCD_DATA13_OUT_PAD                                     3
+
+#define PERIPHS_IO_MUX_U_GPIO35                     (REG_IO_MUX_BASE + 0x8c)
+#define FUNC_GPIO35_GPIO35_0                                               0
+#define FUNC_GPIO35_GPIO35                                                 1
+#define FUNC_GPIO35_REF_GMAC_CLK_PAD                                       2
+#define FUNC_GPIO35_LCD_DATA14_OUT_PAD                                     3
+#define FUNC_GPIO35_SD2_CDATA0_PAD                                         4
+
+// Strapping: LDO sel
+#define PERIPHS_IO_MUX_U_GPIO36                     (REG_IO_MUX_BASE + 0x90)
+#define FUNC_GPIO36_GPIO36_0                                               0
+#define FUNC_GPIO36_GPIO36                                                 1
+#define FUNC_GPIO36_GMAC_PHY_RXDV_PAD                                      2
+#define FUNC_GPIO36_LCD_DATA15_OUT_PAD                                     3
+#define FUNC_GPIO36_SD2_CDATA1_PAD                                         4
+
+// Strapping: USB2JTAG select: 1->usb2jtag 0-> pad_jtag
+#define PERIPHS_IO_MUX_U_GPIO37                     (REG_IO_MUX_BASE + 0x94)
+#define FUNC_GPIO37_GPIO37_0                                               0
+#define FUNC_GPIO37_GPIO37                                                 1
+#define FUNC_GPIO37_GMAC_PHY_TXEN_PAD                                      2
+#define FUNC_GPIO37_LCD_DATA16_OUT_PAD                                     3
+#define FUNC_GPIO37_SD2_CDATA2_PAD                                         4
+
+// Strapping: Boot Mode select 0
+#define PERIPHS_IO_MUX_U_GPIO38                     (REG_IO_MUX_BASE + 0x98)
+#define FUNC_GPIO38_GPIO38_0                                               0
+#define FUNC_GPIO38_GPIO38                                                 1
+#define FUNC_GPIO38_GMAC_PHY_RXD3_PAD                                      2
+#define FUNC_GPIO38_LCD_DATA17_OUT_PAD                                     3
+#define FUNC_GPIO38_SD2_CDATA3_PAD                                         4
+
+// Strapping: Boot Mode select 1
+#define PERIPHS_IO_MUX_U_GPIO39                     (REG_IO_MUX_BASE + 0x9c)
+#define FUNC_GPIO39_GPIO39_0                                               0
+#define FUNC_GPIO39_GPIO39                                                 1
+#define FUNC_GPIO39_GMAC_PHY_RXD2_PAD                                      2
+#define FUNC_GPIO39_LCD_DATA18_OUT_PAD                                     3
+#define FUNC_GPIO39_SD2_CCLK_PAD                                           4
+
+// Strapping: Boot Mode select 2
+#define PERIPHS_IO_MUX_U_GPIO40                     (REG_IO_MUX_BASE + 0xa0)
+#define FUNC_GPIO40_GPIO40_0                                               0
+#define FUNC_GPIO40_GPIO40                                                 1
+#define FUNC_GPIO40_GMAC_PHY_RXD1_PAD                                      2
+#define FUNC_GPIO40_LCD_PCLK_PAD                                           3
+#define FUNC_GPIO40_SD2_CCMD_PAD                                           4
+
+#define PERIPHS_IO_MUX_U_GPIO41                     (REG_IO_MUX_BASE + 0xa4)
+#define FUNC_GPIO41_GPIO41_0                                               0
+#define FUNC_GPIO41_GPIO41                                                 1
+#define FUNC_GPIO41_GMAC_PHY_RXD0_PAD                                      2
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO42                 (REG_IO_MUX_BASE + 0xa8)
+#define FUNC_GPIO42_GPIO42_0                                               0
+#define FUNC_GPIO42_GPIO42                                                 1
+#define FUNC_GPIO42_GMAC_RX_CLK_PAD                                        2
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO43                 (REG_IO_MUX_BASE + 0xac)
+#define FUNC_GPIO43_GPIO43_0                                               0
+#define FUNC_GPIO43_GPIO43                                                 1
+#define FUNC_GPIO43_GMAC_RMII_CLK_PAD                                      2
+#define FUNC_GPIO43_LCD_H_ENABLE_PAD                                       3
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO44                 (REG_IO_MUX_BASE + 0xb0)
+#define FUNC_GPIO44_GPIO44_0                                               0
+#define FUNC_GPIO44_GPIO44                                                 1
+#define FUNC_GPIO44_GMAC_PHY_TXD0_PAD                                      2
+#define FUNC_GPIO44_LCD_H_SYNC_PAD                                         3
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO45                 (REG_IO_MUX_BASE + 0xb4)
+#define FUNC_GPIO45_GPIO45_0                                               0
+#define FUNC_GPIO45_GPIO45                                                 1
+#define FUNC_GPIO45_GMAC_PHY_TXD1_PAD                                      2
+#define FUNC_GPIO45_LCD_V_SYNC_PAD                                         3
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO46                 (REG_IO_MUX_BASE + 0xb8)
+#define FUNC_GPIO46_GPIO46_0                                               0
+#define FUNC_GPIO46_GPIO46                                                 1
+#define FUNC_GPIO46_GMAC_PHY_TXD2_PAD                                      2
+#define FUNC_GPIO46_CAM_DATA0_IN_PAD                                       3
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO47                 (REG_IO_MUX_BASE + 0xbc)
+#define FUNC_GPIO47_GPIO47_0                                               0
+#define FUNC_GPIO47_GPIO47                                                 1
+#define FUNC_GPIO47_GMAC_PHY_TXD3_PAD                                      2
+#define FUNC_GPIO47_CAM_DATA1_IN_PAD                                       3
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO48                 (REG_IO_MUX_BASE + 0xc0)
+#define FUNC_GPIO48_GPIO48_0                                               0
+#define FUNC_GPIO48_GPIO48                                                 1
+#define FUNC_GPIO48_CAM_DATA2_IN_PAD                                       3
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO49                 (REG_IO_MUX_BASE + 0xc4)
+#define FUNC_GPIO49_GPIO49_0                                               0
+#define FUNC_GPIO49_GPIO49                                                 1
+#define FUNC_GPIO49_CAM_DATA3_IN_PAD                                       3
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO50                 (REG_IO_MUX_BASE + 0xc8)
+#define FUNC_GPIO50_GPIO50_0                                               0
+#define FUNC_GPIO50_GPIO50                                                 1
+#define FUNC_GPIO50_CAM_DATA4_IN_PAD                                       3
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO51                 (REG_IO_MUX_BASE + 0xcc)
+#define FUNC_GPIO51_GPIO51_0                                               0
+#define FUNC_GPIO51_GPIO51                                                 1
+#define FUNC_GPIO51_CAM_DATA5_IN_PAD                                       3
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO52                 (REG_IO_MUX_BASE + 0xd0)
+#define FUNC_GPIO52_GPIO52_0                                               0
+#define FUNC_GPIO52_GPIO52                                                 1
+#define FUNC_GPIO52_SPI2_CS_PAD                                            2
+#define FUNC_GPIO52_CAM_DATA6_IN_PAD                                       3
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO53                 (REG_IO_MUX_BASE + 0xd4)
+#define FUNC_GPIO53_GPIO53_0                                               0
+#define FUNC_GPIO53_GPIO53                                                 1
+#define FUNC_GPIO53_SPI2_CK_PAD                                            2
+#define FUNC_GPIO53_CAM_DATA7_IN_PAD                                       3
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO54                 (REG_IO_MUX_BASE + 0xd8)
+#define FUNC_MTDO_MTDO                                                     0
+#define FUNC_MTDO_GPIO54                                                   1
+#define FUNC_MTDO_SPI2_D_PAD                                               2
+#define FUNC_MTDO_CAM_PCLK_PAD                                             3
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO55                 (REG_IO_MUX_BASE + 0xdc)
+#define FUNC_MTCK_MTCK                                                     0
+#define FUNC_MTCK_GPIO55                                                   1
+#define FUNC_MTCK_SPI2_Q_PAD                                               2
+#define FUNC_MTCK_CAM_XCLK_PAD                                             3
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO56                 (REG_IO_MUX_BASE + 0xe0)
+#define FUNC_MTDI_MTDI                                                     0
+#define FUNC_MTDI_GPIO56                                                   1
+#define FUNC_MTDI_SPI2_HOLD_PAD                                            2
+#define FUNC_MTDI_CAM_V_SYNC_PAD                                           3
+
+#define PERIPHS_IO_MUX_U_ADC_GPIO57                 (REG_IO_MUX_BASE + 0xe4)
+#define FUNC_MTMS_MTMS                                                     0
+#define FUNC_MTMS_GPIO57                                                   1
+#define FUNC_MTMS_SPI2_WP_PAD                                              2
+#define FUNC_MTMS_CAM_H_SYNC_PAD                                           3
+
+#define PERIPHS_IO_MUX_U_GPIO58                     (REG_IO_MUX_BASE + 0xe8)
+#define FUNC_GPIO58_UART0_TXD_PAD                                          0
+#define FUNC_GPIO58_GPIO58                                                 1
+
+#define PERIPHS_IO_MUX_U_GPIO59                     (REG_IO_MUX_BASE + 0xec)
+#define FUNC_GPIO59_UART0_RXD_PAD                                          0
+#define FUNC_GPIO59_GPIO59                                                 1
+
+// Strapping: Boot Mode select 3
+#define PERIPHS_IO_MUX_U_GPIO60                     (REG_IO_MUX_BASE + 0xf0)
+#define FUNC_GPIO60_GPIO60_0                                               0
+#define FUNC_GPIO60_GPIO60                                                 1
+
+// Strapping: Boot Mode select 4
+#define PERIPHS_IO_MUX_U_GPIO61                     (REG_IO_MUX_BASE + 0xf4)
+#define FUNC_GPIO61_GPIO61_0                                               0
+#define FUNC_GPIO61_GPIO61                                                 1
+
+#define PERIPHS_IO_MUX_U_GPIO62                     (REG_IO_MUX_BASE + 0xf8)
+#define FUNC_GPIO62_GPIO62_0                                               0
+#define FUNC_GPIO62_GPIO62                                                 1
+
+
+#define IO_MUX_DATE_REG          (REG_IO_MUX_BASE + 0x1FC)
+/* IO_MUX_REG_DATE : R/W ;bitpos:[27:0] ;default: 28'h2502070 ; */
+/*description: Version control register.*/
+#define IO_MUX_REG_DATE    0x0FFFFFFF
+#define IO_MUX_REG_DATE_M  ((IO_MUX_REG_DATE_V)<<(IO_MUX_REG_DATE_S))
+#define IO_MUX_REG_DATE_V  0xFFFFFFF
+#define IO_MUX_REG_DATE_S  0

--- a/src/target/esp32s31/include/soc/reg_base.h
+++ b/src/target/esp32s31/include/soc/reg_base.h
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define DR_REG_USB_OTGHS_BASE                     0x20300000
+#define DR_REG_PAU_BASE                           0x20341000
+#define DR_REG_SDMMC_BASE                         0x20342000
+#define DR_REG_AHB_DMA_BASE                       0x20343000
+#define DR_REG_JPEG_BASE                          0x20344000
+#define DR_REG_PPA_BASE                           0x20345000
+#define DR_REG_DMA2D_BASE                         0x20346000
+#define DR_REG_AXI_DMA_BASE                       0x20348000
+#define DR_REG_GMAC_BASE                          0x20350000
+#define DR_REG_PVT_BASE                           0x20354000
+#define DR_REG_RMT_BASE                           0x20355000
+#define DR_REG_BITSCRAMBLER_BASE                  0x20356000
+#define DR_REG_ASRC_BASE                          0x20357000
+#define DR_REG_CNNT_SYS_REG_BASE                  0x20359000
+#define DR_REG_MCPWM0_BASE                        0x20381000
+#define DR_REG_MCPWM1_BASE                        0x20382000
+#define DR_REG_MCPWM2_BASE                        0x20383000
+#define DR_REG_MCPWM3_BASE                        0x20384000
+#define DR_REG_I2C0_BASE                          0x20385000
+#define DR_REG_I2C1_BASE                          0x20386000
+#define DR_REG_I2S0_BASE                          0x20387000
+#define DR_REG_I2S1_BASE                          0x20388000
+#define DR_REG_PCNT0_BASE                         0x20389000
+#define DR_REG_UART0_BASE                         0x2038A000
+#define DR_REG_UART1_BASE                         0x2038B000
+#define DR_REG_UART2_BASE                         0x2038C000
+#define DR_REG_UART3_BASE                         0x2038D000
+#define DR_REG_PARL_IO_BASE                       0x2038E000
+#define DR_REG_GPSPI2_BASE                        0x2038F000
+#define DR_REG_GPSPI3_BASE                        0x20390000
+#define DR_REG_USB_SERIAL_JTAG_BASE               0x20391000
+#define DR_REG_LEDC0_BASE                         0x20392000
+#define DR_REG_SOC_ETM_BASE                       0x20393000
+#define DR_REG_TWAIFD0_BASE                       0x20394000
+#define DR_REG_TWAIFD1_BASE                       0x20395000
+#define DR_REG_LCD_CAM_BASE                       0x20396000
+#define DR_REG_UHCI0_BASE                         0x20398000
+#define DR_REG_SYSTIMER_BASE                      0x20399000
+#define DR_REG_ZERO_DET_BASE                      0x2039A000
+#define DR_REG_CORDIC_BASE                        0x2039B000
+#define DR_REG_LEDC1_BASE                         0x2039C000
+#define DR_REG_PCNT1_BASE                         0x2039D000
+#define DR_REG_FLASH_SPI0_BASE                    0x20500000
+#define DR_REG_FLASH_SPI1_BASE                    0x20501000
+#define DR_REG_PSRAM_MSPI0_BASE                   0x20502000
+#define DR_REG_PSRAM_MSPI1_BASE                   0x20503000
+#define DR_REG_TEE_BASE                           0x20504000
+#define DR_REG_HP_APM_BASE                        0x20504400
+#define DR_REG_HP_MEM_APM_BASE                    0x20504800
+#define DR_REG_CPU_APM_BASE                       0x20504C00
+#define DR_REG_HP_PERI0_PMS_BASE                  0x20505000
+#define DR_REG_KEYMNG_BASE                        0x20506000
+#define DR_REG_AES_BASE                           0x20508000
+#define DR_REG_SHA_BASE                           0x20509000
+#define DR_REG_RSA_BASE                           0x2050A000
+#define DR_REG_ECC_BASE                           0x2050B000
+#define DR_REG_DS_BASE                            0x2050C000
+#define DR_REG_HMAC_BASE                          0x2050D000
+#define DR_REG_ECDSA_BASE                         0x2050E000
+#define DR_REG_RMA_BASE                           0x2050F000
+#define DR_REG_ICM_SYS_BASE                       0x20510000
+#define DR_REG_ICM_BASE                           0x20510400
+#define DR_REG_AXI_PERF_MON_BASE                  0x20511000
+#define DR_REG_TIMERG0_BASE                       0x20580000
+#define DR_REG_TIMERG1_BASE                       0x20581000
+#define DR_REG_IO_MUX_BASE                        0x20582000
+#define DR_REG_GPIO_BASE                          0x20583000
+#define DR_REG_GPIO_EXT_BASE                      0x20583E00
+#define DR_REG_IOMUX_MSPI_PIN_BASE                0x20584000
+#define DR_REG_INTR0_BASE                         0x20585000
+#define DR_REG_HP_SYS_BASE                        0x20586000
+#define DR_REG_HP_SYS_CLKRST_BASE                 0x20587000
+#define DR_REG_CNNT_PAD_CTRL_BASE                 0x20588000
+#define DR_REG_HP_ALIVE_SYS_BASE                  0x20589000
+#define DR_REG_HP_PERI1_PMS_BASE                  0x2058A000
+#define DR_REG_LP_SYS_BASE                        0x20700000
+#define DR_REG_LP_AONCLKRST_BASE                  0x20701000
+#define DR_REG_LP_ANA_BASE                        0x20702000
+#define DR_REG_HUK_BASE                           0x20703000
+#define DR_REG_PMU_BASE                           0x20704000
+#define DR_REG_TOUCH_AON_BASE                     0x20705000
+#define DR_REG_LP_PERI_PMS_BASE                   0x20706000
+#define DR_REG_LP_TEE_BASE                        0x20706800
+#define DR_REG_LP_APM_BASE                        0x20706C00
+#define DR_REG_LP_PERICLKRST_BASE                 0x20710000
+#define DR_REG_LP_IO_MUX_BASE                     0x20712000
+#define DR_REG_LP_GPIO_BASE                       0x20713000
+#define DR_REG_LP_INTR_BASE                       0x20714000
+#define DR_REG_EFUSE_BASE                         0x20715000
+#define DR_REG_RTC_TIMER_BASE                     0x20800000
+#define DR_REG_RTC_WDT_BASE                       0x20801000
+#define DR_REG_RTCLOCKCALI0_BASE                  0x20802000
+#define DR_REG_RTCLOCKCALI1_BASE                  0x20803000
+#define DR_REG_LP_PWR_REG_BASE                    0x20804000
+#define DR_REG_LP_ADI_BASE                        0x20805000
+#define DR_REG_LP_UART_BASE                       0x20810000
+#define DR_REG_LP_I2C_BASE                        0x20811000
+#define DR_REG_LP_SPI_BASE                        0x20812000
+#define DR_REG_LP_I2C_ANA_MST_BASE                0x20813000
+#define DR_REG_LP_TRNG_BASE                       0x20814000
+#define DR_REG_ADC_BASE                           0x20815000
+#define DR_REG_TOUCH_SENS_BASE                    0x20816000
+#define DR_REG_LP_MAILBOX_BASE                    0x20817000
+#define DR_REG_TSENS_BASE                         0x20818000
+#define DR_REG_LP_AHB_PDMA_BASE                   0x20819000
+#define DR_REG_LP_DAC_BASE                        0x2081A000
+#define DR_REG_CACHE_BASE                         0x2C000000
+#define DR_REG_TRACE0_BASE                        0x2D000000
+#define DR_REG_TRACE1_BASE                        0x2D001000
+#define DR_REG_BUS_MONITOR_BASE                   0x2D002000
+#define DR_REG_MEM_MONITOR0_BASE                  0x2D003000
+#define DR_REG_MEM_MONITOR1_BASE                  0x2D004000
+
+
+
+/**
+ * This are module helper MACROs for quick module reference
+ * including some module(renamed) address
+ */
+#define DR_REG_UART_BASE                        DR_REG_UART0_BASE
+#define DR_REG_TIMERGROUP0_BASE                 DR_REG_TIMERG0_BASE
+#define DR_REG_TIMERGROUP1_BASE                 DR_REG_TIMERG1_BASE
+#define DR_REG_I2S_BASE                         DR_REG_I2S0_BASE
+#define DR_REG_INTERRUPT_MATRIX_BASE            DR_REG_INTR0_BASE
+#define DR_REG_MCPWM_BASE                       DR_REG_MCPWM0_BASE
+#define DR_REG_PVT_MONITOR_BASE                 DR_REG_PVT_BASE
+#define DR_REG_ECC_MULT_BASE                    (DR_REG_AES_BASE + 0x3000)
+#define DR_REG_HP_CLKRST_BASE                   DR_REG_HP_SYS_CLKRST_BASE
+#define DR_REG_DSPI_MEM_BASE                    DR_REG_PSRAM_MSPI0_BASE
+#define DR_REG_INTERRUPT_CORE0_BASE             DR_REG_INTR0_BASE
+#define DR_REG_INTERRUPT_CORE1_BASE             (DR_REG_INTR0_BASE + 0x800)
+#define DR_REG_LPPERI_BASE                      DR_REG_LP_PERICLKRST_BASE
+#define DR_REG_SDHOST_BASE                      DR_REG_SDMMC_BASE
+#define DR_REG_TRACE_BASE                       DR_REG_TRACE0_BASE
+#define DR_REG_MB_BASE                          DR_REG_LP_MAILBOX_BASE
+#define DR_REG_AXI_IC_BASE                      (DR_REG_ICM_SYS_BASE + 0x400)

--- a/src/target/esp32s31/include/soc/soc.h
+++ b/src/target/esp32s31/include/soc/soc.h
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include "reg_base.h"
+
+#define REG_UART_BASE(i)                        (DR_REG_UART_BASE + (i) * 0x1000)        // UART0 and UART1
+#define REG_TIMG_BASE(i)                        (DR_REG_TIMERGROUP0_BASE + (i) * 0x1000) // TIMERG0 and TIMERG1
+
+/* TODO: Might not be fully correct yet, need to check after IDF-14669 */
+
+/* Overall memory map */
+
+#define SOC_IROM_LOW        0x40000000
+#define SOC_IROM_HIGH       0x44000000
+#define SOC_DROM_LOW        0x40000000
+#define SOC_DROM_HIGH       0x44000000
+
+#define SOC_EXTRAM_LOW      0x50000000
+#define SOC_EXTRAM_HIGH     0x54000000
+#define SOC_EXTRAM_SIZE     (SOC_EXTRAM_HIGH - SOC_EXTRAM_LOW)
+
+#define SOC_IROM_MASK_LOW   0x2F800000
+#define SOC_IROM_MASK_HIGH  0x2F850000
+#define SOC_DROM_MASK_LOW   0x2F800000
+#define SOC_DROM_MASK_HIGH  0x2F850000
+
+#define SOC_IRAM_LOW        0x2F000000
+#define SOC_IRAM_HIGH       0x2F080000
+#define SOC_DRAM_LOW        0x2F000000
+#define SOC_DRAM_HIGH       0x2F080000
+#define SOC_RTC_IRAM_LOW    0x2E000000
+#define SOC_RTC_IRAM_HIGH   0x2E008000
+#define SOC_RTC_DRAM_LOW    0x2E000000
+#define SOC_RTC_DRAM_HIGH   0x2E008000
+#define SOC_RTC_DATA_LOW    0x2E000000
+#define SOC_RTC_DATA_HIGH   0x2E008000
+
+#define SOC_LP_RAM_LOW      0x2E000000
+#define SOC_LP_RAM_HIGH     0x2E008000
+
+//First and last words of the D/IRAM region, for both the DRAM address as well as the IRAM alias.
+#define SOC_DIRAM_IRAM_LOW    0x2F000000
+#define SOC_DIRAM_IRAM_HIGH   0x2F080000
+#define SOC_DIRAM_DRAM_LOW    0x2F000000
+#define SOC_DIRAM_DRAM_HIGH   0x2F080000
+#define SOC_DIRAM_ROM_RESERVE_HIGH 0x2F080000
+
+#define MAP_DRAM_TO_IRAM(addr) (addr)
+#define MAP_IRAM_TO_DRAM(addr) (addr)
+
+// Region of memory accessible via DMA. See esp_ptr_dma_capable().
+#define SOC_DMA_LOW             0x2F000000
+#define SOC_DMA_HIGH            0x2F080000
+
+// Region of RAM that is byte-accessible. See esp_ptr_byte_accessible().
+#define SOC_BYTE_ACCESSIBLE_LOW     0x2F000000
+#define SOC_BYTE_ACCESSIBLE_HIGH    0x2F080000
+
+//Region of memory that is internal, as in on the same silicon die as the ESP32 CPUs
+//(excluding RTC data region, that's checked separately.) See esp_ptr_internal().
+#define SOC_MEM_INTERNAL_LOW        0x2F000000
+#define SOC_MEM_INTERNAL_HIGH       0x2F080000
+#define SOC_MEM_INTERNAL_LOW1       0x2F000000
+#define SOC_MEM_INTERNAL_HIGH1      0x2F080000
+
+#define SOC_MAX_CONTIGUOUS_RAM_SIZE (SOC_EXTRAM_HIGH - SOC_EXTRAM_LOW) ///< Largest span of contiguous memory (DRAM or IRAM) in the address space
+
+#define CPU_PERIPH_LOW          0x2C000000
+#define CPU_PERIPH_HIGH         0x2C020000
+
+// Region of address space that holds peripherals, HP APB peripherals
+#define SOC_PERIPHERAL_LOW      0x50000000       //TODO need update
+#define SOC_PERIPHERAL_HIGH     0x50100000      //TODO need update
+
+#define SOC_LP_PERIPH_LOW       0x50110000       //TODO need update
+#define SOC_LP_PERIPH_HIGH      0x50130000       //TODO need update
+
+// CPU sub-system region, contains interrupt config registers
+#define SOC_CPU_SUBSYSTEM_LOW   0x10000000
+#define SOC_CPU_SUBSYSTEM_HIGH  0x20000000
+
+// Start (highest address) of ROM boot stack, only relevant during early boot
+#define SOC_ROM_STACK_START     0x2f07cfb0
+#define SOC_ROM_STACK_SIZE      0x2000
+
+// non-cacheable offset for memory behind the cache
+#define SOC_NON_CACHEABLE_OFFSET_PSRAM       0x70000000
+
+//On RISC-V CPUs, the interrupt sources are all external interrupts, whose type, source and priority are configured by SW.
+//There is no HW NMI conception. SW should controlled the masked levels through INT_THRESH_REG.
+
+//CPU0 Interrupt number reserved in riscv/vector_clic.S, do not touch this.
+#define ETS_T1_WDT_INUM                         24
+#define ETS_CACHEERR_INUM                       25
+#define ETS_MEMPROT_ERR_INUM                    26
+#define ETS_ASSIST_DEBUG_INUM                   27  // Note: this interrupt can be combined with others (e.g., CACHEERR), as we can identify its trigger is activated
+#define ETS_IPC_ISR_INUM                        28
+//CPU0 Max valid interrupt number
+#define ETS_MAX_INUM                            31
+
+//CPU0 Interrupt number used in ROM, should be cancelled in SDK
+#define ETS_SLC_INUM                            1
+#define ETS_UART0_INUM                          5
+#define ETS_UART1_INUM                          5
+#define ETS_SPI2_INUM                           1
+//CPU0 Interrupt number used in ROM code only when module init function called, should pay attention here.
+#define ETS_GPIO_INUM       4
+
+//Other interrupt number should be managed by the user
+
+//Invalid interrupt for number interrupt matrix
+#define ETS_INVALID_INUM                        0
+
+//Interrupt medium level, used for INT WDT for example
+#define SOC_INTERRUPT_LEVEL_MEDIUM              4
+
+// Interrupt number for the Interrupt watchdog
+#define ETS_INT_WDT_INUM                         (ETS_T1_WDT_INUM)

--- a/src/target/esp32s31/include/soc/soc_caps.h
+++ b/src/target/esp32s31/include/soc/soc_caps.h
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+/*-------------------------- COMMON CAPS ---------------------------------------*/
+#define SOC_UART_HP_NUM         (4)    /*!< HP UART number */

--- a/src/target/esp32s31/include/soc/spi1_mem_c_reg.h
+++ b/src/target/esp32s31/include/soc/spi1_mem_c_reg.h
@@ -1,0 +1,1556 @@
+/**
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ *  SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "soc/soc.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** SPI1_MEM_C_CMD_REG register
+ *  SPI1 memory command register
+ */
+#define SPI1_MEM_C_CMD_REG (DR_REG_FLASH_SPI1_BASE + 0x0)
+/** SPI1_MEM_C_MST_ST : RO; bitpos: [3:0]; default: 0;
+ *  The current status of SPI1 master FSM.
+ */
+#define SPI1_MEM_C_MST_ST    0x0000000FU
+#define SPI1_MEM_C_MST_ST_M  (SPI1_MEM_C_MST_ST_V << SPI1_MEM_C_MST_ST_S)
+#define SPI1_MEM_C_MST_ST_V  0x0000000FU
+#define SPI1_MEM_C_MST_ST_S  0
+/** SPI1_MEM_C_SLV_ST : RO; bitpos: [7:4]; default: 0;
+ *  The current status of SPI1 slave FSM: mspi_st. 0: idle state, 1: preparation state,
+ *  2: send command state, 3: send address state, 4: wait state, 5: read data state,
+ *  6:write data state, 7: done state, 8: read data end state.
+ */
+#define SPI1_MEM_C_SLV_ST    0x0000000FU
+#define SPI1_MEM_C_SLV_ST_M  (SPI1_MEM_C_SLV_ST_V << SPI1_MEM_C_SLV_ST_S)
+#define SPI1_MEM_C_SLV_ST_V  0x0000000FU
+#define SPI1_MEM_C_SLV_ST_S  4
+/** SPI1_MEM_C_FLASH_PE : R/W/SC; bitpos: [17]; default: 0;
+ *  In user mode, it is set to indicate that program/erase operation will be triggered.
+ *  The bit is combined with SPI1_MEM_C_usr bit. The bit will be cleared once the
+ *  operation done.1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FLASH_PE    (BIT(17))
+#define SPI1_MEM_C_FLASH_PE_M  (SPI1_MEM_C_FLASH_PE_V << SPI1_MEM_C_FLASH_PE_S)
+#define SPI1_MEM_C_FLASH_PE_V  0x00000001U
+#define SPI1_MEM_C_FLASH_PE_S  17
+/** SPI1_MEM_C_USR : R/W/SC; bitpos: [18]; default: 0;
+ *  User define command enable.  An operation will be triggered when the bit is set.
+ *  The bit will be cleared once the operation done.1: enable 0: disable.
+ */
+#define SPI1_MEM_C_USR    (BIT(18))
+#define SPI1_MEM_C_USR_M  (SPI1_MEM_C_USR_V << SPI1_MEM_C_USR_S)
+#define SPI1_MEM_C_USR_V  0x00000001U
+#define SPI1_MEM_C_USR_S  18
+/** SPI1_MEM_C_FLASH_HPM : R/W/SC; bitpos: [19]; default: 0;
+ *  Drive Flash into high performance mode.  The bit will be cleared once the operation
+ *  done.1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FLASH_HPM    (BIT(19))
+#define SPI1_MEM_C_FLASH_HPM_M  (SPI1_MEM_C_FLASH_HPM_V << SPI1_MEM_C_FLASH_HPM_S)
+#define SPI1_MEM_C_FLASH_HPM_V  0x00000001U
+#define SPI1_MEM_C_FLASH_HPM_S  19
+/** SPI1_MEM_C_FLASH_RES : R/W/SC; bitpos: [20]; default: 0;
+ *  This bit combined with reg_resandres bit releases Flash from the power-down state
+ *  or high performance mode and obtains the devices ID. The bit will be cleared once
+ *  the operation done.1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FLASH_RES    (BIT(20))
+#define SPI1_MEM_C_FLASH_RES_M  (SPI1_MEM_C_FLASH_RES_V << SPI1_MEM_C_FLASH_RES_S)
+#define SPI1_MEM_C_FLASH_RES_V  0x00000001U
+#define SPI1_MEM_C_FLASH_RES_S  20
+/** SPI1_MEM_C_FLASH_DP : R/W/SC; bitpos: [21]; default: 0;
+ *  Drive Flash into power down.  An operation will be triggered when the bit is set.
+ *  The bit will be cleared once the operation done.1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FLASH_DP    (BIT(21))
+#define SPI1_MEM_C_FLASH_DP_M  (SPI1_MEM_C_FLASH_DP_V << SPI1_MEM_C_FLASH_DP_S)
+#define SPI1_MEM_C_FLASH_DP_V  0x00000001U
+#define SPI1_MEM_C_FLASH_DP_S  21
+/** SPI1_MEM_C_FLASH_CE : R/W/SC; bitpos: [22]; default: 0;
+ *  Chip erase enable. Chip erase operation will be triggered when the bit is set. The
+ *  bit will be cleared once the operation done.1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FLASH_CE    (BIT(22))
+#define SPI1_MEM_C_FLASH_CE_M  (SPI1_MEM_C_FLASH_CE_V << SPI1_MEM_C_FLASH_CE_S)
+#define SPI1_MEM_C_FLASH_CE_V  0x00000001U
+#define SPI1_MEM_C_FLASH_CE_S  22
+/** SPI1_MEM_C_FLASH_BE : R/W/SC; bitpos: [23]; default: 0;
+ *  Block erase enable(32KB) .  Block erase operation will be triggered when the bit is
+ *  set. The bit will be cleared once the operation done.1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FLASH_BE    (BIT(23))
+#define SPI1_MEM_C_FLASH_BE_M  (SPI1_MEM_C_FLASH_BE_V << SPI1_MEM_C_FLASH_BE_S)
+#define SPI1_MEM_C_FLASH_BE_V  0x00000001U
+#define SPI1_MEM_C_FLASH_BE_S  23
+/** SPI1_MEM_C_FLASH_SE : R/W/SC; bitpos: [24]; default: 0;
+ *  Sector erase enable(4KB). Sector erase operation will be triggered when the bit is
+ *  set. The bit will be cleared once the operation done.1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FLASH_SE    (BIT(24))
+#define SPI1_MEM_C_FLASH_SE_M  (SPI1_MEM_C_FLASH_SE_V << SPI1_MEM_C_FLASH_SE_S)
+#define SPI1_MEM_C_FLASH_SE_V  0x00000001U
+#define SPI1_MEM_C_FLASH_SE_S  24
+/** SPI1_MEM_C_FLASH_PP : R/W/SC; bitpos: [25]; default: 0;
+ *  Page program enable(1 byte ~256 bytes data to be programmed). Page program
+ *  operation  will be triggered when the bit is set. The bit will be cleared once the
+ *  operation done .1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FLASH_PP    (BIT(25))
+#define SPI1_MEM_C_FLASH_PP_M  (SPI1_MEM_C_FLASH_PP_V << SPI1_MEM_C_FLASH_PP_S)
+#define SPI1_MEM_C_FLASH_PP_V  0x00000001U
+#define SPI1_MEM_C_FLASH_PP_S  25
+/** SPI1_MEM_C_FLASH_WRSR : R/W/SC; bitpos: [26]; default: 0;
+ *  Write status register enable.   Write status operation  will be triggered when the
+ *  bit is set. The bit will be cleared once the operation done.1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FLASH_WRSR    (BIT(26))
+#define SPI1_MEM_C_FLASH_WRSR_M  (SPI1_MEM_C_FLASH_WRSR_V << SPI1_MEM_C_FLASH_WRSR_S)
+#define SPI1_MEM_C_FLASH_WRSR_V  0x00000001U
+#define SPI1_MEM_C_FLASH_WRSR_S  26
+/** SPI1_MEM_C_FLASH_RDSR : R/W/SC; bitpos: [27]; default: 0;
+ *  Read status register-1.  Read status operation will be triggered when the bit is
+ *  set. The bit will be cleared once the operation done.1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FLASH_RDSR    (BIT(27))
+#define SPI1_MEM_C_FLASH_RDSR_M  (SPI1_MEM_C_FLASH_RDSR_V << SPI1_MEM_C_FLASH_RDSR_S)
+#define SPI1_MEM_C_FLASH_RDSR_V  0x00000001U
+#define SPI1_MEM_C_FLASH_RDSR_S  27
+/** SPI1_MEM_C_FLASH_RDID : R/W/SC; bitpos: [28]; default: 0;
+ *  Read JEDEC ID . Read ID command will be sent when the bit is set. The bit will be
+ *  cleared once the operation done. 1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FLASH_RDID    (BIT(28))
+#define SPI1_MEM_C_FLASH_RDID_M  (SPI1_MEM_C_FLASH_RDID_V << SPI1_MEM_C_FLASH_RDID_S)
+#define SPI1_MEM_C_FLASH_RDID_V  0x00000001U
+#define SPI1_MEM_C_FLASH_RDID_S  28
+/** SPI1_MEM_C_FLASH_WRDI : R/W/SC; bitpos: [29]; default: 0;
+ *  Write flash disable. Write disable command will be sent when the bit is set. The
+ *  bit will be cleared once the operation done. 1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FLASH_WRDI    (BIT(29))
+#define SPI1_MEM_C_FLASH_WRDI_M  (SPI1_MEM_C_FLASH_WRDI_V << SPI1_MEM_C_FLASH_WRDI_S)
+#define SPI1_MEM_C_FLASH_WRDI_V  0x00000001U
+#define SPI1_MEM_C_FLASH_WRDI_S  29
+/** SPI1_MEM_C_FLASH_WREN : R/W/SC; bitpos: [30]; default: 0;
+ *  Write flash enable.  Write enable command will be sent when the bit is set. The bit
+ *  will be cleared once the operation done. 1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FLASH_WREN    (BIT(30))
+#define SPI1_MEM_C_FLASH_WREN_M  (SPI1_MEM_C_FLASH_WREN_V << SPI1_MEM_C_FLASH_WREN_S)
+#define SPI1_MEM_C_FLASH_WREN_V  0x00000001U
+#define SPI1_MEM_C_FLASH_WREN_S  30
+/** SPI1_MEM_C_FLASH_READ : R/W/SC; bitpos: [31]; default: 0;
+ *  Read flash enable. Read flash operation will be triggered when the bit is set. The
+ *  bit will be cleared once the operation done. 1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FLASH_READ    (BIT(31))
+#define SPI1_MEM_C_FLASH_READ_M  (SPI1_MEM_C_FLASH_READ_V << SPI1_MEM_C_FLASH_READ_S)
+#define SPI1_MEM_C_FLASH_READ_V  0x00000001U
+#define SPI1_MEM_C_FLASH_READ_S  31
+
+/** SPI1_MEM_C_ADDR_REG register
+ *  SPI1 address register
+ */
+#define SPI1_MEM_C_ADDR_REG (DR_REG_FLASH_SPI1_BASE + 0x4)
+/** SPI1_MEM_C_USR_ADDR_VALUE : R/W; bitpos: [31:0]; default: 0;
+ *  In user mode, it is the memory address. other then the bit0-bit23 is the memory
+ *  address, the bit24-bit31 are the byte length of a transfer.
+ */
+#define SPI1_MEM_C_USR_ADDR_VALUE    0xFFFFFFFFU
+#define SPI1_MEM_C_USR_ADDR_VALUE_M  (SPI1_MEM_C_USR_ADDR_VALUE_V << SPI1_MEM_C_USR_ADDR_VALUE_S)
+#define SPI1_MEM_C_USR_ADDR_VALUE_V  0xFFFFFFFFU
+#define SPI1_MEM_C_USR_ADDR_VALUE_S  0
+
+/** SPI1_MEM_C_CTRL_REG register
+ *  SPI1 control register.
+ */
+#define SPI1_MEM_C_CTRL_REG (DR_REG_FLASH_SPI1_BASE + 0x8)
+/** SPI1_MEM_C_FDUMMY_RIN : R/W; bitpos: [2]; default: 1;
+ *  In the dummy phase of a MSPI read data transfer when accesses to flash, the signal
+ *  level of SPI bus is output by the MSPI controller.
+ */
+#define SPI1_MEM_C_FDUMMY_RIN    (BIT(2))
+#define SPI1_MEM_C_FDUMMY_RIN_M  (SPI1_MEM_C_FDUMMY_RIN_V << SPI1_MEM_C_FDUMMY_RIN_S)
+#define SPI1_MEM_C_FDUMMY_RIN_V  0x00000001U
+#define SPI1_MEM_C_FDUMMY_RIN_S  2
+/** SPI1_MEM_C_FDUMMY_WOUT : R/W; bitpos: [3]; default: 1;
+ *  In the dummy phase of a MSPI write data transfer when accesses to flash, the signal
+ *  level of SPI bus is output by the MSPI controller.
+ */
+#define SPI1_MEM_C_FDUMMY_WOUT    (BIT(3))
+#define SPI1_MEM_C_FDUMMY_WOUT_M  (SPI1_MEM_C_FDUMMY_WOUT_V << SPI1_MEM_C_FDUMMY_WOUT_S)
+#define SPI1_MEM_C_FDUMMY_WOUT_V  0x00000001U
+#define SPI1_MEM_C_FDUMMY_WOUT_S  3
+/** SPI1_MEM_C_FDOUT_OCT : HRO; bitpos: [4]; default: 0;
+ *  Apply 8 signals during write-data phase 1:enable 0: disable
+ */
+#define SPI1_MEM_C_FDOUT_OCT    (BIT(4))
+#define SPI1_MEM_C_FDOUT_OCT_M  (SPI1_MEM_C_FDOUT_OCT_V << SPI1_MEM_C_FDOUT_OCT_S)
+#define SPI1_MEM_C_FDOUT_OCT_V  0x00000001U
+#define SPI1_MEM_C_FDOUT_OCT_S  4
+/** SPI1_MEM_C_FDIN_OCT : HRO; bitpos: [5]; default: 0;
+ *  Apply 8 signals during read-data phase 1:enable 0: disable
+ */
+#define SPI1_MEM_C_FDIN_OCT    (BIT(5))
+#define SPI1_MEM_C_FDIN_OCT_M  (SPI1_MEM_C_FDIN_OCT_V << SPI1_MEM_C_FDIN_OCT_S)
+#define SPI1_MEM_C_FDIN_OCT_V  0x00000001U
+#define SPI1_MEM_C_FDIN_OCT_S  5
+/** SPI1_MEM_C_FADDR_OCT : HRO; bitpos: [6]; default: 0;
+ *  Apply 8 signals during address phase 1:enable 0: disable
+ */
+#define SPI1_MEM_C_FADDR_OCT    (BIT(6))
+#define SPI1_MEM_C_FADDR_OCT_M  (SPI1_MEM_C_FADDR_OCT_V << SPI1_MEM_C_FADDR_OCT_S)
+#define SPI1_MEM_C_FADDR_OCT_V  0x00000001U
+#define SPI1_MEM_C_FADDR_OCT_S  6
+/** SPI1_MEM_C_FCMD_QUAD : R/W; bitpos: [8]; default: 0;
+ *  Apply 4 signals during command phase 1:enable 0: disable
+ */
+#define SPI1_MEM_C_FCMD_QUAD    (BIT(8))
+#define SPI1_MEM_C_FCMD_QUAD_M  (SPI1_MEM_C_FCMD_QUAD_V << SPI1_MEM_C_FCMD_QUAD_S)
+#define SPI1_MEM_C_FCMD_QUAD_V  0x00000001U
+#define SPI1_MEM_C_FCMD_QUAD_S  8
+/** SPI1_MEM_C_FCMD_OCT : HRO; bitpos: [9]; default: 0;
+ *  Apply 8 signals during command phase 1:enable 0: disable
+ */
+#define SPI1_MEM_C_FCMD_OCT    (BIT(9))
+#define SPI1_MEM_C_FCMD_OCT_M  (SPI1_MEM_C_FCMD_OCT_V << SPI1_MEM_C_FCMD_OCT_S)
+#define SPI1_MEM_C_FCMD_OCT_V  0x00000001U
+#define SPI1_MEM_C_FCMD_OCT_S  9
+/** SPI1_MEM_C_FCS_CRC_EN : HRO; bitpos: [10]; default: 0;
+ *  For SPI1,  initialize crc32 module before writing encrypted data to flash. Active
+ *  low.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FCS_CRC_EN    (BIT(10))
+#define SPI1_MEM_C_FCS_CRC_EN_M  (SPI1_MEM_C_FCS_CRC_EN_V << SPI1_MEM_C_FCS_CRC_EN_S)
+#define SPI1_MEM_C_FCS_CRC_EN_V  0x00000001U
+#define SPI1_MEM_C_FCS_CRC_EN_S  10
+/** SPI1_MEM_C_TX_CRC_EN : HRO; bitpos: [11]; default: 0;
+ *  For SPI1,  enable crc32 when writing encrypted data to flash. 1: enable 0:disable
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_TX_CRC_EN    (BIT(11))
+#define SPI1_MEM_C_TX_CRC_EN_M  (SPI1_MEM_C_TX_CRC_EN_V << SPI1_MEM_C_TX_CRC_EN_S)
+#define SPI1_MEM_C_TX_CRC_EN_V  0x00000001U
+#define SPI1_MEM_C_TX_CRC_EN_S  11
+/** SPI1_MEM_C_FASTRD_MODE : R/W; bitpos: [13]; default: 1;
+ *  This bit enable the bits: SPI1_MEM_C_fread_qio, SPI1_MEM_C_fread_dio, SPI1_MEM_C_fread_qout
+ *  and SPI1_MEM_C_fread_dout. 1: enable 0: disable.
+ */
+#define SPI1_MEM_C_FASTRD_MODE    (BIT(13))
+#define SPI1_MEM_C_FASTRD_MODE_M  (SPI1_MEM_C_FASTRD_MODE_V << SPI1_MEM_C_FASTRD_MODE_S)
+#define SPI1_MEM_C_FASTRD_MODE_V  0x00000001U
+#define SPI1_MEM_C_FASTRD_MODE_S  13
+/** SPI1_MEM_C_FREAD_DUAL : R/W; bitpos: [14]; default: 0;
+ *  In the read operations, read-data phase apply 2 signals. 1: enable 0: disable.
+ */
+#define SPI1_MEM_C_FREAD_DUAL    (BIT(14))
+#define SPI1_MEM_C_FREAD_DUAL_M  (SPI1_MEM_C_FREAD_DUAL_V << SPI1_MEM_C_FREAD_DUAL_S)
+#define SPI1_MEM_C_FREAD_DUAL_V  0x00000001U
+#define SPI1_MEM_C_FREAD_DUAL_S  14
+/** SPI1_MEM_C_RESANDRES : R/W; bitpos: [15]; default: 1;
+ *  The Device ID is read out to SPI1_MEM_C_RD_STATUS register,  this bit combine with
+ *  SPI1_MEM_C_flash_res bit. 1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_RESANDRES    (BIT(15))
+#define SPI1_MEM_C_RESANDRES_M  (SPI1_MEM_C_RESANDRES_V << SPI1_MEM_C_RESANDRES_S)
+#define SPI1_MEM_C_RESANDRES_V  0x00000001U
+#define SPI1_MEM_C_RESANDRES_S  15
+/** SPI1_MEM_C_Q_POL : R/W; bitpos: [18]; default: 1;
+ *  The bit is used to set MISO line polarity, 1: high 0, low
+ */
+#define SPI1_MEM_C_Q_POL    (BIT(18))
+#define SPI1_MEM_C_Q_POL_M  (SPI1_MEM_C_Q_POL_V << SPI1_MEM_C_Q_POL_S)
+#define SPI1_MEM_C_Q_POL_V  0x00000001U
+#define SPI1_MEM_C_Q_POL_S  18
+/** SPI1_MEM_C_D_POL : R/W; bitpos: [19]; default: 1;
+ *  The bit is used to set MOSI line polarity, 1: high 0, low
+ */
+#define SPI1_MEM_C_D_POL    (BIT(19))
+#define SPI1_MEM_C_D_POL_M  (SPI1_MEM_C_D_POL_V << SPI1_MEM_C_D_POL_S)
+#define SPI1_MEM_C_D_POL_V  0x00000001U
+#define SPI1_MEM_C_D_POL_S  19
+/** SPI1_MEM_C_FREAD_QUAD : R/W; bitpos: [20]; default: 0;
+ *  In the read operations read-data phase apply 4 signals. 1: enable 0: disable.
+ */
+#define SPI1_MEM_C_FREAD_QUAD    (BIT(20))
+#define SPI1_MEM_C_FREAD_QUAD_M  (SPI1_MEM_C_FREAD_QUAD_V << SPI1_MEM_C_FREAD_QUAD_S)
+#define SPI1_MEM_C_FREAD_QUAD_V  0x00000001U
+#define SPI1_MEM_C_FREAD_QUAD_S  20
+/** SPI1_MEM_C_WP_REG : R/W; bitpos: [21]; default: 1;
+ *  Write protect signal output when SPI is idle.  1: output high, 0: output low.
+ */
+#define SPI1_MEM_C_WP_REG    (BIT(21))
+#define SPI1_MEM_C_WP_REG_M  (SPI1_MEM_C_WP_REG_V << SPI1_MEM_C_WP_REG_S)
+#define SPI1_MEM_C_WP_REG_V  0x00000001U
+#define SPI1_MEM_C_WP_REG_S  21
+/** SPI1_MEM_C_WRSR_2B : R/W; bitpos: [22]; default: 0;
+ *  two bytes data will be written to status register when it is set. 1: enable 0:
+ *  disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_WRSR_2B    (BIT(22))
+#define SPI1_MEM_C_WRSR_2B_M  (SPI1_MEM_C_WRSR_2B_V << SPI1_MEM_C_WRSR_2B_S)
+#define SPI1_MEM_C_WRSR_2B_V  0x00000001U
+#define SPI1_MEM_C_WRSR_2B_S  22
+/** SPI1_MEM_C_FREAD_DIO : R/W; bitpos: [23]; default: 0;
+ *  In the read operations address phase and read-data phase apply 2 signals. 1: enable
+ *  0: disable.
+ */
+#define SPI1_MEM_C_FREAD_DIO    (BIT(23))
+#define SPI1_MEM_C_FREAD_DIO_M  (SPI1_MEM_C_FREAD_DIO_V << SPI1_MEM_C_FREAD_DIO_S)
+#define SPI1_MEM_C_FREAD_DIO_V  0x00000001U
+#define SPI1_MEM_C_FREAD_DIO_S  23
+/** SPI1_MEM_C_FREAD_QIO : R/W; bitpos: [24]; default: 0;
+ *  In the read operations address phase and read-data phase apply 4 signals. 1: enable
+ *  0: disable.
+ */
+#define SPI1_MEM_C_FREAD_QIO    (BIT(24))
+#define SPI1_MEM_C_FREAD_QIO_M  (SPI1_MEM_C_FREAD_QIO_V << SPI1_MEM_C_FREAD_QIO_S)
+#define SPI1_MEM_C_FREAD_QIO_V  0x00000001U
+#define SPI1_MEM_C_FREAD_QIO_S  24
+
+/** SPI1_MEM_C_CTRL1_REG register
+ *  SPI1 control1 register.
+ */
+#define SPI1_MEM_C_CTRL1_REG (DR_REG_FLASH_SPI1_BASE + 0xc)
+/** SPI1_MEM_C_CLK_MODE : R/W; bitpos: [1:0]; default: 0;
+ *  SPI clock mode bits. 0: SPI clock is off when CS inactive 1: SPI clock is delayed
+ *  one cycle after CS inactive 2: SPI clock is delayed two cycles after CS inactive 3:
+ *  SPI clock is always on.
+ */
+#define SPI1_MEM_C_CLK_MODE    0x00000003U
+#define SPI1_MEM_C_CLK_MODE_M  (SPI1_MEM_C_CLK_MODE_V << SPI1_MEM_C_CLK_MODE_S)
+#define SPI1_MEM_C_CLK_MODE_V  0x00000003U
+#define SPI1_MEM_C_CLK_MODE_S  0
+/** SPI1_MEM_C_CS_HOLD_DLY_RES : R/W; bitpos: [11:2]; default: 1023;
+ *  After RES/DP/HPM/PES command is sent, SPI1 waits (SPI1_MEM_C_CS_HOLD_DELAY_RES[9:0] *
+ *  128) SPI_CLK cycles.
+ */
+#define SPI1_MEM_C_CS_HOLD_DLY_RES    0x000003FFU
+#define SPI1_MEM_C_CS_HOLD_DLY_RES_M  (SPI1_MEM_C_CS_HOLD_DLY_RES_V << SPI1_MEM_C_CS_HOLD_DLY_RES_S)
+#define SPI1_MEM_C_CS_HOLD_DLY_RES_V  0x000003FFU
+#define SPI1_MEM_C_CS_HOLD_DLY_RES_S  2
+/** SPI1_MEM_C_CS_HOLD_DLY_PER : R/W; bitpos: [21:12]; default: 1023;
+ *  After PER command is sent, SPI1 waits (SPI1_MEM_C_CS_HOLD_DLY_PER[9:0] * 128) SPI_CLK
+ *  cycles.
+ */
+#define SPI1_MEM_C_CS_HOLD_DLY_PER    0x000003FFU
+#define SPI1_MEM_C_CS_HOLD_DLY_PER_M  (SPI1_MEM_C_CS_HOLD_DLY_PER_V << SPI1_MEM_C_CS_HOLD_DLY_PER_S)
+#define SPI1_MEM_C_CS_HOLD_DLY_PER_V  0x000003FFU
+#define SPI1_MEM_C_CS_HOLD_DLY_PER_S  12
+
+/** SPI1_MEM_C_CTRL2_REG register
+ *  SPI1 control2 register.
+ */
+#define SPI1_MEM_C_CTRL2_REG (DR_REG_FLASH_SPI1_BASE + 0x10)
+/** SPI1_MEM_C_SYNC_RESET : WT; bitpos: [31]; default: 0;
+ *  The FSM will be reset.
+ */
+#define SPI1_MEM_C_SYNC_RESET    (BIT(31))
+#define SPI1_MEM_C_SYNC_RESET_M  (SPI1_MEM_C_SYNC_RESET_V << SPI1_MEM_C_SYNC_RESET_S)
+#define SPI1_MEM_C_SYNC_RESET_V  0x00000001U
+#define SPI1_MEM_C_SYNC_RESET_S  31
+
+/** SPI1_MEM_C_CLOCK_REG register
+ *  SPI1 clock division control register.
+ */
+#define SPI1_MEM_C_CLOCK_REG (DR_REG_FLASH_SPI1_BASE + 0x14)
+/** SPI1_MEM_C_CLKCNT_L : R/W; bitpos: [7:0]; default: 3;
+ *  In the master mode it must be equal to SPI1_MEM_C_CLKCNT_N.
+ */
+#define SPI1_MEM_C_CLKCNT_L    0x000000FFU
+#define SPI1_MEM_C_CLKCNT_L_M  (SPI1_MEM_C_CLKCNT_L_V << SPI1_MEM_C_CLKCNT_L_S)
+#define SPI1_MEM_C_CLKCNT_L_V  0x000000FFU
+#define SPI1_MEM_C_CLKCNT_L_S  0
+/** SPI1_MEM_C_CLKCNT_H : R/W; bitpos: [15:8]; default: 1;
+ *  In the master mode it must be floor((SPI1_MEM_C_CLKCNT_N+1)/2-1).
+ */
+#define SPI1_MEM_C_CLKCNT_H    0x000000FFU
+#define SPI1_MEM_C_CLKCNT_H_M  (SPI1_MEM_C_CLKCNT_H_V << SPI1_MEM_C_CLKCNT_H_S)
+#define SPI1_MEM_C_CLKCNT_H_V  0x000000FFU
+#define SPI1_MEM_C_CLKCNT_H_S  8
+/** SPI1_MEM_C_CLKCNT_N : R/W; bitpos: [23:16]; default: 3;
+ *  In the master mode it is the divider of SPI1_MEM_C_clk. So SPI1_MEM_C_clk frequency is
+ *  system/(SPI1_MEM_C_CLKCNT_N+1)
+ */
+#define SPI1_MEM_C_CLKCNT_N    0x000000FFU
+#define SPI1_MEM_C_CLKCNT_N_M  (SPI1_MEM_C_CLKCNT_N_V << SPI1_MEM_C_CLKCNT_N_S)
+#define SPI1_MEM_C_CLKCNT_N_V  0x000000FFU
+#define SPI1_MEM_C_CLKCNT_N_S  16
+/** SPI1_MEM_C_CLK_EQU_SYSCLK : R/W; bitpos: [31]; default: 0;
+ *  reserved
+ */
+#define SPI1_MEM_C_CLK_EQU_SYSCLK    (BIT(31))
+#define SPI1_MEM_C_CLK_EQU_SYSCLK_M  (SPI1_MEM_C_CLK_EQU_SYSCLK_V << SPI1_MEM_C_CLK_EQU_SYSCLK_S)
+#define SPI1_MEM_C_CLK_EQU_SYSCLK_V  0x00000001U
+#define SPI1_MEM_C_CLK_EQU_SYSCLK_S  31
+
+/** SPI1_MEM_C_USER_REG register
+ *  SPI1 user register.
+ */
+#define SPI1_MEM_C_USER_REG (DR_REG_FLASH_SPI1_BASE + 0x18)
+/** SPI1_MEM_C_CK_OUT_EDGE : R/W; bitpos: [9]; default: 0;
+ *  the bit combined with SPI1_MEM_C_mosi_delay_mode bits to set mosi signal delay mode.
+ */
+#define SPI1_MEM_C_CK_OUT_EDGE    (BIT(9))
+#define SPI1_MEM_C_CK_OUT_EDGE_M  (SPI1_MEM_C_CK_OUT_EDGE_V << SPI1_MEM_C_CK_OUT_EDGE_S)
+#define SPI1_MEM_C_CK_OUT_EDGE_V  0x00000001U
+#define SPI1_MEM_C_CK_OUT_EDGE_S  9
+/** SPI1_MEM_C_FWRITE_DUAL : R/W; bitpos: [12]; default: 0;
+ *  In the write operations read-data phase apply 2 signals
+ */
+#define SPI1_MEM_C_FWRITE_DUAL    (BIT(12))
+#define SPI1_MEM_C_FWRITE_DUAL_M  (SPI1_MEM_C_FWRITE_DUAL_V << SPI1_MEM_C_FWRITE_DUAL_S)
+#define SPI1_MEM_C_FWRITE_DUAL_V  0x00000001U
+#define SPI1_MEM_C_FWRITE_DUAL_S  12
+/** SPI1_MEM_C_FWRITE_QUAD : R/W; bitpos: [13]; default: 0;
+ *  In the write operations read-data phase apply 4 signals
+ */
+#define SPI1_MEM_C_FWRITE_QUAD    (BIT(13))
+#define SPI1_MEM_C_FWRITE_QUAD_M  (SPI1_MEM_C_FWRITE_QUAD_V << SPI1_MEM_C_FWRITE_QUAD_S)
+#define SPI1_MEM_C_FWRITE_QUAD_V  0x00000001U
+#define SPI1_MEM_C_FWRITE_QUAD_S  13
+/** SPI1_MEM_C_FWRITE_DIO : R/W; bitpos: [14]; default: 0;
+ *  In the write operations address phase and read-data phase apply 2 signals.
+ */
+#define SPI1_MEM_C_FWRITE_DIO    (BIT(14))
+#define SPI1_MEM_C_FWRITE_DIO_M  (SPI1_MEM_C_FWRITE_DIO_V << SPI1_MEM_C_FWRITE_DIO_S)
+#define SPI1_MEM_C_FWRITE_DIO_V  0x00000001U
+#define SPI1_MEM_C_FWRITE_DIO_S  14
+/** SPI1_MEM_C_FWRITE_QIO : R/W; bitpos: [15]; default: 0;
+ *  In the write operations address phase and read-data phase apply 4 signals.
+ */
+#define SPI1_MEM_C_FWRITE_QIO    (BIT(15))
+#define SPI1_MEM_C_FWRITE_QIO_M  (SPI1_MEM_C_FWRITE_QIO_V << SPI1_MEM_C_FWRITE_QIO_S)
+#define SPI1_MEM_C_FWRITE_QIO_V  0x00000001U
+#define SPI1_MEM_C_FWRITE_QIO_S  15
+/** SPI1_MEM_C_USR_MISO_HIGHPART : HRO; bitpos: [24]; default: 0;
+ *  read-data phase only access to high-part of the buffer SPI1_MEM_C_w8~SPI1_MEM_C_w15. 1:
+ *  enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_USR_MISO_HIGHPART    (BIT(24))
+#define SPI1_MEM_C_USR_MISO_HIGHPART_M  (SPI1_MEM_C_USR_MISO_HIGHPART_V << SPI1_MEM_C_USR_MISO_HIGHPART_S)
+#define SPI1_MEM_C_USR_MISO_HIGHPART_V  0x00000001U
+#define SPI1_MEM_C_USR_MISO_HIGHPART_S  24
+/** SPI1_MEM_C_USR_MOSI_HIGHPART : HRO; bitpos: [25]; default: 0;
+ *  write-data phase only access to high-part of the buffer SPI1_MEM_C_w8~SPI1_MEM_C_w15. 1:
+ *  enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_USR_MOSI_HIGHPART    (BIT(25))
+#define SPI1_MEM_C_USR_MOSI_HIGHPART_M  (SPI1_MEM_C_USR_MOSI_HIGHPART_V << SPI1_MEM_C_USR_MOSI_HIGHPART_S)
+#define SPI1_MEM_C_USR_MOSI_HIGHPART_V  0x00000001U
+#define SPI1_MEM_C_USR_MOSI_HIGHPART_S  25
+/** SPI1_MEM_C_USR_DUMMY_IDLE : R/W; bitpos: [26]; default: 0;
+ *  SPI clock is disable in dummy phase when the bit is enable.
+ */
+#define SPI1_MEM_C_USR_DUMMY_IDLE    (BIT(26))
+#define SPI1_MEM_C_USR_DUMMY_IDLE_M  (SPI1_MEM_C_USR_DUMMY_IDLE_V << SPI1_MEM_C_USR_DUMMY_IDLE_S)
+#define SPI1_MEM_C_USR_DUMMY_IDLE_V  0x00000001U
+#define SPI1_MEM_C_USR_DUMMY_IDLE_S  26
+/** SPI1_MEM_C_USR_MOSI : R/W; bitpos: [27]; default: 0;
+ *  This bit enable the write-data phase of an operation.
+ */
+#define SPI1_MEM_C_USR_MOSI    (BIT(27))
+#define SPI1_MEM_C_USR_MOSI_M  (SPI1_MEM_C_USR_MOSI_V << SPI1_MEM_C_USR_MOSI_S)
+#define SPI1_MEM_C_USR_MOSI_V  0x00000001U
+#define SPI1_MEM_C_USR_MOSI_S  27
+/** SPI1_MEM_C_USR_MISO : R/W; bitpos: [28]; default: 0;
+ *  This bit enable the read-data phase of an operation.
+ */
+#define SPI1_MEM_C_USR_MISO    (BIT(28))
+#define SPI1_MEM_C_USR_MISO_M  (SPI1_MEM_C_USR_MISO_V << SPI1_MEM_C_USR_MISO_S)
+#define SPI1_MEM_C_USR_MISO_V  0x00000001U
+#define SPI1_MEM_C_USR_MISO_S  28
+/** SPI1_MEM_C_USR_DUMMY : R/W; bitpos: [29]; default: 0;
+ *  This bit enable the dummy phase of an operation.
+ */
+#define SPI1_MEM_C_USR_DUMMY    (BIT(29))
+#define SPI1_MEM_C_USR_DUMMY_M  (SPI1_MEM_C_USR_DUMMY_V << SPI1_MEM_C_USR_DUMMY_S)
+#define SPI1_MEM_C_USR_DUMMY_V  0x00000001U
+#define SPI1_MEM_C_USR_DUMMY_S  29
+/** SPI1_MEM_C_USR_ADDR : R/W; bitpos: [30]; default: 0;
+ *  This bit enable the address phase of an operation.
+ */
+#define SPI1_MEM_C_USR_ADDR    (BIT(30))
+#define SPI1_MEM_C_USR_ADDR_M  (SPI1_MEM_C_USR_ADDR_V << SPI1_MEM_C_USR_ADDR_S)
+#define SPI1_MEM_C_USR_ADDR_V  0x00000001U
+#define SPI1_MEM_C_USR_ADDR_S  30
+/** SPI1_MEM_C_USR_COMMAND : R/W; bitpos: [31]; default: 1;
+ *  This bit enable the command phase of an operation.
+ */
+#define SPI1_MEM_C_USR_COMMAND    (BIT(31))
+#define SPI1_MEM_C_USR_COMMAND_M  (SPI1_MEM_C_USR_COMMAND_V << SPI1_MEM_C_USR_COMMAND_S)
+#define SPI1_MEM_C_USR_COMMAND_V  0x00000001U
+#define SPI1_MEM_C_USR_COMMAND_S  31
+
+/** SPI1_MEM_C_USER1_REG register
+ *  SPI1 user1 register.
+ */
+#define SPI1_MEM_C_USER1_REG (DR_REG_FLASH_SPI1_BASE + 0x1c)
+/** SPI1_MEM_C_USR_DUMMY_CYCLELEN : R/W; bitpos: [5:0]; default: 7;
+ *  The length in SPI1_MEM_C_clk cycles of dummy phase. The register value shall be
+ *  (cycle_num-1).
+ */
+#define SPI1_MEM_C_USR_DUMMY_CYCLELEN    0x0000003FU
+#define SPI1_MEM_C_USR_DUMMY_CYCLELEN_M  (SPI1_MEM_C_USR_DUMMY_CYCLELEN_V << SPI1_MEM_C_USR_DUMMY_CYCLELEN_S)
+#define SPI1_MEM_C_USR_DUMMY_CYCLELEN_V  0x0000003FU
+#define SPI1_MEM_C_USR_DUMMY_CYCLELEN_S  0
+/** SPI1_MEM_C_USR_ADDR_BITLEN : R/W; bitpos: [31:26]; default: 23;
+ *  The length in bits of address phase. The register value shall be (bit_num-1).
+ */
+#define SPI1_MEM_C_USR_ADDR_BITLEN    0x0000003FU
+#define SPI1_MEM_C_USR_ADDR_BITLEN_M  (SPI1_MEM_C_USR_ADDR_BITLEN_V << SPI1_MEM_C_USR_ADDR_BITLEN_S)
+#define SPI1_MEM_C_USR_ADDR_BITLEN_V  0x0000003FU
+#define SPI1_MEM_C_USR_ADDR_BITLEN_S  26
+
+/** SPI1_MEM_C_USER2_REG register
+ *  SPI1 user2 register.
+ */
+#define SPI1_MEM_C_USER2_REG (DR_REG_FLASH_SPI1_BASE + 0x20)
+/** SPI1_MEM_C_USR_COMMAND_VALUE : R/W; bitpos: [15:0]; default: 0;
+ *  The value of  command.
+ */
+#define SPI1_MEM_C_USR_COMMAND_VALUE    0x0000FFFFU
+#define SPI1_MEM_C_USR_COMMAND_VALUE_M  (SPI1_MEM_C_USR_COMMAND_VALUE_V << SPI1_MEM_C_USR_COMMAND_VALUE_S)
+#define SPI1_MEM_C_USR_COMMAND_VALUE_V  0x0000FFFFU
+#define SPI1_MEM_C_USR_COMMAND_VALUE_S  0
+/** SPI1_MEM_C_USR_COMMAND_BITLEN : R/W; bitpos: [31:28]; default: 7;
+ *  The length in bits of command phase. The register value shall be (bit_num-1)
+ */
+#define SPI1_MEM_C_USR_COMMAND_BITLEN    0x0000000FU
+#define SPI1_MEM_C_USR_COMMAND_BITLEN_M  (SPI1_MEM_C_USR_COMMAND_BITLEN_V << SPI1_MEM_C_USR_COMMAND_BITLEN_S)
+#define SPI1_MEM_C_USR_COMMAND_BITLEN_V  0x0000000FU
+#define SPI1_MEM_C_USR_COMMAND_BITLEN_S  28
+
+/** SPI1_MEM_C_MOSI_DLEN_REG register
+ *  SPI1 send data bit length control register.
+ */
+#define SPI1_MEM_C_MOSI_DLEN_REG (DR_REG_FLASH_SPI1_BASE + 0x24)
+/** SPI1_MEM_C_USR_MOSI_DBITLEN : R/W; bitpos: [9:0]; default: 0;
+ *  The length in bits of write-data. The register value shall be (bit_num-1).
+ */
+#define SPI1_MEM_C_USR_MOSI_DBITLEN    0x000003FFU
+#define SPI1_MEM_C_USR_MOSI_DBITLEN_M  (SPI1_MEM_C_USR_MOSI_DBITLEN_V << SPI1_MEM_C_USR_MOSI_DBITLEN_S)
+#define SPI1_MEM_C_USR_MOSI_DBITLEN_V  0x000003FFU
+#define SPI1_MEM_C_USR_MOSI_DBITLEN_S  0
+
+/** SPI1_MEM_C_MISO_DLEN_REG register
+ *  SPI1 receive data bit length control register.
+ */
+#define SPI1_MEM_C_MISO_DLEN_REG (DR_REG_FLASH_SPI1_BASE + 0x28)
+/** SPI1_MEM_C_USR_MISO_DBITLEN : R/W; bitpos: [9:0]; default: 0;
+ *  The length in bits of  read-data. The register value shall be (bit_num-1).
+ */
+#define SPI1_MEM_C_USR_MISO_DBITLEN    0x000003FFU
+#define SPI1_MEM_C_USR_MISO_DBITLEN_M  (SPI1_MEM_C_USR_MISO_DBITLEN_V << SPI1_MEM_C_USR_MISO_DBITLEN_S)
+#define SPI1_MEM_C_USR_MISO_DBITLEN_V  0x000003FFU
+#define SPI1_MEM_C_USR_MISO_DBITLEN_S  0
+
+/** SPI1_MEM_C_RD_STATUS_REG register
+ *  SPI1 status register.
+ */
+#define SPI1_MEM_C_RD_STATUS_REG (DR_REG_FLASH_SPI1_BASE + 0x2c)
+/** SPI1_MEM_C_STATUS : R/W/SS; bitpos: [15:0]; default: 0;
+ *  The value is stored when set SPI1_MEM_C_flash_rdsr bit and SPI1_MEM_C_flash_res bit.
+ */
+#define SPI1_MEM_C_STATUS    0x0000FFFFU
+#define SPI1_MEM_C_STATUS_M  (SPI1_MEM_C_STATUS_V << SPI1_MEM_C_STATUS_S)
+#define SPI1_MEM_C_STATUS_V  0x0000FFFFU
+#define SPI1_MEM_C_STATUS_S  0
+/** SPI1_MEM_C_WB_MODE : R/W; bitpos: [23:16]; default: 0;
+ *  Mode bits in the flash fast read mode  it is combined with SPI1_MEM_C_fastrd_mode bit.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_WB_MODE    0x000000FFU
+#define SPI1_MEM_C_WB_MODE_M  (SPI1_MEM_C_WB_MODE_V << SPI1_MEM_C_WB_MODE_S)
+#define SPI1_MEM_C_WB_MODE_V  0x000000FFU
+#define SPI1_MEM_C_WB_MODE_S  16
+/** SPI1_MEM_C_WB_MODE_BITLEN : R/W; bitpos: [26:24]; default: 0;
+ *  Mode bits length for flash fast read mode.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_WB_MODE_BITLEN    0x00000007U
+#define SPI1_MEM_C_WB_MODE_BITLEN_M  (SPI1_MEM_C_WB_MODE_BITLEN_V << SPI1_MEM_C_WB_MODE_BITLEN_S)
+#define SPI1_MEM_C_WB_MODE_BITLEN_V  0x00000007U
+#define SPI1_MEM_C_WB_MODE_BITLEN_S  24
+/** SPI1_MEM_C_WB_MODE_EN : R/W; bitpos: [27]; default: 0;
+ *  Mode bits is valid while this bit is enable. 1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_WB_MODE_EN    (BIT(27))
+#define SPI1_MEM_C_WB_MODE_EN_M  (SPI1_MEM_C_WB_MODE_EN_V << SPI1_MEM_C_WB_MODE_EN_S)
+#define SPI1_MEM_C_WB_MODE_EN_V  0x00000001U
+#define SPI1_MEM_C_WB_MODE_EN_S  27
+
+/** SPI1_MEM_C_MISC_REG register
+ *  SPI1 misc register
+ */
+#define SPI1_MEM_C_MISC_REG (DR_REG_FLASH_SPI1_BASE + 0x34)
+/** SPI1_MEM_C_CS0_DIS : R/W; bitpos: [0]; default: 0;
+ *  SPI_CS0 pin enable, 1: disable SPI_CS0, 0: SPI_CS0 pin is active to select SPI
+ *  device, such as flash, external RAM and so on.
+ */
+#define SPI1_MEM_C_CS0_DIS    (BIT(0))
+#define SPI1_MEM_C_CS0_DIS_M  (SPI1_MEM_C_CS0_DIS_V << SPI1_MEM_C_CS0_DIS_S)
+#define SPI1_MEM_C_CS0_DIS_V  0x00000001U
+#define SPI1_MEM_C_CS0_DIS_S  0
+/** SPI1_MEM_C_CS1_DIS : R/W; bitpos: [1]; default: 1;
+ *  SPI_CS1 pin enable, 1: disable SPI_CS1, 0: SPI_CS1 pin is active to select SPI
+ *  device, such as flash, external RAM and so on.
+ */
+#define SPI1_MEM_C_CS1_DIS    (BIT(1))
+#define SPI1_MEM_C_CS1_DIS_M  (SPI1_MEM_C_CS1_DIS_V << SPI1_MEM_C_CS1_DIS_S)
+#define SPI1_MEM_C_CS1_DIS_V  0x00000001U
+#define SPI1_MEM_C_CS1_DIS_S  1
+/** SPI1_MEM_C_CK_IDLE_EDGE : R/W; bitpos: [9]; default: 0;
+ *  1: spi clk line is high when idle     0: spi clk line is low when idle
+ */
+#define SPI1_MEM_C_CK_IDLE_EDGE    (BIT(9))
+#define SPI1_MEM_C_CK_IDLE_EDGE_M  (SPI1_MEM_C_CK_IDLE_EDGE_V << SPI1_MEM_C_CK_IDLE_EDGE_S)
+#define SPI1_MEM_C_CK_IDLE_EDGE_V  0x00000001U
+#define SPI1_MEM_C_CK_IDLE_EDGE_S  9
+/** SPI1_MEM_C_CS_KEEP_ACTIVE : R/W; bitpos: [10]; default: 0;
+ *  spi cs line keep low when the bit is set.
+ */
+#define SPI1_MEM_C_CS_KEEP_ACTIVE    (BIT(10))
+#define SPI1_MEM_C_CS_KEEP_ACTIVE_M  (SPI1_MEM_C_CS_KEEP_ACTIVE_V << SPI1_MEM_C_CS_KEEP_ACTIVE_S)
+#define SPI1_MEM_C_CS_KEEP_ACTIVE_V  0x00000001U
+#define SPI1_MEM_C_CS_KEEP_ACTIVE_S  10
+
+/** SPI1_MEM_C_TX_CRC_REG register
+ *  SPI1 TX CRC data register.
+ *  This register is only for internal debugging purposes. Do not use it in
+ *  applications.
+ */
+#define SPI1_MEM_C_TX_CRC_REG (DR_REG_FLASH_SPI1_BASE + 0x38)
+/** SPI1_MEM_C_TX_CRC_DATA : RO; bitpos: [31:0]; default: 4294967295;
+ *  For SPI1, the value of crc32.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_TX_CRC_DATA    0xFFFFFFFFU
+#define SPI1_MEM_C_TX_CRC_DATA_M  (SPI1_MEM_C_TX_CRC_DATA_V << SPI1_MEM_C_TX_CRC_DATA_S)
+#define SPI1_MEM_C_TX_CRC_DATA_V  0xFFFFFFFFU
+#define SPI1_MEM_C_TX_CRC_DATA_S  0
+
+/** SPI1_MEM_C_CACHE_FCTRL_REG register
+ *  SPI1 bit mode control register.
+ *  This register is only for internal debugging purposes. Do not use it in
+ *  applications.
+ */
+#define SPI1_MEM_C_CACHE_FCTRL_REG (DR_REG_FLASH_SPI1_BASE + 0x3c)
+/** SPI1_MEM_C_CACHE_USR_ADDR_4BYTE : R/W; bitpos: [1]; default: 0;
+ *  For SPI1,  cache  read flash with 4 bytes address, 1: enable, 0:disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_CACHE_USR_ADDR_4BYTE    (BIT(1))
+#define SPI1_MEM_C_CACHE_USR_ADDR_4BYTE_M  (SPI1_MEM_C_CACHE_USR_ADDR_4BYTE_V << SPI1_MEM_C_CACHE_USR_ADDR_4BYTE_S)
+#define SPI1_MEM_C_CACHE_USR_ADDR_4BYTE_V  0x00000001U
+#define SPI1_MEM_C_CACHE_USR_ADDR_4BYTE_S  1
+/** SPI1_MEM_C_FDIN_DUAL : R/W; bitpos: [3]; default: 0;
+ *  For SPI1, din phase apply 2 signals. 1: enable 0: disable. The bit is the same with
+ *  SPI1_MEM_C_fread_dio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FDIN_DUAL    (BIT(3))
+#define SPI1_MEM_C_FDIN_DUAL_M  (SPI1_MEM_C_FDIN_DUAL_V << SPI1_MEM_C_FDIN_DUAL_S)
+#define SPI1_MEM_C_FDIN_DUAL_V  0x00000001U
+#define SPI1_MEM_C_FDIN_DUAL_S  3
+/** SPI1_MEM_C_FDOUT_DUAL : R/W; bitpos: [4]; default: 0;
+ *  For SPI1, dout phase apply 2 signals. 1: enable 0: disable. The bit is the same
+ *  with SPI1_MEM_C_fread_dio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FDOUT_DUAL    (BIT(4))
+#define SPI1_MEM_C_FDOUT_DUAL_M  (SPI1_MEM_C_FDOUT_DUAL_V << SPI1_MEM_C_FDOUT_DUAL_S)
+#define SPI1_MEM_C_FDOUT_DUAL_V  0x00000001U
+#define SPI1_MEM_C_FDOUT_DUAL_S  4
+/** SPI1_MEM_C_FADDR_DUAL : R/W; bitpos: [5]; default: 0;
+ *  For SPI1, address phase apply 2 signals. 1: enable 0: disable.  The bit is the same
+ *  with SPI1_MEM_C_fread_dio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FADDR_DUAL    (BIT(5))
+#define SPI1_MEM_C_FADDR_DUAL_M  (SPI1_MEM_C_FADDR_DUAL_V << SPI1_MEM_C_FADDR_DUAL_S)
+#define SPI1_MEM_C_FADDR_DUAL_V  0x00000001U
+#define SPI1_MEM_C_FADDR_DUAL_S  5
+/** SPI1_MEM_C_FDIN_QUAD : R/W; bitpos: [6]; default: 0;
+ *  For SPI1, din phase apply 4 signals. 1: enable 0: disable.  The bit is the same
+ *  with SPI1_MEM_C_fread_qio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FDIN_QUAD    (BIT(6))
+#define SPI1_MEM_C_FDIN_QUAD_M  (SPI1_MEM_C_FDIN_QUAD_V << SPI1_MEM_C_FDIN_QUAD_S)
+#define SPI1_MEM_C_FDIN_QUAD_V  0x00000001U
+#define SPI1_MEM_C_FDIN_QUAD_S  6
+/** SPI1_MEM_C_FDOUT_QUAD : R/W; bitpos: [7]; default: 0;
+ *  For SPI1, dout phase apply 4 signals. 1: enable 0: disable.  The bit is the same
+ *  with SPI1_MEM_C_fread_qio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FDOUT_QUAD    (BIT(7))
+#define SPI1_MEM_C_FDOUT_QUAD_M  (SPI1_MEM_C_FDOUT_QUAD_V << SPI1_MEM_C_FDOUT_QUAD_S)
+#define SPI1_MEM_C_FDOUT_QUAD_V  0x00000001U
+#define SPI1_MEM_C_FDOUT_QUAD_S  7
+/** SPI1_MEM_C_FADDR_QUAD : R/W; bitpos: [8]; default: 0;
+ *  For SPI1, address phase apply 4 signals. 1: enable 0: disable.  The bit is the same
+ *  with SPI1_MEM_C_fread_qio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI1_MEM_C_FADDR_QUAD    (BIT(8))
+#define SPI1_MEM_C_FADDR_QUAD_M  (SPI1_MEM_C_FADDR_QUAD_V << SPI1_MEM_C_FADDR_QUAD_S)
+#define SPI1_MEM_C_FADDR_QUAD_V  0x00000001U
+#define SPI1_MEM_C_FADDR_QUAD_S  8
+
+/** SPI1_MEM_C_W0_REG register
+ *  SPI1 memory data buffer0
+ */
+#define SPI1_MEM_C_W0_REG (DR_REG_FLASH_SPI1_BASE + 0x58)
+/** SPI1_MEM_C_BUF0 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF0    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF0_M  (SPI1_MEM_C_BUF0_V << SPI1_MEM_C_BUF0_S)
+#define SPI1_MEM_C_BUF0_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF0_S  0
+
+/** SPI1_MEM_C_W1_REG register
+ *  SPI1 memory data buffer1
+ */
+#define SPI1_MEM_C_W1_REG (DR_REG_FLASH_SPI1_BASE + 0x5c)
+/** SPI1_MEM_C_BUF1 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF1    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF1_M  (SPI1_MEM_C_BUF1_V << SPI1_MEM_C_BUF1_S)
+#define SPI1_MEM_C_BUF1_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF1_S  0
+
+/** SPI1_MEM_C_W2_REG register
+ *  SPI1 memory data buffer2
+ */
+#define SPI1_MEM_C_W2_REG (DR_REG_FLASH_SPI1_BASE + 0x60)
+/** SPI1_MEM_C_BUF2 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF2    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF2_M  (SPI1_MEM_C_BUF2_V << SPI1_MEM_C_BUF2_S)
+#define SPI1_MEM_C_BUF2_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF2_S  0
+
+/** SPI1_MEM_C_W3_REG register
+ *  SPI1 memory data buffer3
+ */
+#define SPI1_MEM_C_W3_REG (DR_REG_FLASH_SPI1_BASE + 0x64)
+/** SPI1_MEM_C_BUF3 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF3    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF3_M  (SPI1_MEM_C_BUF3_V << SPI1_MEM_C_BUF3_S)
+#define SPI1_MEM_C_BUF3_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF3_S  0
+
+/** SPI1_MEM_C_W4_REG register
+ *  SPI1 memory data buffer4
+ */
+#define SPI1_MEM_C_W4_REG (DR_REG_FLASH_SPI1_BASE + 0x68)
+/** SPI1_MEM_C_BUF4 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF4    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF4_M  (SPI1_MEM_C_BUF4_V << SPI1_MEM_C_BUF4_S)
+#define SPI1_MEM_C_BUF4_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF4_S  0
+
+/** SPI1_MEM_C_W5_REG register
+ *  SPI1 memory data buffer5
+ */
+#define SPI1_MEM_C_W5_REG (DR_REG_FLASH_SPI1_BASE + 0x6c)
+/** SPI1_MEM_C_BUF5 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF5    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF5_M  (SPI1_MEM_C_BUF5_V << SPI1_MEM_C_BUF5_S)
+#define SPI1_MEM_C_BUF5_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF5_S  0
+
+/** SPI1_MEM_C_W6_REG register
+ *  SPI1 memory data buffer6
+ */
+#define SPI1_MEM_C_W6_REG (DR_REG_FLASH_SPI1_BASE + 0x70)
+/** SPI1_MEM_C_BUF6 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF6    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF6_M  (SPI1_MEM_C_BUF6_V << SPI1_MEM_C_BUF6_S)
+#define SPI1_MEM_C_BUF6_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF6_S  0
+
+/** SPI1_MEM_C_W7_REG register
+ *  SPI1 memory data buffer7
+ */
+#define SPI1_MEM_C_W7_REG (DR_REG_FLASH_SPI1_BASE + 0x74)
+/** SPI1_MEM_C_BUF7 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF7    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF7_M  (SPI1_MEM_C_BUF7_V << SPI1_MEM_C_BUF7_S)
+#define SPI1_MEM_C_BUF7_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF7_S  0
+
+/** SPI1_MEM_C_W8_REG register
+ *  SPI1 memory data buffer8
+ */
+#define SPI1_MEM_C_W8_REG (DR_REG_FLASH_SPI1_BASE + 0x78)
+/** SPI1_MEM_C_BUF8 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF8    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF8_M  (SPI1_MEM_C_BUF8_V << SPI1_MEM_C_BUF8_S)
+#define SPI1_MEM_C_BUF8_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF8_S  0
+
+/** SPI1_MEM_C_W9_REG register
+ *  SPI1 memory data buffer9
+ */
+#define SPI1_MEM_C_W9_REG (DR_REG_FLASH_SPI1_BASE + 0x7c)
+/** SPI1_MEM_C_BUF9 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF9    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF9_M  (SPI1_MEM_C_BUF9_V << SPI1_MEM_C_BUF9_S)
+#define SPI1_MEM_C_BUF9_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF9_S  0
+
+/** SPI1_MEM_C_W10_REG register
+ *  SPI1 memory data buffer10
+ */
+#define SPI1_MEM_C_W10_REG (DR_REG_FLASH_SPI1_BASE + 0x80)
+/** SPI1_MEM_C_BUF10 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF10    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF10_M  (SPI1_MEM_C_BUF10_V << SPI1_MEM_C_BUF10_S)
+#define SPI1_MEM_C_BUF10_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF10_S  0
+
+/** SPI1_MEM_C_W11_REG register
+ *  SPI1 memory data buffer11
+ */
+#define SPI1_MEM_C_W11_REG (DR_REG_FLASH_SPI1_BASE + 0x84)
+/** SPI1_MEM_C_BUF11 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF11    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF11_M  (SPI1_MEM_C_BUF11_V << SPI1_MEM_C_BUF11_S)
+#define SPI1_MEM_C_BUF11_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF11_S  0
+
+/** SPI1_MEM_C_W12_REG register
+ *  SPI1 memory data buffer12
+ */
+#define SPI1_MEM_C_W12_REG (DR_REG_FLASH_SPI1_BASE + 0x88)
+/** SPI1_MEM_C_BUF12 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF12    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF12_M  (SPI1_MEM_C_BUF12_V << SPI1_MEM_C_BUF12_S)
+#define SPI1_MEM_C_BUF12_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF12_S  0
+
+/** SPI1_MEM_C_W13_REG register
+ *  SPI1 memory data buffer13
+ */
+#define SPI1_MEM_C_W13_REG (DR_REG_FLASH_SPI1_BASE + 0x8c)
+/** SPI1_MEM_C_BUF13 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF13    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF13_M  (SPI1_MEM_C_BUF13_V << SPI1_MEM_C_BUF13_S)
+#define SPI1_MEM_C_BUF13_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF13_S  0
+
+/** SPI1_MEM_C_W14_REG register
+ *  SPI1 memory data buffer14
+ */
+#define SPI1_MEM_C_W14_REG (DR_REG_FLASH_SPI1_BASE + 0x90)
+/** SPI1_MEM_C_BUF14 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF14    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF14_M  (SPI1_MEM_C_BUF14_V << SPI1_MEM_C_BUF14_S)
+#define SPI1_MEM_C_BUF14_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF14_S  0
+
+/** SPI1_MEM_C_W15_REG register
+ *  SPI1 memory data buffer15
+ */
+#define SPI1_MEM_C_W15_REG (DR_REG_FLASH_SPI1_BASE + 0x94)
+/** SPI1_MEM_C_BUF15 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI1_MEM_C_BUF15    0xFFFFFFFFU
+#define SPI1_MEM_C_BUF15_M  (SPI1_MEM_C_BUF15_V << SPI1_MEM_C_BUF15_S)
+#define SPI1_MEM_C_BUF15_V  0xFFFFFFFFU
+#define SPI1_MEM_C_BUF15_S  0
+
+/** SPI1_MEM_C_FLASH_WAITI_CTRL_REG register
+ *  SPI1 wait idle control register
+ */
+#define SPI1_MEM_C_FLASH_WAITI_CTRL_REG (DR_REG_FLASH_SPI1_BASE + 0x98)
+/** SPI1_MEM_C_WAITI_EN : R/W; bitpos: [0]; default: 1;
+ *  1: The hardware will wait idle after SE/PP/WRSR automatically, and hardware auto
+ *  Suspend/Resume can be enabled. 0: The functions of hardware wait idle and auto
+ *  Suspend/Resume are not supported.
+ */
+#define SPI1_MEM_C_WAITI_EN    (BIT(0))
+#define SPI1_MEM_C_WAITI_EN_M  (SPI1_MEM_C_WAITI_EN_V << SPI1_MEM_C_WAITI_EN_S)
+#define SPI1_MEM_C_WAITI_EN_V  0x00000001U
+#define SPI1_MEM_C_WAITI_EN_S  0
+/** SPI1_MEM_C_WAITI_DUMMY : R/W; bitpos: [1]; default: 0;
+ *  The dummy phase enable when wait flash idle (RDSR)
+ */
+#define SPI1_MEM_C_WAITI_DUMMY    (BIT(1))
+#define SPI1_MEM_C_WAITI_DUMMY_M  (SPI1_MEM_C_WAITI_DUMMY_V << SPI1_MEM_C_WAITI_DUMMY_S)
+#define SPI1_MEM_C_WAITI_DUMMY_V  0x00000001U
+#define SPI1_MEM_C_WAITI_DUMMY_S  1
+/** SPI1_MEM_C_WAITI_ADDR_EN : R/W; bitpos: [2]; default: 0;
+ *  1: Output  address 0 in RDSR or read SUS command transfer. 0: Do not send out
+ *  address in RDSR or read SUS command transfer.
+ */
+#define SPI1_MEM_C_WAITI_ADDR_EN    (BIT(2))
+#define SPI1_MEM_C_WAITI_ADDR_EN_M  (SPI1_MEM_C_WAITI_ADDR_EN_V << SPI1_MEM_C_WAITI_ADDR_EN_S)
+#define SPI1_MEM_C_WAITI_ADDR_EN_V  0x00000001U
+#define SPI1_MEM_C_WAITI_ADDR_EN_S  2
+/** SPI1_MEM_C_WAITI_ADDR_CYCLELEN : R/W; bitpos: [4:3]; default: 0;
+ *  When SPI1_MEM_C_WAITI_ADDR_EN is set, the  cycle length of sent out address is
+ *  (SPI1_MEM_C_WAITI_ADDR_CYCLELEN[1:0] + 1) SPI  bus clock cycles. It is not active when
+ *  SPI1_MEM_C_WAITI_ADDR_EN is cleared.
+ */
+#define SPI1_MEM_C_WAITI_ADDR_CYCLELEN    0x00000003U
+#define SPI1_MEM_C_WAITI_ADDR_CYCLELEN_M  (SPI1_MEM_C_WAITI_ADDR_CYCLELEN_V << SPI1_MEM_C_WAITI_ADDR_CYCLELEN_S)
+#define SPI1_MEM_C_WAITI_ADDR_CYCLELEN_V  0x00000003U
+#define SPI1_MEM_C_WAITI_ADDR_CYCLELEN_S  3
+/** SPI1_MEM_C_WAITI_CMD_2B : R/W; bitpos: [9]; default: 0;
+ *  1:The wait idle command bit length is 16. 0: The wait idle command bit length is 8.
+ */
+#define SPI1_MEM_C_WAITI_CMD_2B    (BIT(9))
+#define SPI1_MEM_C_WAITI_CMD_2B_M  (SPI1_MEM_C_WAITI_CMD_2B_V << SPI1_MEM_C_WAITI_CMD_2B_S)
+#define SPI1_MEM_C_WAITI_CMD_2B_V  0x00000001U
+#define SPI1_MEM_C_WAITI_CMD_2B_S  9
+/** SPI1_MEM_C_WAITI_DUMMY_CYCLELEN : R/W; bitpos: [15:10]; default: 0;
+ *  The dummy cycle length when wait flash idle(RDSR).
+ */
+#define SPI1_MEM_C_WAITI_DUMMY_CYCLELEN    0x0000003FU
+#define SPI1_MEM_C_WAITI_DUMMY_CYCLELEN_M  (SPI1_MEM_C_WAITI_DUMMY_CYCLELEN_V << SPI1_MEM_C_WAITI_DUMMY_CYCLELEN_S)
+#define SPI1_MEM_C_WAITI_DUMMY_CYCLELEN_V  0x0000003FU
+#define SPI1_MEM_C_WAITI_DUMMY_CYCLELEN_S  10
+/** SPI1_MEM_C_WAITI_CMD : R/W; bitpos: [31:16]; default: 5;
+ *  The command value to wait flash idle(RDSR).
+ */
+#define SPI1_MEM_C_WAITI_CMD    0x0000FFFFU
+#define SPI1_MEM_C_WAITI_CMD_M  (SPI1_MEM_C_WAITI_CMD_V << SPI1_MEM_C_WAITI_CMD_S)
+#define SPI1_MEM_C_WAITI_CMD_V  0x0000FFFFU
+#define SPI1_MEM_C_WAITI_CMD_S  16
+
+/** SPI1_MEM_C_FLASH_SUS_CTRL_REG register
+ *  SPI1 flash suspend control register
+ */
+#define SPI1_MEM_C_FLASH_SUS_CTRL_REG (DR_REG_FLASH_SPI1_BASE + 0x9c)
+/** SPI1_MEM_C_FLASH_PER : R/W/SC; bitpos: [0]; default: 0;
+ *  program erase resume bit, program erase suspend operation will be triggered when
+ *  the bit is set. The bit will be cleared once the operation done.1: enable 0:
+ *  disable.
+ */
+#define SPI1_MEM_C_FLASH_PER    (BIT(0))
+#define SPI1_MEM_C_FLASH_PER_M  (SPI1_MEM_C_FLASH_PER_V << SPI1_MEM_C_FLASH_PER_S)
+#define SPI1_MEM_C_FLASH_PER_V  0x00000001U
+#define SPI1_MEM_C_FLASH_PER_S  0
+/** SPI1_MEM_C_FLASH_PES : R/W/SC; bitpos: [1]; default: 0;
+ *  program erase suspend bit, program erase suspend operation will be triggered when
+ *  the bit is set. The bit will be cleared once the operation done.1: enable 0:
+ *  disable.
+ */
+#define SPI1_MEM_C_FLASH_PES    (BIT(1))
+#define SPI1_MEM_C_FLASH_PES_M  (SPI1_MEM_C_FLASH_PES_V << SPI1_MEM_C_FLASH_PES_S)
+#define SPI1_MEM_C_FLASH_PES_V  0x00000001U
+#define SPI1_MEM_C_FLASH_PES_S  1
+/** SPI1_MEM_C_FLASH_PER_WAIT_EN : R/W; bitpos: [2]; default: 0;
+ *  1: SPI1 waits (SPI1_MEM_C_CS_HOLD_DELAY_RES[9:0] * 4 or *128) SPI_CLK cycles after
+ *  program erase resume command is sent. 0: SPI1 does not wait after program erase
+ *  resume command is sent.
+ */
+#define SPI1_MEM_C_FLASH_PER_WAIT_EN    (BIT(2))
+#define SPI1_MEM_C_FLASH_PER_WAIT_EN_M  (SPI1_MEM_C_FLASH_PER_WAIT_EN_V << SPI1_MEM_C_FLASH_PER_WAIT_EN_S)
+#define SPI1_MEM_C_FLASH_PER_WAIT_EN_V  0x00000001U
+#define SPI1_MEM_C_FLASH_PER_WAIT_EN_S  2
+/** SPI1_MEM_C_FLASH_PES_WAIT_EN : R/W; bitpos: [3]; default: 0;
+ *  1: SPI1 waits (SPI1_MEM_C_CS_HOLD_DELAY_RES[9:0] * 4 or *128) SPI_CLK cycles after
+ *  program erase suspend command is sent. 0: SPI1 does not wait after program erase
+ *  suspend command is sent.
+ */
+#define SPI1_MEM_C_FLASH_PES_WAIT_EN    (BIT(3))
+#define SPI1_MEM_C_FLASH_PES_WAIT_EN_M  (SPI1_MEM_C_FLASH_PES_WAIT_EN_V << SPI1_MEM_C_FLASH_PES_WAIT_EN_S)
+#define SPI1_MEM_C_FLASH_PES_WAIT_EN_V  0x00000001U
+#define SPI1_MEM_C_FLASH_PES_WAIT_EN_S  3
+/** SPI1_MEM_C_PES_PER_EN : R/W; bitpos: [4]; default: 0;
+ *  Set this bit to enable PES end triggers PER transfer option. If this bit is 0,
+ *  application should send PER after PES is done.
+ */
+#define SPI1_MEM_C_PES_PER_EN    (BIT(4))
+#define SPI1_MEM_C_PES_PER_EN_M  (SPI1_MEM_C_PES_PER_EN_V << SPI1_MEM_C_PES_PER_EN_S)
+#define SPI1_MEM_C_PES_PER_EN_V  0x00000001U
+#define SPI1_MEM_C_PES_PER_EN_S  4
+/** SPI1_MEM_C_FLASH_PES_EN : R/W; bitpos: [5]; default: 0;
+ *  Set this bit to enable Auto-suspending function.
+ */
+#define SPI1_MEM_C_FLASH_PES_EN    (BIT(5))
+#define SPI1_MEM_C_FLASH_PES_EN_M  (SPI1_MEM_C_FLASH_PES_EN_V << SPI1_MEM_C_FLASH_PES_EN_S)
+#define SPI1_MEM_C_FLASH_PES_EN_V  0x00000001U
+#define SPI1_MEM_C_FLASH_PES_EN_S  5
+/** SPI1_MEM_C_PESR_END_MSK : R/W; bitpos: [21:6]; default: 128;
+ *  The mask value when check SUS/SUS1/SUS2 status bit. If the read status value is
+ *  status_in[15:0](only status_in[7:0] is valid when only one byte of data is read
+ *  out, status_in[15:0] is valid when two bytes of data are read out), SUS/SUS1/SUS2 =
+ *  status_in[15:0]^ SPI1_MEM_C_PESR_END_MSK[15:0].
+ */
+#define SPI1_MEM_C_PESR_END_MSK    0x0000FFFFU
+#define SPI1_MEM_C_PESR_END_MSK_M  (SPI1_MEM_C_PESR_END_MSK_V << SPI1_MEM_C_PESR_END_MSK_S)
+#define SPI1_MEM_C_PESR_END_MSK_V  0x0000FFFFU
+#define SPI1_MEM_C_PESR_END_MSK_S  6
+/** SPI1_MEM_C_FMEM_RD_SUS_2B : R/W; bitpos: [22]; default: 0;
+ *  1: Read two bytes when check flash SUS/SUS1/SUS2 status bit. 0:  Read one byte when
+ *  check flash SUS/SUS1/SUS2 status bit
+ */
+#define SPI1_MEM_C_FMEM_RD_SUS_2B    (BIT(22))
+#define SPI1_MEM_C_FMEM_RD_SUS_2B_M  (SPI1_MEM_C_FMEM_RD_SUS_2B_V << SPI1_MEM_C_FMEM_RD_SUS_2B_S)
+#define SPI1_MEM_C_FMEM_RD_SUS_2B_V  0x00000001U
+#define SPI1_MEM_C_FMEM_RD_SUS_2B_S  22
+/** SPI1_MEM_C_PER_END_EN : R/W; bitpos: [23]; default: 0;
+ *  1: Both WIP and SUS/SUS1/SUS2 bits should be checked to insure the resume status of
+ *  flash. 0: Only need to check WIP is 0.
+ */
+#define SPI1_MEM_C_PER_END_EN    (BIT(23))
+#define SPI1_MEM_C_PER_END_EN_M  (SPI1_MEM_C_PER_END_EN_V << SPI1_MEM_C_PER_END_EN_S)
+#define SPI1_MEM_C_PER_END_EN_V  0x00000001U
+#define SPI1_MEM_C_PER_END_EN_S  23
+/** SPI1_MEM_C_PES_END_EN : R/W; bitpos: [24]; default: 0;
+ *  1: Both WIP and SUS/SUS1/SUS2 bits should be checked to insure the suspend status
+ *  of flash. 0: Only need to check WIP is 0.
+ */
+#define SPI1_MEM_C_PES_END_EN    (BIT(24))
+#define SPI1_MEM_C_PES_END_EN_M  (SPI1_MEM_C_PES_END_EN_V << SPI1_MEM_C_PES_END_EN_S)
+#define SPI1_MEM_C_PES_END_EN_V  0x00000001U
+#define SPI1_MEM_C_PES_END_EN_S  24
+/** SPI1_MEM_C_SUS_TIMEOUT_CNT : R/W; bitpos: [31:25]; default: 4;
+ *  When SPI1 checks SUS/SUS1/SUS2 bits fail for SPI1_MEM_C_SUS_TIMEOUT_CNT[6:0] times, it
+ *  will be treated as check pass.
+ */
+#define SPI1_MEM_C_SUS_TIMEOUT_CNT    0x0000007FU
+#define SPI1_MEM_C_SUS_TIMEOUT_CNT_M  (SPI1_MEM_C_SUS_TIMEOUT_CNT_V << SPI1_MEM_C_SUS_TIMEOUT_CNT_S)
+#define SPI1_MEM_C_SUS_TIMEOUT_CNT_V  0x0000007FU
+#define SPI1_MEM_C_SUS_TIMEOUT_CNT_S  25
+
+/** SPI1_MEM_C_FLASH_SUS_CMD_REG register
+ *  SPI1 flash suspend command register
+ */
+#define SPI1_MEM_C_FLASH_SUS_CMD_REG (DR_REG_FLASH_SPI1_BASE + 0xa0)
+/** SPI1_MEM_C_FLASH_PES_COMMAND : R/W; bitpos: [15:0]; default: 30069;
+ *  Program/Erase suspend command.
+ */
+#define SPI1_MEM_C_FLASH_PES_COMMAND    0x0000FFFFU
+#define SPI1_MEM_C_FLASH_PES_COMMAND_M  (SPI1_MEM_C_FLASH_PES_COMMAND_V << SPI1_MEM_C_FLASH_PES_COMMAND_S)
+#define SPI1_MEM_C_FLASH_PES_COMMAND_V  0x0000FFFFU
+#define SPI1_MEM_C_FLASH_PES_COMMAND_S  0
+/** SPI1_MEM_C_WAIT_PESR_COMMAND : R/W; bitpos: [31:16]; default: 5;
+ *  Flash SUS/SUS1/SUS2 status bit read command. The command should be sent when
+ *  SUS/SUS1/SUS2 bit should be checked to insure the suspend or resume status of flash.
+ */
+#define SPI1_MEM_C_WAIT_PESR_COMMAND    0x0000FFFFU
+#define SPI1_MEM_C_WAIT_PESR_COMMAND_M  (SPI1_MEM_C_WAIT_PESR_COMMAND_V << SPI1_MEM_C_WAIT_PESR_COMMAND_S)
+#define SPI1_MEM_C_WAIT_PESR_COMMAND_V  0x0000FFFFU
+#define SPI1_MEM_C_WAIT_PESR_COMMAND_S  16
+
+/** SPI1_MEM_C_SUS_STATUS_REG register
+ *  SPI1 flash suspend status register
+ */
+#define SPI1_MEM_C_SUS_STATUS_REG (DR_REG_FLASH_SPI1_BASE + 0xa4)
+/** SPI1_MEM_C_FLASH_SUS : R/W/SS/SC; bitpos: [0]; default: 0;
+ *  The status of flash suspend, only used in SPI1.
+ */
+#define SPI1_MEM_C_FLASH_SUS    (BIT(0))
+#define SPI1_MEM_C_FLASH_SUS_M  (SPI1_MEM_C_FLASH_SUS_V << SPI1_MEM_C_FLASH_SUS_S)
+#define SPI1_MEM_C_FLASH_SUS_V  0x00000001U
+#define SPI1_MEM_C_FLASH_SUS_S  0
+/** SPI1_MEM_C_WAIT_PESR_CMD_2B : R/W; bitpos: [1]; default: 0;
+ *  1: SPI1 sends out SPI1_MEM_C_WAIT_PESR_COMMAND[15:0] to check SUS/SUS1/SUS2 bit. 0:
+ *  SPI1 sends out SPI1_MEM_C_WAIT_PESR_COMMAND[7:0] to check SUS/SUS1/SUS2 bit.
+ */
+#define SPI1_MEM_C_WAIT_PESR_CMD_2B    (BIT(1))
+#define SPI1_MEM_C_WAIT_PESR_CMD_2B_M  (SPI1_MEM_C_WAIT_PESR_CMD_2B_V << SPI1_MEM_C_WAIT_PESR_CMD_2B_S)
+#define SPI1_MEM_C_WAIT_PESR_CMD_2B_V  0x00000001U
+#define SPI1_MEM_C_WAIT_PESR_CMD_2B_S  1
+/** SPI1_MEM_C_FLASH_HPM_DLY_128 : R/W; bitpos: [2]; default: 0;
+ *  1: SPI1 waits (SPI1_MEM_C_CS_HOLD_DELAY_RES[9:0] * 128) SPI_CLK cycles after HPM
+ *  command is sent. 0: SPI1 waits (SPI1_MEM_C_CS_HOLD_DELAY_RES[9:0] * 4) SPI_CLK cycles
+ *  after HPM command is sent.
+ */
+#define SPI1_MEM_C_FLASH_HPM_DLY_128    (BIT(2))
+#define SPI1_MEM_C_FLASH_HPM_DLY_128_M  (SPI1_MEM_C_FLASH_HPM_DLY_128_V << SPI1_MEM_C_FLASH_HPM_DLY_128_S)
+#define SPI1_MEM_C_FLASH_HPM_DLY_128_V  0x00000001U
+#define SPI1_MEM_C_FLASH_HPM_DLY_128_S  2
+/** SPI1_MEM_C_FLASH_RES_DLY_128 : R/W; bitpos: [3]; default: 0;
+ *  1: SPI1 waits (SPI1_MEM_C_CS_HOLD_DELAY_RES[9:0] * 128) SPI_CLK cycles after RES
+ *  command is sent. 0: SPI1 waits (SPI1_MEM_C_CS_HOLD_DELAY_RES[9:0] * 4) SPI_CLK cycles
+ *  after RES command is sent.
+ */
+#define SPI1_MEM_C_FLASH_RES_DLY_128    (BIT(3))
+#define SPI1_MEM_C_FLASH_RES_DLY_128_M  (SPI1_MEM_C_FLASH_RES_DLY_128_V << SPI1_MEM_C_FLASH_RES_DLY_128_S)
+#define SPI1_MEM_C_FLASH_RES_DLY_128_V  0x00000001U
+#define SPI1_MEM_C_FLASH_RES_DLY_128_S  3
+/** SPI1_MEM_C_FLASH_DP_DLY_128 : R/W; bitpos: [4]; default: 0;
+ *  1: SPI1 waits (SPI1_MEM_C_CS_HOLD_DELAY_RES[9:0] * 128) SPI_CLK cycles after DP
+ *  command is sent. 0: SPI1 waits (SPI1_MEM_C_CS_HOLD_DELAY_RES[9:0] * 4) SPI_CLK cycles
+ *  after DP command is sent.
+ */
+#define SPI1_MEM_C_FLASH_DP_DLY_128    (BIT(4))
+#define SPI1_MEM_C_FLASH_DP_DLY_128_M  (SPI1_MEM_C_FLASH_DP_DLY_128_V << SPI1_MEM_C_FLASH_DP_DLY_128_S)
+#define SPI1_MEM_C_FLASH_DP_DLY_128_V  0x00000001U
+#define SPI1_MEM_C_FLASH_DP_DLY_128_S  4
+/** SPI1_MEM_C_FLASH_PER_DLY_128 : R/W; bitpos: [5]; default: 0;
+ *  Valid when SPI1_MEM_C_FLASH_PER_WAIT_EN is 1. 1: SPI1 waits
+ *  (SPI1_MEM_C_CS_HOLD_DELAY_RES[9:0] * 128) SPI_CLK cycles after PER command is sent. 0:
+ *  SPI1 waits (SPI1_MEM_C_CS_HOLD_DELAY_RES[9:0] * 4) SPI_CLK cycles after PER command is
+ *  sent.
+ */
+#define SPI1_MEM_C_FLASH_PER_DLY_128    (BIT(5))
+#define SPI1_MEM_C_FLASH_PER_DLY_128_M  (SPI1_MEM_C_FLASH_PER_DLY_128_V << SPI1_MEM_C_FLASH_PER_DLY_128_S)
+#define SPI1_MEM_C_FLASH_PER_DLY_128_V  0x00000001U
+#define SPI1_MEM_C_FLASH_PER_DLY_128_S  5
+/** SPI1_MEM_C_FLASH_PES_DLY_128 : R/W; bitpos: [6]; default: 0;
+ *  Valid when SPI1_MEM_C_FLASH_PES_WAIT_EN is 1. 1: SPI1 waits
+ *  (SPI1_MEM_C_CS_HOLD_DELAY_RES[9:0] * 128) SPI_CLK cycles after PES command is sent. 0:
+ *  SPI1 waits (SPI1_MEM_C_CS_HOLD_DELAY_RES[9:0] * 4) SPI_CLK cycles after PES command is
+ *  sent.
+ */
+#define SPI1_MEM_C_FLASH_PES_DLY_128    (BIT(6))
+#define SPI1_MEM_C_FLASH_PES_DLY_128_M  (SPI1_MEM_C_FLASH_PES_DLY_128_V << SPI1_MEM_C_FLASH_PES_DLY_128_S)
+#define SPI1_MEM_C_FLASH_PES_DLY_128_V  0x00000001U
+#define SPI1_MEM_C_FLASH_PES_DLY_128_S  6
+/** SPI1_MEM_C_SPI0_LOCK_EN : R/W; bitpos: [7]; default: 0;
+ *  1: Enable SPI0 lock SPI0/1 arbiter option. 0: Disable it.
+ */
+#define SPI1_MEM_C_SPI0_LOCK_EN    (BIT(7))
+#define SPI1_MEM_C_SPI0_LOCK_EN_M  (SPI1_MEM_C_SPI0_LOCK_EN_V << SPI1_MEM_C_SPI0_LOCK_EN_S)
+#define SPI1_MEM_C_SPI0_LOCK_EN_V  0x00000001U
+#define SPI1_MEM_C_SPI0_LOCK_EN_S  7
+/** SPI1_MEM_C_FLASH_PESR_CMD_2B : R/W; bitpos: [15]; default: 0;
+ *  1: The bit length of Program/Erase Suspend/Resume command is 16. 0: The bit length
+ *  of Program/Erase Suspend/Resume command is 8.
+ */
+#define SPI1_MEM_C_FLASH_PESR_CMD_2B    (BIT(15))
+#define SPI1_MEM_C_FLASH_PESR_CMD_2B_M  (SPI1_MEM_C_FLASH_PESR_CMD_2B_V << SPI1_MEM_C_FLASH_PESR_CMD_2B_S)
+#define SPI1_MEM_C_FLASH_PESR_CMD_2B_V  0x00000001U
+#define SPI1_MEM_C_FLASH_PESR_CMD_2B_S  15
+/** SPI1_MEM_C_FLASH_PER_COMMAND : R/W; bitpos: [31:16]; default: 31354;
+ *  Program/Erase resume command.
+ */
+#define SPI1_MEM_C_FLASH_PER_COMMAND    0x0000FFFFU
+#define SPI1_MEM_C_FLASH_PER_COMMAND_M  (SPI1_MEM_C_FLASH_PER_COMMAND_V << SPI1_MEM_C_FLASH_PER_COMMAND_S)
+#define SPI1_MEM_C_FLASH_PER_COMMAND_V  0x0000FFFFU
+#define SPI1_MEM_C_FLASH_PER_COMMAND_S  16
+
+/** SPI1_MEM_C_FLASH_WAITI_CTRL1_REG register
+ *  SPI1 wait idle control register
+ */
+#define SPI1_MEM_C_FLASH_WAITI_CTRL1_REG (DR_REG_FLASH_SPI1_BASE + 0xac)
+/** SPI1_MEM_C_WAITI_IDLE_DELAY_TIME : R/W; bitpos: [9:0]; default: 0;
+ *  SPI1 wait idle gap time configuration. SPI1 slv fsm will count during SPI1 IDLE.
+ */
+#define SPI1_MEM_C_WAITI_IDLE_DELAY_TIME    0x000003FFU
+#define SPI1_MEM_C_WAITI_IDLE_DELAY_TIME_M  (SPI1_MEM_C_WAITI_IDLE_DELAY_TIME_V << SPI1_MEM_C_WAITI_IDLE_DELAY_TIME_S)
+#define SPI1_MEM_C_WAITI_IDLE_DELAY_TIME_V  0x000003FFU
+#define SPI1_MEM_C_WAITI_IDLE_DELAY_TIME_S  0
+/** SPI1_MEM_C_WAITI_IDLE_DELAY_TIME_EN : R/W; bitpos: [10]; default: 0;
+ *  Enable SPI1 wait idle gap time count function. 1: Enable. 0: Disable.
+ */
+#define SPI1_MEM_C_WAITI_IDLE_DELAY_TIME_EN    (BIT(10))
+#define SPI1_MEM_C_WAITI_IDLE_DELAY_TIME_EN_M  (SPI1_MEM_C_WAITI_IDLE_DELAY_TIME_EN_V << SPI1_MEM_C_WAITI_IDLE_DELAY_TIME_EN_S)
+#define SPI1_MEM_C_WAITI_IDLE_DELAY_TIME_EN_V  0x00000001U
+#define SPI1_MEM_C_WAITI_IDLE_DELAY_TIME_EN_S  10
+
+/** SPI1_MEM_C_INT_ENA_REG register
+ *  SPI1 interrupt enable register
+ */
+#define SPI1_MEM_C_INT_ENA_REG (DR_REG_FLASH_SPI1_BASE + 0xc0)
+/** SPI1_MEM_C_PER_END_INT_ENA : R/W; bitpos: [0]; default: 0;
+ *  The enable bit for SPI1_MEM_C_PER_END_INT interrupt.
+ */
+#define SPI1_MEM_C_PER_END_INT_ENA    (BIT(0))
+#define SPI1_MEM_C_PER_END_INT_ENA_M  (SPI1_MEM_C_PER_END_INT_ENA_V << SPI1_MEM_C_PER_END_INT_ENA_S)
+#define SPI1_MEM_C_PER_END_INT_ENA_V  0x00000001U
+#define SPI1_MEM_C_PER_END_INT_ENA_S  0
+/** SPI1_MEM_C_PES_END_INT_ENA : R/W; bitpos: [1]; default: 0;
+ *  The enable bit for SPI1_MEM_C_PES_END_INT interrupt.
+ */
+#define SPI1_MEM_C_PES_END_INT_ENA    (BIT(1))
+#define SPI1_MEM_C_PES_END_INT_ENA_M  (SPI1_MEM_C_PES_END_INT_ENA_V << SPI1_MEM_C_PES_END_INT_ENA_S)
+#define SPI1_MEM_C_PES_END_INT_ENA_V  0x00000001U
+#define SPI1_MEM_C_PES_END_INT_ENA_S  1
+/** SPI1_MEM_C_WPE_END_INT_ENA : R/W; bitpos: [2]; default: 0;
+ *  The enable bit for SPI1_MEM_C_WPE_END_INT interrupt.
+ */
+#define SPI1_MEM_C_WPE_END_INT_ENA    (BIT(2))
+#define SPI1_MEM_C_WPE_END_INT_ENA_M  (SPI1_MEM_C_WPE_END_INT_ENA_V << SPI1_MEM_C_WPE_END_INT_ENA_S)
+#define SPI1_MEM_C_WPE_END_INT_ENA_V  0x00000001U
+#define SPI1_MEM_C_WPE_END_INT_ENA_S  2
+/** SPI1_MEM_C_SLV_ST_END_INT_ENA : R/W; bitpos: [3]; default: 0;
+ *  The enable bit for SPI1_MEM_C_SLV_ST_END_INT interrupt.
+ */
+#define SPI1_MEM_C_SLV_ST_END_INT_ENA    (BIT(3))
+#define SPI1_MEM_C_SLV_ST_END_INT_ENA_M  (SPI1_MEM_C_SLV_ST_END_INT_ENA_V << SPI1_MEM_C_SLV_ST_END_INT_ENA_S)
+#define SPI1_MEM_C_SLV_ST_END_INT_ENA_V  0x00000001U
+#define SPI1_MEM_C_SLV_ST_END_INT_ENA_S  3
+/** SPI1_MEM_C_MST_ST_END_INT_ENA : R/W; bitpos: [4]; default: 0;
+ *  The enable bit for SPI1_MEM_C_MST_ST_END_INT interrupt.
+ */
+#define SPI1_MEM_C_MST_ST_END_INT_ENA    (BIT(4))
+#define SPI1_MEM_C_MST_ST_END_INT_ENA_M  (SPI1_MEM_C_MST_ST_END_INT_ENA_V << SPI1_MEM_C_MST_ST_END_INT_ENA_S)
+#define SPI1_MEM_C_MST_ST_END_INT_ENA_V  0x00000001U
+#define SPI1_MEM_C_MST_ST_END_INT_ENA_S  4
+/** SPI1_MEM_C_BROWN_OUT_INT_ENA : R/W; bitpos: [10]; default: 0;
+ *  The enable bit for SPI1_MEM_C_BROWN_OUT_INT interrupt.
+ */
+#define SPI1_MEM_C_BROWN_OUT_INT_ENA    (BIT(10))
+#define SPI1_MEM_C_BROWN_OUT_INT_ENA_M  (SPI1_MEM_C_BROWN_OUT_INT_ENA_V << SPI1_MEM_C_BROWN_OUT_INT_ENA_S)
+#define SPI1_MEM_C_BROWN_OUT_INT_ENA_V  0x00000001U
+#define SPI1_MEM_C_BROWN_OUT_INT_ENA_S  10
+
+/** SPI1_MEM_C_INT_CLR_REG register
+ *  SPI1 interrupt clear register
+ */
+#define SPI1_MEM_C_INT_CLR_REG (DR_REG_FLASH_SPI1_BASE + 0xc4)
+/** SPI1_MEM_C_PER_END_INT_CLR : WT; bitpos: [0]; default: 0;
+ *  The clear bit for SPI1_MEM_C_PER_END_INT interrupt.
+ */
+#define SPI1_MEM_C_PER_END_INT_CLR    (BIT(0))
+#define SPI1_MEM_C_PER_END_INT_CLR_M  (SPI1_MEM_C_PER_END_INT_CLR_V << SPI1_MEM_C_PER_END_INT_CLR_S)
+#define SPI1_MEM_C_PER_END_INT_CLR_V  0x00000001U
+#define SPI1_MEM_C_PER_END_INT_CLR_S  0
+/** SPI1_MEM_C_PES_END_INT_CLR : WT; bitpos: [1]; default: 0;
+ *  The clear bit for SPI1_MEM_C_PES_END_INT interrupt.
+ */
+#define SPI1_MEM_C_PES_END_INT_CLR    (BIT(1))
+#define SPI1_MEM_C_PES_END_INT_CLR_M  (SPI1_MEM_C_PES_END_INT_CLR_V << SPI1_MEM_C_PES_END_INT_CLR_S)
+#define SPI1_MEM_C_PES_END_INT_CLR_V  0x00000001U
+#define SPI1_MEM_C_PES_END_INT_CLR_S  1
+/** SPI1_MEM_C_WPE_END_INT_CLR : WT; bitpos: [2]; default: 0;
+ *  The clear bit for SPI1_MEM_C_WPE_END_INT interrupt.
+ */
+#define SPI1_MEM_C_WPE_END_INT_CLR    (BIT(2))
+#define SPI1_MEM_C_WPE_END_INT_CLR_M  (SPI1_MEM_C_WPE_END_INT_CLR_V << SPI1_MEM_C_WPE_END_INT_CLR_S)
+#define SPI1_MEM_C_WPE_END_INT_CLR_V  0x00000001U
+#define SPI1_MEM_C_WPE_END_INT_CLR_S  2
+/** SPI1_MEM_C_SLV_ST_END_INT_CLR : WT; bitpos: [3]; default: 0;
+ *  The clear bit for SPI1_MEM_C_SLV_ST_END_INT interrupt.
+ */
+#define SPI1_MEM_C_SLV_ST_END_INT_CLR    (BIT(3))
+#define SPI1_MEM_C_SLV_ST_END_INT_CLR_M  (SPI1_MEM_C_SLV_ST_END_INT_CLR_V << SPI1_MEM_C_SLV_ST_END_INT_CLR_S)
+#define SPI1_MEM_C_SLV_ST_END_INT_CLR_V  0x00000001U
+#define SPI1_MEM_C_SLV_ST_END_INT_CLR_S  3
+/** SPI1_MEM_C_MST_ST_END_INT_CLR : WT; bitpos: [4]; default: 0;
+ *  The clear bit for SPI1_MEM_C_MST_ST_END_INT interrupt.
+ */
+#define SPI1_MEM_C_MST_ST_END_INT_CLR    (BIT(4))
+#define SPI1_MEM_C_MST_ST_END_INT_CLR_M  (SPI1_MEM_C_MST_ST_END_INT_CLR_V << SPI1_MEM_C_MST_ST_END_INT_CLR_S)
+#define SPI1_MEM_C_MST_ST_END_INT_CLR_V  0x00000001U
+#define SPI1_MEM_C_MST_ST_END_INT_CLR_S  4
+/** SPI1_MEM_C_BROWN_OUT_INT_CLR : WT; bitpos: [10]; default: 0;
+ *  The status bit for SPI1_MEM_C_BROWN_OUT_INT interrupt.
+ */
+#define SPI1_MEM_C_BROWN_OUT_INT_CLR    (BIT(10))
+#define SPI1_MEM_C_BROWN_OUT_INT_CLR_M  (SPI1_MEM_C_BROWN_OUT_INT_CLR_V << SPI1_MEM_C_BROWN_OUT_INT_CLR_S)
+#define SPI1_MEM_C_BROWN_OUT_INT_CLR_V  0x00000001U
+#define SPI1_MEM_C_BROWN_OUT_INT_CLR_S  10
+
+/** SPI1_MEM_C_INT_RAW_REG register
+ *  SPI1 interrupt raw register
+ */
+#define SPI1_MEM_C_INT_RAW_REG (DR_REG_FLASH_SPI1_BASE + 0xc8)
+/** SPI1_MEM_C_PER_END_INT_RAW : R/WTC/SS; bitpos: [0]; default: 0;
+ *  The raw bit for SPI1_MEM_C_PER_END_INT interrupt. 1: Triggered when Auto Resume
+ *  command (0x7A) is sent and flash is resumed successfully. 0: Others.
+ */
+#define SPI1_MEM_C_PER_END_INT_RAW    (BIT(0))
+#define SPI1_MEM_C_PER_END_INT_RAW_M  (SPI1_MEM_C_PER_END_INT_RAW_V << SPI1_MEM_C_PER_END_INT_RAW_S)
+#define SPI1_MEM_C_PER_END_INT_RAW_V  0x00000001U
+#define SPI1_MEM_C_PER_END_INT_RAW_S  0
+/** SPI1_MEM_C_PES_END_INT_RAW : R/WTC/SS; bitpos: [1]; default: 0;
+ *  The raw bit for SPI1_MEM_C_PES_END_INT interrupt.1: Triggered when Auto Suspend
+ *  command (0x75) is sent and flash is suspended successfully. 0: Others.
+ */
+#define SPI1_MEM_C_PES_END_INT_RAW    (BIT(1))
+#define SPI1_MEM_C_PES_END_INT_RAW_M  (SPI1_MEM_C_PES_END_INT_RAW_V << SPI1_MEM_C_PES_END_INT_RAW_S)
+#define SPI1_MEM_C_PES_END_INT_RAW_V  0x00000001U
+#define SPI1_MEM_C_PES_END_INT_RAW_S  1
+/** SPI1_MEM_C_WPE_END_INT_RAW : R/WTC/SS; bitpos: [2]; default: 0;
+ *  The raw bit for SPI1_MEM_C_WPE_END_INT interrupt. 1: Triggered when WRSR/PP/SE/BE/CE
+ *  is sent and flash is already idle. 0: Others.
+ */
+#define SPI1_MEM_C_WPE_END_INT_RAW    (BIT(2))
+#define SPI1_MEM_C_WPE_END_INT_RAW_M  (SPI1_MEM_C_WPE_END_INT_RAW_V << SPI1_MEM_C_WPE_END_INT_RAW_S)
+#define SPI1_MEM_C_WPE_END_INT_RAW_V  0x00000001U
+#define SPI1_MEM_C_WPE_END_INT_RAW_S  2
+/** SPI1_MEM_C_SLV_ST_END_INT_RAW : R/WTC/SS; bitpos: [3]; default: 0;
+ *  The raw bit for SPI1_MEM_C_SLV_ST_END_INT interrupt. 1: Triggered when spi1_slv_st is
+ *  changed from non idle state to idle state. It means that SPI_CS raises high. 0:
+ *  Others
+ */
+#define SPI1_MEM_C_SLV_ST_END_INT_RAW    (BIT(3))
+#define SPI1_MEM_C_SLV_ST_END_INT_RAW_M  (SPI1_MEM_C_SLV_ST_END_INT_RAW_V << SPI1_MEM_C_SLV_ST_END_INT_RAW_S)
+#define SPI1_MEM_C_SLV_ST_END_INT_RAW_V  0x00000001U
+#define SPI1_MEM_C_SLV_ST_END_INT_RAW_S  3
+/** SPI1_MEM_C_MST_ST_END_INT_RAW : R/WTC/SS; bitpos: [4]; default: 0;
+ *  The raw bit for SPI1_MEM_C_MST_ST_END_INT interrupt. 1: Triggered when spi1_mst_st is
+ *  changed from non idle state to idle state. 0: Others.
+ */
+#define SPI1_MEM_C_MST_ST_END_INT_RAW    (BIT(4))
+#define SPI1_MEM_C_MST_ST_END_INT_RAW_M  (SPI1_MEM_C_MST_ST_END_INT_RAW_V << SPI1_MEM_C_MST_ST_END_INT_RAW_S)
+#define SPI1_MEM_C_MST_ST_END_INT_RAW_V  0x00000001U
+#define SPI1_MEM_C_MST_ST_END_INT_RAW_S  4
+/** SPI1_MEM_C_BROWN_OUT_INT_RAW : R/WTC/SS; bitpos: [10]; default: 0;
+ *  The raw bit for SPI1_MEM_C_BROWN_OUT_INT interrupt. 1: Triggered condition is that
+ *  chip is losing power and RTC module sends out brown out close flash request to
+ *  SPI1. After SPI1 sends out suspend command to flash, this interrupt is triggered
+ *  and MSPI returns to idle state. 0: Others.
+ */
+#define SPI1_MEM_C_BROWN_OUT_INT_RAW    (BIT(10))
+#define SPI1_MEM_C_BROWN_OUT_INT_RAW_M  (SPI1_MEM_C_BROWN_OUT_INT_RAW_V << SPI1_MEM_C_BROWN_OUT_INT_RAW_S)
+#define SPI1_MEM_C_BROWN_OUT_INT_RAW_V  0x00000001U
+#define SPI1_MEM_C_BROWN_OUT_INT_RAW_S  10
+
+/** SPI1_MEM_C_INT_ST_REG register
+ *  SPI1 interrupt status register
+ */
+#define SPI1_MEM_C_INT_ST_REG (DR_REG_FLASH_SPI1_BASE + 0xcc)
+/** SPI1_MEM_C_PER_END_INT_ST : RO; bitpos: [0]; default: 0;
+ *  The status bit for SPI1_MEM_C_PER_END_INT interrupt.
+ */
+#define SPI1_MEM_C_PER_END_INT_ST    (BIT(0))
+#define SPI1_MEM_C_PER_END_INT_ST_M  (SPI1_MEM_C_PER_END_INT_ST_V << SPI1_MEM_C_PER_END_INT_ST_S)
+#define SPI1_MEM_C_PER_END_INT_ST_V  0x00000001U
+#define SPI1_MEM_C_PER_END_INT_ST_S  0
+/** SPI1_MEM_C_PES_END_INT_ST : RO; bitpos: [1]; default: 0;
+ *  The status bit for SPI1_MEM_C_PES_END_INT interrupt.
+ */
+#define SPI1_MEM_C_PES_END_INT_ST    (BIT(1))
+#define SPI1_MEM_C_PES_END_INT_ST_M  (SPI1_MEM_C_PES_END_INT_ST_V << SPI1_MEM_C_PES_END_INT_ST_S)
+#define SPI1_MEM_C_PES_END_INT_ST_V  0x00000001U
+#define SPI1_MEM_C_PES_END_INT_ST_S  1
+/** SPI1_MEM_C_WPE_END_INT_ST : RO; bitpos: [2]; default: 0;
+ *  The status bit for SPI1_MEM_C_WPE_END_INT interrupt.
+ */
+#define SPI1_MEM_C_WPE_END_INT_ST    (BIT(2))
+#define SPI1_MEM_C_WPE_END_INT_ST_M  (SPI1_MEM_C_WPE_END_INT_ST_V << SPI1_MEM_C_WPE_END_INT_ST_S)
+#define SPI1_MEM_C_WPE_END_INT_ST_V  0x00000001U
+#define SPI1_MEM_C_WPE_END_INT_ST_S  2
+/** SPI1_MEM_C_SLV_ST_END_INT_ST : RO; bitpos: [3]; default: 0;
+ *  The status bit for SPI1_MEM_C_SLV_ST_END_INT interrupt.
+ */
+#define SPI1_MEM_C_SLV_ST_END_INT_ST    (BIT(3))
+#define SPI1_MEM_C_SLV_ST_END_INT_ST_M  (SPI1_MEM_C_SLV_ST_END_INT_ST_V << SPI1_MEM_C_SLV_ST_END_INT_ST_S)
+#define SPI1_MEM_C_SLV_ST_END_INT_ST_V  0x00000001U
+#define SPI1_MEM_C_SLV_ST_END_INT_ST_S  3
+/** SPI1_MEM_C_MST_ST_END_INT_ST : RO; bitpos: [4]; default: 0;
+ *  The status bit for SPI1_MEM_C_MST_ST_END_INT interrupt.
+ */
+#define SPI1_MEM_C_MST_ST_END_INT_ST    (BIT(4))
+#define SPI1_MEM_C_MST_ST_END_INT_ST_M  (SPI1_MEM_C_MST_ST_END_INT_ST_V << SPI1_MEM_C_MST_ST_END_INT_ST_S)
+#define SPI1_MEM_C_MST_ST_END_INT_ST_V  0x00000001U
+#define SPI1_MEM_C_MST_ST_END_INT_ST_S  4
+/** SPI1_MEM_C_BROWN_OUT_INT_ST : RO; bitpos: [10]; default: 0;
+ *  The status bit for SPI1_MEM_C_BROWN_OUT_INT interrupt.
+ */
+#define SPI1_MEM_C_BROWN_OUT_INT_ST    (BIT(10))
+#define SPI1_MEM_C_BROWN_OUT_INT_ST_M  (SPI1_MEM_C_BROWN_OUT_INT_ST_V << SPI1_MEM_C_BROWN_OUT_INT_ST_S)
+#define SPI1_MEM_C_BROWN_OUT_INT_ST_V  0x00000001U
+#define SPI1_MEM_C_BROWN_OUT_INT_ST_S  10
+
+/** SPI1_MEM_C_DDR_REG register
+ *  SPI1 DDR control register
+ */
+#define SPI1_MEM_C_DDR_REG (DR_REG_FLASH_SPI1_BASE + 0xd4)
+/** SPI1_MEM_C_FMEM_DDR_EN : HRO; bitpos: [0]; default: 0;
+ *  1: in ddr mode,  0 in sdr mode
+ */
+#define SPI1_MEM_C_FMEM_DDR_EN    (BIT(0))
+#define SPI1_MEM_C_FMEM_DDR_EN_M  (SPI1_MEM_C_FMEM_DDR_EN_V << SPI1_MEM_C_FMEM_DDR_EN_S)
+#define SPI1_MEM_C_FMEM_DDR_EN_V  0x00000001U
+#define SPI1_MEM_C_FMEM_DDR_EN_S  0
+/** SPI1_MEM_C_FMEM_VAR_DUMMY : HRO; bitpos: [1]; default: 0;
+ *  Set the bit to enable variable dummy cycle in spi ddr mode.
+ */
+#define SPI1_MEM_C_FMEM_VAR_DUMMY    (BIT(1))
+#define SPI1_MEM_C_FMEM_VAR_DUMMY_M  (SPI1_MEM_C_FMEM_VAR_DUMMY_V << SPI1_MEM_C_FMEM_VAR_DUMMY_S)
+#define SPI1_MEM_C_FMEM_VAR_DUMMY_V  0x00000001U
+#define SPI1_MEM_C_FMEM_VAR_DUMMY_S  1
+/** SPI1_MEM_C_FMEM_DDR_RDAT_SWP : HRO; bitpos: [2]; default: 0;
+ *  Set the bit to reorder rx data of the word in spi ddr mode.
+ */
+#define SPI1_MEM_C_FMEM_DDR_RDAT_SWP    (BIT(2))
+#define SPI1_MEM_C_FMEM_DDR_RDAT_SWP_M  (SPI1_MEM_C_FMEM_DDR_RDAT_SWP_V << SPI1_MEM_C_FMEM_DDR_RDAT_SWP_S)
+#define SPI1_MEM_C_FMEM_DDR_RDAT_SWP_V  0x00000001U
+#define SPI1_MEM_C_FMEM_DDR_RDAT_SWP_S  2
+/** SPI1_MEM_C_FMEM_DDR_WDAT_SWP : HRO; bitpos: [3]; default: 0;
+ *  Set the bit to reorder tx data of the word in spi ddr mode.
+ */
+#define SPI1_MEM_C_FMEM_DDR_WDAT_SWP    (BIT(3))
+#define SPI1_MEM_C_FMEM_DDR_WDAT_SWP_M  (SPI1_MEM_C_FMEM_DDR_WDAT_SWP_V << SPI1_MEM_C_FMEM_DDR_WDAT_SWP_S)
+#define SPI1_MEM_C_FMEM_DDR_WDAT_SWP_V  0x00000001U
+#define SPI1_MEM_C_FMEM_DDR_WDAT_SWP_S  3
+/** SPI1_MEM_C_FMEM_DDR_CMD_DIS : HRO; bitpos: [4]; default: 0;
+ *  the bit is used to disable dual edge in command phase when ddr mode.
+ */
+#define SPI1_MEM_C_FMEM_DDR_CMD_DIS    (BIT(4))
+#define SPI1_MEM_C_FMEM_DDR_CMD_DIS_M  (SPI1_MEM_C_FMEM_DDR_CMD_DIS_V << SPI1_MEM_C_FMEM_DDR_CMD_DIS_S)
+#define SPI1_MEM_C_FMEM_DDR_CMD_DIS_V  0x00000001U
+#define SPI1_MEM_C_FMEM_DDR_CMD_DIS_S  4
+/** SPI1_MEM_C_FMEM_OUTMINBYTELEN : HRO; bitpos: [11:5]; default: 1;
+ *  It is the minimum output data length in the panda device.
+ */
+#define SPI1_MEM_C_FMEM_OUTMINBYTELEN    0x0000007FU
+#define SPI1_MEM_C_FMEM_OUTMINBYTELEN_M  (SPI1_MEM_C_FMEM_OUTMINBYTELEN_V << SPI1_MEM_C_FMEM_OUTMINBYTELEN_S)
+#define SPI1_MEM_C_FMEM_OUTMINBYTELEN_V  0x0000007FU
+#define SPI1_MEM_C_FMEM_OUTMINBYTELEN_S  5
+/** SPI1_MEM_C_FMEM_USR_DDR_DQS_THD : HRO; bitpos: [20:14]; default: 0;
+ *  The delay number of data strobe which from memory based on SPI clock.
+ */
+#define SPI1_MEM_C_FMEM_USR_DDR_DQS_THD    0x0000007FU
+#define SPI1_MEM_C_FMEM_USR_DDR_DQS_THD_M  (SPI1_MEM_C_FMEM_USR_DDR_DQS_THD_V << SPI1_MEM_C_FMEM_USR_DDR_DQS_THD_S)
+#define SPI1_MEM_C_FMEM_USR_DDR_DQS_THD_V  0x0000007FU
+#define SPI1_MEM_C_FMEM_USR_DDR_DQS_THD_S  14
+/** SPI1_MEM_C_FMEM_DDR_DQS_LOOP : HRO; bitpos: [21]; default: 0;
+ *  1: Do not need the input of SPI_DQS signal, SPI0 starts to receive data when
+ *  spi0_slv_st is in SPI1_MEM_C_DIN state. It is used when there is no SPI_DQS signal or
+ *  SPI_DQS signal is not stable. 0: SPI0 starts to store data at the positive and
+ *  negative edge of SPI_DQS.
+ */
+#define SPI1_MEM_C_FMEM_DDR_DQS_LOOP    (BIT(21))
+#define SPI1_MEM_C_FMEM_DDR_DQS_LOOP_M  (SPI1_MEM_C_FMEM_DDR_DQS_LOOP_V << SPI1_MEM_C_FMEM_DDR_DQS_LOOP_S)
+#define SPI1_MEM_C_FMEM_DDR_DQS_LOOP_V  0x00000001U
+#define SPI1_MEM_C_FMEM_DDR_DQS_LOOP_S  21
+/** SPI1_MEM_C_FMEM_CLK_DIFF_EN : HRO; bitpos: [24]; default: 0;
+ *  Set this bit to enable the differential SPI_CLK#.
+ */
+#define SPI1_MEM_C_FMEM_CLK_DIFF_EN    (BIT(24))
+#define SPI1_MEM_C_FMEM_CLK_DIFF_EN_M  (SPI1_MEM_C_FMEM_CLK_DIFF_EN_V << SPI1_MEM_C_FMEM_CLK_DIFF_EN_S)
+#define SPI1_MEM_C_FMEM_CLK_DIFF_EN_V  0x00000001U
+#define SPI1_MEM_C_FMEM_CLK_DIFF_EN_S  24
+/** SPI1_MEM_C_FMEM_DQS_CA_IN : HRO; bitpos: [26]; default: 0;
+ *  Set this bit to enable the input of SPI_DQS signal in SPI phases of CMD and ADDR.
+ */
+#define SPI1_MEM_C_FMEM_DQS_CA_IN    (BIT(26))
+#define SPI1_MEM_C_FMEM_DQS_CA_IN_M  (SPI1_MEM_C_FMEM_DQS_CA_IN_V << SPI1_MEM_C_FMEM_DQS_CA_IN_S)
+#define SPI1_MEM_C_FMEM_DQS_CA_IN_V  0x00000001U
+#define SPI1_MEM_C_FMEM_DQS_CA_IN_S  26
+/** SPI1_MEM_C_FMEM_HYPERBUS_DUMMY_2X : HRO; bitpos: [27]; default: 0;
+ *  Set this bit to enable the vary dummy function in SPI HyperBus mode, when SPI0
+ *  accesses flash or SPI1 accesses flash or sram.
+ */
+#define SPI1_MEM_C_FMEM_HYPERBUS_DUMMY_2X    (BIT(27))
+#define SPI1_MEM_C_FMEM_HYPERBUS_DUMMY_2X_M  (SPI1_MEM_C_FMEM_HYPERBUS_DUMMY_2X_V << SPI1_MEM_C_FMEM_HYPERBUS_DUMMY_2X_S)
+#define SPI1_MEM_C_FMEM_HYPERBUS_DUMMY_2X_V  0x00000001U
+#define SPI1_MEM_C_FMEM_HYPERBUS_DUMMY_2X_S  27
+/** SPI1_MEM_C_FMEM_CLK_DIFF_INV : HRO; bitpos: [28]; default: 0;
+ *  Set this bit to invert SPI_DIFF when accesses to flash. .
+ */
+#define SPI1_MEM_C_FMEM_CLK_DIFF_INV    (BIT(28))
+#define SPI1_MEM_C_FMEM_CLK_DIFF_INV_M  (SPI1_MEM_C_FMEM_CLK_DIFF_INV_V << SPI1_MEM_C_FMEM_CLK_DIFF_INV_S)
+#define SPI1_MEM_C_FMEM_CLK_DIFF_INV_V  0x00000001U
+#define SPI1_MEM_C_FMEM_CLK_DIFF_INV_S  28
+/** SPI1_MEM_C_FMEM_OCTA_RAM_ADDR : HRO; bitpos: [29]; default: 0;
+ *  Set this bit to enable octa_ram address out when accesses to flash, which means
+ *  ADDR_OUT[31:0] = {spi_usr_addr_value[25:4], 6'd0, spi_usr_addr_value[3:1], 1'b0}.
+ */
+#define SPI1_MEM_C_FMEM_OCTA_RAM_ADDR    (BIT(29))
+#define SPI1_MEM_C_FMEM_OCTA_RAM_ADDR_M  (SPI1_MEM_C_FMEM_OCTA_RAM_ADDR_V << SPI1_MEM_C_FMEM_OCTA_RAM_ADDR_S)
+#define SPI1_MEM_C_FMEM_OCTA_RAM_ADDR_V  0x00000001U
+#define SPI1_MEM_C_FMEM_OCTA_RAM_ADDR_S  29
+/** SPI1_MEM_C_FMEM_HYPERBUS_CA : HRO; bitpos: [30]; default: 0;
+ *  Set this bit to enable HyperRAM address out when accesses to flash, which means
+ *  ADDR_OUT[31:0] = {spi_usr_addr_value[19:4], 13'd0, spi_usr_addr_value[3:1]}.
+ */
+#define SPI1_MEM_C_FMEM_HYPERBUS_CA    (BIT(30))
+#define SPI1_MEM_C_FMEM_HYPERBUS_CA_M  (SPI1_MEM_C_FMEM_HYPERBUS_CA_V << SPI1_MEM_C_FMEM_HYPERBUS_CA_S)
+#define SPI1_MEM_C_FMEM_HYPERBUS_CA_V  0x00000001U
+#define SPI1_MEM_C_FMEM_HYPERBUS_CA_S  30
+
+/** SPI1_MEM_C_TIMING_CALI_REG register
+ *  SPI1 timing control register
+ */
+#define SPI1_MEM_C_TIMING_CALI_REG (DR_REG_FLASH_SPI1_BASE + 0x180)
+/** SPI1_MEM_C_TIMING_CALI : R/W; bitpos: [1]; default: 0;
+ *  The bit is used to enable timing auto-calibration for all reading operations.
+ */
+#define SPI1_MEM_C_TIMING_CALI    (BIT(1))
+#define SPI1_MEM_C_TIMING_CALI_M  (SPI1_MEM_C_TIMING_CALI_V << SPI1_MEM_C_TIMING_CALI_S)
+#define SPI1_MEM_C_TIMING_CALI_V  0x00000001U
+#define SPI1_MEM_C_TIMING_CALI_S  1
+/** SPI1_MEM_C_EXTRA_DUMMY_CYCLELEN : R/W; bitpos: [4:2]; default: 0;
+ *  add extra dummy spi clock cycle length for spi clock calibration.
+ */
+#define SPI1_MEM_C_EXTRA_DUMMY_CYCLELEN    0x00000007U
+#define SPI1_MEM_C_EXTRA_DUMMY_CYCLELEN_M  (SPI1_MEM_C_EXTRA_DUMMY_CYCLELEN_V << SPI1_MEM_C_EXTRA_DUMMY_CYCLELEN_S)
+#define SPI1_MEM_C_EXTRA_DUMMY_CYCLELEN_V  0x00000007U
+#define SPI1_MEM_C_EXTRA_DUMMY_CYCLELEN_S  2
+
+/** SPI1_MEM_C_CLOCK_GATE_REG register
+ *  SPI1 clk_gate register
+ */
+#define SPI1_MEM_C_CLOCK_GATE_REG (DR_REG_FLASH_SPI1_BASE + 0x200)
+/** SPI1_MEM_C_CLK_EN : R/W; bitpos: [0]; default: 1;
+ *  Register clock gate enable signal. 1: Enable. 0: Disable.
+ */
+#define SPI1_MEM_C_CLK_EN    (BIT(0))
+#define SPI1_MEM_C_CLK_EN_M  (SPI1_MEM_C_CLK_EN_V << SPI1_MEM_C_CLK_EN_S)
+#define SPI1_MEM_C_CLK_EN_V  0x00000001U
+#define SPI1_MEM_C_CLK_EN_S  0
+
+/** SPI1_MEM_C_DATE_REG register
+ *  Version control register
+ */
+#define SPI1_MEM_C_DATE_REG (DR_REG_FLASH_SPI1_BASE + 0x3fc)
+/** SPI1_MEM_C_DATE : R/W; bitpos: [27:0]; default: 37786176;
+ *  Version control register
+ */
+#define SPI1_MEM_C_DATE    0x0FFFFFFFU
+#define SPI1_MEM_C_DATE_M  (SPI1_MEM_C_DATE_V << SPI1_MEM_C_DATE_S)
+#define SPI1_MEM_C_DATE_V  0x0FFFFFFFU
+#define SPI1_MEM_C_DATE_S  0
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/target/esp32s31/include/soc/spi_mem_c_reg.h
+++ b/src/target/esp32s31/include/soc/spi_mem_c_reg.h
@@ -1,0 +1,6499 @@
+/**
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ *  SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "soc/soc.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** SPI_MEM_C_CMD_REG register
+ *  SPI0 FSM status register
+ */
+#define SPI_MEM_C_CMD_REG (DR_REG_FLASH_SPI0_BASE + 0x0)
+/** SPI_MEM_C_MST_ST : RO; bitpos: [3:0]; default: 0;
+ *  The current status of SPI0 master FSM: spi0_mst_st. 0: idle state, 1:SPI0_GRANT ,
+ *  2: program/erase suspend state, 3: SPI0 read data state, 4: wait cache/EDMA sent
+ *  data is stored in SPI0 TX FIFO, 5: SPI0 write data state.
+ */
+#define SPI_MEM_C_MST_ST    0x0000000FU
+#define SPI_MEM_C_MST_ST_M  (SPI_MEM_C_MST_ST_V << SPI_MEM_C_MST_ST_S)
+#define SPI_MEM_C_MST_ST_V  0x0000000FU
+#define SPI_MEM_C_MST_ST_S  0
+/** SPI_MEM_C_SLV_ST : RO; bitpos: [7:4]; default: 0;
+ *  The current status of SPI0 slave FSM: mspi_st. 0: idle state, 1: preparation state,
+ *  2: send command state, 3: send address state, 4: wait state, 5: read data state,
+ *  6:write data state, 7: done state, 8: read data end state.
+ */
+#define SPI_MEM_C_SLV_ST    0x0000000FU
+#define SPI_MEM_C_SLV_ST_M  (SPI_MEM_C_SLV_ST_V << SPI_MEM_C_SLV_ST_S)
+#define SPI_MEM_C_SLV_ST_V  0x0000000FU
+#define SPI_MEM_C_SLV_ST_S  4
+/** SPI_MEM_C_USR : HRO; bitpos: [18]; default: 0;
+ *  SPI0 USR_CMD start bit, only used when SPI_MEM_C_AXI_REQ_EN is cleared.  An operation
+ *  will be triggered when the bit is set. The bit will be cleared once the operation
+ *  done.1: enable 0: disable.
+ */
+#define SPI_MEM_C_USR    (BIT(18))
+#define SPI_MEM_C_USR_M  (SPI_MEM_C_USR_V << SPI_MEM_C_USR_S)
+#define SPI_MEM_C_USR_V  0x00000001U
+#define SPI_MEM_C_USR_S  18
+
+/** SPI_MEM_C_ADDR_REG register
+ *  SPI0 USR_CMD address register
+ */
+#define SPI_MEM_C_ADDR_REG (DR_REG_FLASH_SPI0_BASE + 0x4)
+/** SPI_MEM_C_USR_ADDR_VALUE : HRO; bitpos: [31:0]; default: 0;
+ *  In SPI0 USR_CMD mode when SPI_MEM_C_USR is set, it is the memory address.
+ */
+#define SPI_MEM_C_USR_ADDR_VALUE    0xFFFFFFFFU
+#define SPI_MEM_C_USR_ADDR_VALUE_M  (SPI_MEM_C_USR_ADDR_VALUE_V << SPI_MEM_C_USR_ADDR_VALUE_S)
+#define SPI_MEM_C_USR_ADDR_VALUE_V  0xFFFFFFFFU
+#define SPI_MEM_C_USR_ADDR_VALUE_S  0
+
+/** SPI_MEM_C_CTRL_REG register
+ *  SPI0 control register.
+ */
+#define SPI_MEM_C_CTRL_REG (DR_REG_FLASH_SPI0_BASE + 0x8)
+/** SPI_MEM_C_WDUMMY_DQS_ALWAYS_OUT : HRO; bitpos: [0]; default: 0;
+ *  In the dummy phase of an MSPI write data transfer when accesses to flash, the level
+ *  of SPI_DQS is output by the MSPI controller.
+ */
+#define SPI_MEM_C_WDUMMY_DQS_ALWAYS_OUT    (BIT(0))
+#define SPI_MEM_C_WDUMMY_DQS_ALWAYS_OUT_M  (SPI_MEM_C_WDUMMY_DQS_ALWAYS_OUT_V << SPI_MEM_C_WDUMMY_DQS_ALWAYS_OUT_S)
+#define SPI_MEM_C_WDUMMY_DQS_ALWAYS_OUT_V  0x00000001U
+#define SPI_MEM_C_WDUMMY_DQS_ALWAYS_OUT_S  0
+/** SPI_MEM_C_WDUMMY_ALWAYS_OUT : R/W; bitpos: [1]; default: 0;
+ *  In the dummy phase of an MSPI write data transfer when accesses to flash, the level
+ *  of SPI_IO[7:0] is output by the MSPI controller.
+ */
+#define SPI_MEM_C_WDUMMY_ALWAYS_OUT    (BIT(1))
+#define SPI_MEM_C_WDUMMY_ALWAYS_OUT_M  (SPI_MEM_C_WDUMMY_ALWAYS_OUT_V << SPI_MEM_C_WDUMMY_ALWAYS_OUT_S)
+#define SPI_MEM_C_WDUMMY_ALWAYS_OUT_V  0x00000001U
+#define SPI_MEM_C_WDUMMY_ALWAYS_OUT_S  1
+/** SPI_MEM_C_FDUMMY_RIN : R/W; bitpos: [2]; default: 1;
+ *  In an MSPI read data transfer when accesses to flash, the level of SPI_IO[7:0] is
+ *  output by the MSPI controller in the first half part of dummy phase. It is used to
+ *  mask invalid SPI_DQS in the half part of dummy phase.
+ */
+#define SPI_MEM_C_FDUMMY_RIN    (BIT(2))
+#define SPI_MEM_C_FDUMMY_RIN_M  (SPI_MEM_C_FDUMMY_RIN_V << SPI_MEM_C_FDUMMY_RIN_S)
+#define SPI_MEM_C_FDUMMY_RIN_V  0x00000001U
+#define SPI_MEM_C_FDUMMY_RIN_S  2
+/** SPI_MEM_C_FDUMMY_WOUT : R/W; bitpos: [3]; default: 1;
+ *  In an MSPI write data transfer when accesses to flash, the level of SPI_IO[7:0] is
+ *  output by the MSPI controller in the second half part of dummy phase. It is used to
+ *  pre-drive flash.
+ */
+#define SPI_MEM_C_FDUMMY_WOUT    (BIT(3))
+#define SPI_MEM_C_FDUMMY_WOUT_M  (SPI_MEM_C_FDUMMY_WOUT_V << SPI_MEM_C_FDUMMY_WOUT_S)
+#define SPI_MEM_C_FDUMMY_WOUT_V  0x00000001U
+#define SPI_MEM_C_FDUMMY_WOUT_S  3
+/** SPI_MEM_C_FDOUT_OCT : HRO; bitpos: [4]; default: 0;
+ *  Apply 8 signals during write-data phase 1:enable 0: disable
+ */
+#define SPI_MEM_C_FDOUT_OCT    (BIT(4))
+#define SPI_MEM_C_FDOUT_OCT_M  (SPI_MEM_C_FDOUT_OCT_V << SPI_MEM_C_FDOUT_OCT_S)
+#define SPI_MEM_C_FDOUT_OCT_V  0x00000001U
+#define SPI_MEM_C_FDOUT_OCT_S  4
+/** SPI_MEM_C_FDIN_OCT : HRO; bitpos: [5]; default: 0;
+ *  Apply 8 signals during read-data phase 1:enable 0: disable
+ */
+#define SPI_MEM_C_FDIN_OCT    (BIT(5))
+#define SPI_MEM_C_FDIN_OCT_M  (SPI_MEM_C_FDIN_OCT_V << SPI_MEM_C_FDIN_OCT_S)
+#define SPI_MEM_C_FDIN_OCT_V  0x00000001U
+#define SPI_MEM_C_FDIN_OCT_S  5
+/** SPI_MEM_C_FADDR_OCT : HRO; bitpos: [6]; default: 0;
+ *  Apply 8 signals during address phase 1:enable 0: disable
+ */
+#define SPI_MEM_C_FADDR_OCT    (BIT(6))
+#define SPI_MEM_C_FADDR_OCT_M  (SPI_MEM_C_FADDR_OCT_V << SPI_MEM_C_FADDR_OCT_S)
+#define SPI_MEM_C_FADDR_OCT_V  0x00000001U
+#define SPI_MEM_C_FADDR_OCT_S  6
+/** SPI_MEM_C_FCMD_QUAD : R/W; bitpos: [8]; default: 0;
+ *  Apply 4 signals during command phase 1:enable 0: disable
+ */
+#define SPI_MEM_C_FCMD_QUAD    (BIT(8))
+#define SPI_MEM_C_FCMD_QUAD_M  (SPI_MEM_C_FCMD_QUAD_V << SPI_MEM_C_FCMD_QUAD_S)
+#define SPI_MEM_C_FCMD_QUAD_V  0x00000001U
+#define SPI_MEM_C_FCMD_QUAD_S  8
+/** SPI_MEM_C_FCMD_OCT : HRO; bitpos: [9]; default: 0;
+ *  Apply 8 signals during command phase 1:enable 0: disable
+ */
+#define SPI_MEM_C_FCMD_OCT    (BIT(9))
+#define SPI_MEM_C_FCMD_OCT_M  (SPI_MEM_C_FCMD_OCT_V << SPI_MEM_C_FCMD_OCT_S)
+#define SPI_MEM_C_FCMD_OCT_V  0x00000001U
+#define SPI_MEM_C_FCMD_OCT_S  9
+/** SPI_MEM_C_FASTRD_MODE : R/W; bitpos: [13]; default: 1;
+ *  This bit enable the bits: SPI_MEM_C_FREAD_QIO, SPI_MEM_C_FREAD_DIO, SPI_MEM_C_FREAD_QOUT
+ *  and SPI_MEM_C_FREAD_DOUT. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_FASTRD_MODE    (BIT(13))
+#define SPI_MEM_C_FASTRD_MODE_M  (SPI_MEM_C_FASTRD_MODE_V << SPI_MEM_C_FASTRD_MODE_S)
+#define SPI_MEM_C_FASTRD_MODE_V  0x00000001U
+#define SPI_MEM_C_FASTRD_MODE_S  13
+/** SPI_MEM_C_FREAD_DUAL : R/W; bitpos: [14]; default: 0;
+ *  In the read operations, read-data phase apply 2 signals. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_FREAD_DUAL    (BIT(14))
+#define SPI_MEM_C_FREAD_DUAL_M  (SPI_MEM_C_FREAD_DUAL_V << SPI_MEM_C_FREAD_DUAL_S)
+#define SPI_MEM_C_FREAD_DUAL_V  0x00000001U
+#define SPI_MEM_C_FREAD_DUAL_S  14
+/** SPI_MEM_C_Q_POL : R/W; bitpos: [18]; default: 1;
+ *  The bit is used to set MISO line polarity, 1: high 0, low
+ */
+#define SPI_MEM_C_Q_POL    (BIT(18))
+#define SPI_MEM_C_Q_POL_M  (SPI_MEM_C_Q_POL_V << SPI_MEM_C_Q_POL_S)
+#define SPI_MEM_C_Q_POL_V  0x00000001U
+#define SPI_MEM_C_Q_POL_S  18
+/** SPI_MEM_C_D_POL : R/W; bitpos: [19]; default: 1;
+ *  The bit is used to set MOSI line polarity, 1: high 0, low
+ */
+#define SPI_MEM_C_D_POL    (BIT(19))
+#define SPI_MEM_C_D_POL_M  (SPI_MEM_C_D_POL_V << SPI_MEM_C_D_POL_S)
+#define SPI_MEM_C_D_POL_V  0x00000001U
+#define SPI_MEM_C_D_POL_S  19
+/** SPI_MEM_C_FREAD_QUAD : R/W; bitpos: [20]; default: 0;
+ *  In the read operations read-data phase apply 4 signals. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_FREAD_QUAD    (BIT(20))
+#define SPI_MEM_C_FREAD_QUAD_M  (SPI_MEM_C_FREAD_QUAD_V << SPI_MEM_C_FREAD_QUAD_S)
+#define SPI_MEM_C_FREAD_QUAD_V  0x00000001U
+#define SPI_MEM_C_FREAD_QUAD_S  20
+/** SPI_MEM_C_WP_REG : R/W; bitpos: [21]; default: 1;
+ *  Write protect signal output when SPI is idle.  1: output high, 0: output low.
+ */
+#define SPI_MEM_C_WP_REG    (BIT(21))
+#define SPI_MEM_C_WP_REG_M  (SPI_MEM_C_WP_REG_V << SPI_MEM_C_WP_REG_S)
+#define SPI_MEM_C_WP_REG_V  0x00000001U
+#define SPI_MEM_C_WP_REG_S  21
+/** SPI_MEM_C_FREAD_DIO : R/W; bitpos: [23]; default: 0;
+ *  In the read operations address phase and read-data phase apply 2 signals. 1: enable
+ *  0: disable.
+ */
+#define SPI_MEM_C_FREAD_DIO    (BIT(23))
+#define SPI_MEM_C_FREAD_DIO_M  (SPI_MEM_C_FREAD_DIO_V << SPI_MEM_C_FREAD_DIO_S)
+#define SPI_MEM_C_FREAD_DIO_V  0x00000001U
+#define SPI_MEM_C_FREAD_DIO_S  23
+/** SPI_MEM_C_FREAD_QIO : R/W; bitpos: [24]; default: 0;
+ *  In the read operations address phase and read-data phase apply 4 signals. 1: enable
+ *  0: disable.
+ */
+#define SPI_MEM_C_FREAD_QIO    (BIT(24))
+#define SPI_MEM_C_FREAD_QIO_M  (SPI_MEM_C_FREAD_QIO_V << SPI_MEM_C_FREAD_QIO_S)
+#define SPI_MEM_C_FREAD_QIO_V  0x00000001U
+#define SPI_MEM_C_FREAD_QIO_S  24
+/** SPI_MEM_C_DQS_IE_ALWAYS_ON : HRO; bitpos: [30]; default: 0;
+ *  When accesses to flash, 1: the IE signals of pads connected to SPI_DQS are always
+ *  1. 0: Others.
+ */
+#define SPI_MEM_C_DQS_IE_ALWAYS_ON    (BIT(30))
+#define SPI_MEM_C_DQS_IE_ALWAYS_ON_M  (SPI_MEM_C_DQS_IE_ALWAYS_ON_V << SPI_MEM_C_DQS_IE_ALWAYS_ON_S)
+#define SPI_MEM_C_DQS_IE_ALWAYS_ON_V  0x00000001U
+#define SPI_MEM_C_DQS_IE_ALWAYS_ON_S  30
+/** SPI_MEM_C_DATA_IE_ALWAYS_ON : R/W; bitpos: [31]; default: 1;
+ *  When accesses to flash, 1: the IE signals of pads connected to SPI_IO[7:0] are
+ *  always 1. 0: Others.
+ */
+#define SPI_MEM_C_DATA_IE_ALWAYS_ON    (BIT(31))
+#define SPI_MEM_C_DATA_IE_ALWAYS_ON_M  (SPI_MEM_C_DATA_IE_ALWAYS_ON_V << SPI_MEM_C_DATA_IE_ALWAYS_ON_S)
+#define SPI_MEM_C_DATA_IE_ALWAYS_ON_V  0x00000001U
+#define SPI_MEM_C_DATA_IE_ALWAYS_ON_S  31
+
+/** SPI_MEM_C_CTRL1_REG register
+ *  SPI0 control1 register.
+ */
+#define SPI_MEM_C_CTRL1_REG (DR_REG_FLASH_SPI0_BASE + 0xc)
+/** SPI_MEM_C_CLK_MODE : R/W; bitpos: [1:0]; default: 0;
+ *  SPI clock mode bits. 0: SPI clock is off when CS inactive 1: SPI clock is delayed
+ *  one cycle after CS inactive 2: SPI clock is delayed two cycles after CS inactive 3:
+ *  SPI clock is always on.
+ */
+#define SPI_MEM_C_CLK_MODE    0x00000003U
+#define SPI_MEM_C_CLK_MODE_M  (SPI_MEM_C_CLK_MODE_V << SPI_MEM_C_CLK_MODE_S)
+#define SPI_MEM_C_CLK_MODE_V  0x00000003U
+#define SPI_MEM_C_CLK_MODE_S  0
+/** SPI_AR_SIZE0_1_SUPPORT_EN : R/W; bitpos: [22]; default: 1;
+ *  1: MSPI supports ARSIZE 0~3. When ARSIZE =0~2, MSPI read address is 4*n and reply
+ *  the real AXI read data back. 0: When ARSIZE 0~1, MSPI reply SLV_ERR.
+ */
+#define SPI_AR_SIZE0_1_SUPPORT_EN    (BIT(22))
+#define SPI_AR_SIZE0_1_SUPPORT_EN_M  (SPI_AR_SIZE0_1_SUPPORT_EN_V << SPI_AR_SIZE0_1_SUPPORT_EN_S)
+#define SPI_AR_SIZE0_1_SUPPORT_EN_V  0x00000001U
+#define SPI_AR_SIZE0_1_SUPPORT_EN_S  22
+/** SPI_AW_SIZE0_1_SUPPORT_EN : R/W; bitpos: [23]; default: 1;
+ *  1: MSPI supports AWSIZE 0~3. 0: When AWSIZE 0~1, MSPI reply SLV_ERR.
+ */
+#define SPI_AW_SIZE0_1_SUPPORT_EN    (BIT(23))
+#define SPI_AW_SIZE0_1_SUPPORT_EN_M  (SPI_AW_SIZE0_1_SUPPORT_EN_V << SPI_AW_SIZE0_1_SUPPORT_EN_S)
+#define SPI_AW_SIZE0_1_SUPPORT_EN_V  0x00000001U
+#define SPI_AW_SIZE0_1_SUPPORT_EN_S  23
+/** SPI_MEM_C_RRESP_ECC_ERR_EN : R/W; bitpos: [24]; default: 0;
+ *  1: RRESP is SLV_ERR when there is a ECC error in AXI read data. 0: RRESP is OKAY
+ *  when there is a ECC error in AXI read data. The ECC error information is recorded
+ *  in SPI_MEM_C_ECC_ERR_ADDR_REG.
+ */
+#define SPI_MEM_C_RRESP_ECC_ERR_EN    (BIT(24))
+#define SPI_MEM_C_RRESP_ECC_ERR_EN_M  (SPI_MEM_C_RRESP_ECC_ERR_EN_V << SPI_MEM_C_RRESP_ECC_ERR_EN_S)
+#define SPI_MEM_C_RRESP_ECC_ERR_EN_V  0x00000001U
+#define SPI_MEM_C_RRESP_ECC_ERR_EN_S  24
+/** SPI_MEM_C_AR_SPLICE_EN : R/W; bitpos: [25]; default: 0;
+ *  Set this bit to enable AXI Read Splice-transfer.
+ */
+#define SPI_MEM_C_AR_SPLICE_EN    (BIT(25))
+#define SPI_MEM_C_AR_SPLICE_EN_M  (SPI_MEM_C_AR_SPLICE_EN_V << SPI_MEM_C_AR_SPLICE_EN_S)
+#define SPI_MEM_C_AR_SPLICE_EN_V  0x00000001U
+#define SPI_MEM_C_AR_SPLICE_EN_S  25
+/** SPI_MEM_C_AW_SPLICE_EN : R/W; bitpos: [26]; default: 0;
+ *  Set this bit to enable AXI Write Splice-transfer.
+ */
+#define SPI_MEM_C_AW_SPLICE_EN    (BIT(26))
+#define SPI_MEM_C_AW_SPLICE_EN_M  (SPI_MEM_C_AW_SPLICE_EN_V << SPI_MEM_C_AW_SPLICE_EN_S)
+#define SPI_MEM_C_AW_SPLICE_EN_V  0x00000001U
+#define SPI_MEM_C_AW_SPLICE_EN_S  26
+/** SPI_MEM_C_RAM0_EN : HRO; bitpos: [27]; default: 1;
+ *  When SPI_MEM_C_DUAL_RAM_EN is 0 and SPI_MEM_C_RAM0_EN is 1, only EXT_RAM0 will be
+ *  accessed. When SPI_MEM_C_DUAL_RAM_EN is 0 and SPI_MEM_C_RAM0_EN is 0, only EXT_RAM1
+ *  will be accessed. When SPI_MEM_C_DUAL_RAM_EN is 1,  EXT_RAM0 and EXT_RAM1 will be
+ *  accessed at the same time.
+ */
+#define SPI_MEM_C_RAM0_EN    (BIT(27))
+#define SPI_MEM_C_RAM0_EN_M  (SPI_MEM_C_RAM0_EN_V << SPI_MEM_C_RAM0_EN_S)
+#define SPI_MEM_C_RAM0_EN_V  0x00000001U
+#define SPI_MEM_C_RAM0_EN_S  27
+/** SPI_MEM_C_DUAL_RAM_EN : HRO; bitpos: [28]; default: 0;
+ *  Set this bit to enable DUAL-RAM mode, EXT_RAM0 and EXT_RAM1 will be accessed at the
+ *  same time.
+ */
+#define SPI_MEM_C_DUAL_RAM_EN    (BIT(28))
+#define SPI_MEM_C_DUAL_RAM_EN_M  (SPI_MEM_C_DUAL_RAM_EN_V << SPI_MEM_C_DUAL_RAM_EN_S)
+#define SPI_MEM_C_DUAL_RAM_EN_V  0x00000001U
+#define SPI_MEM_C_DUAL_RAM_EN_S  28
+/** SPI_MEM_C_FAST_WRITE_EN : R/W; bitpos: [29]; default: 1;
+ *  Set this bit to write data faster, do not wait write data has been stored in
+ *  tx_bus_fifo_l2. It will wait 4*T_clk_ctrl to insure the write data has been stored
+ *  in  tx_bus_fifo_l2.
+ */
+#define SPI_MEM_C_FAST_WRITE_EN    (BIT(29))
+#define SPI_MEM_C_FAST_WRITE_EN_M  (SPI_MEM_C_FAST_WRITE_EN_V << SPI_MEM_C_FAST_WRITE_EN_S)
+#define SPI_MEM_C_FAST_WRITE_EN_V  0x00000001U
+#define SPI_MEM_C_FAST_WRITE_EN_S  29
+/** SPI_MEM_C_RXFIFO_RST : WT; bitpos: [30]; default: 0;
+ *  The synchronous reset signal for SPI0 RX AFIFO and all the AES_MSPI SYNC FIFO to
+ *  receive signals from AXI.  Set this bit to reset these FIFO.
+ */
+#define SPI_MEM_C_RXFIFO_RST    (BIT(30))
+#define SPI_MEM_C_RXFIFO_RST_M  (SPI_MEM_C_RXFIFO_RST_V << SPI_MEM_C_RXFIFO_RST_S)
+#define SPI_MEM_C_RXFIFO_RST_V  0x00000001U
+#define SPI_MEM_C_RXFIFO_RST_S  30
+/** SPI_MEM_C_TXFIFO_RST : WT; bitpos: [31]; default: 0;
+ *  The synchronous reset signal for SPI0 TX AFIFO and all the AES_MSPI SYNC FIFO to
+ *  send signals to AXI. Set this bit to reset these FIFO.
+ */
+#define SPI_MEM_C_TXFIFO_RST    (BIT(31))
+#define SPI_MEM_C_TXFIFO_RST_M  (SPI_MEM_C_TXFIFO_RST_V << SPI_MEM_C_TXFIFO_RST_S)
+#define SPI_MEM_C_TXFIFO_RST_V  0x00000001U
+#define SPI_MEM_C_TXFIFO_RST_S  31
+
+/** SPI_MEM_C_CTRL2_REG register
+ *  SPI0 control2 register.
+ */
+#define SPI_MEM_C_CTRL2_REG (DR_REG_FLASH_SPI0_BASE + 0x10)
+/** SPI_MEM_C_CS_SETUP_TIME : R/W; bitpos: [4:0]; default: 1;
+ *  (cycles-1) of prepare phase by SPI Bus clock, this bits are combined with
+ *  SPI_MEM_C_CS_SETUP bit.
+ */
+#define SPI_MEM_C_CS_SETUP_TIME    0x0000001FU
+#define SPI_MEM_C_CS_SETUP_TIME_M  (SPI_MEM_C_CS_SETUP_TIME_V << SPI_MEM_C_CS_SETUP_TIME_S)
+#define SPI_MEM_C_CS_SETUP_TIME_V  0x0000001FU
+#define SPI_MEM_C_CS_SETUP_TIME_S  0
+/** SPI_MEM_C_CS_HOLD_TIME : R/W; bitpos: [9:5]; default: 1;
+ *  SPI CS signal is delayed to inactive by SPI bus clock, this bits are combined with
+ *  SPI_MEM_C_CS_HOLD bit.
+ */
+#define SPI_MEM_C_CS_HOLD_TIME    0x0000001FU
+#define SPI_MEM_C_CS_HOLD_TIME_M  (SPI_MEM_C_CS_HOLD_TIME_V << SPI_MEM_C_CS_HOLD_TIME_S)
+#define SPI_MEM_C_CS_HOLD_TIME_V  0x0000001FU
+#define SPI_MEM_C_CS_HOLD_TIME_S  5
+/** SPI_MEM_C_ECC_CS_HOLD_TIME : HRO; bitpos: [12:10]; default: 3;
+ *  SPI_MEM_C_CS_HOLD_TIME + SPI_MEM_C_ECC_CS_HOLD_TIME is the SPI0 CS hold cycle in ECC
+ *  mode when accessed flash.
+ */
+#define SPI_MEM_C_ECC_CS_HOLD_TIME    0x00000007U
+#define SPI_MEM_C_ECC_CS_HOLD_TIME_M  (SPI_MEM_C_ECC_CS_HOLD_TIME_V << SPI_MEM_C_ECC_CS_HOLD_TIME_S)
+#define SPI_MEM_C_ECC_CS_HOLD_TIME_V  0x00000007U
+#define SPI_MEM_C_ECC_CS_HOLD_TIME_S  10
+/** SPI_MEM_C_ECC_SKIP_PAGE_CORNER : HRO; bitpos: [13]; default: 1;
+ *  1: SPI0 and SPI1 skip page corner when accesses flash. 0: Not skip page corner when
+ *  accesses flash.
+ */
+#define SPI_MEM_C_ECC_SKIP_PAGE_CORNER    (BIT(13))
+#define SPI_MEM_C_ECC_SKIP_PAGE_CORNER_M  (SPI_MEM_C_ECC_SKIP_PAGE_CORNER_V << SPI_MEM_C_ECC_SKIP_PAGE_CORNER_S)
+#define SPI_MEM_C_ECC_SKIP_PAGE_CORNER_V  0x00000001U
+#define SPI_MEM_C_ECC_SKIP_PAGE_CORNER_S  13
+/** SPI_MEM_C_ECC_16TO18_BYTE_EN : HRO; bitpos: [14]; default: 0;
+ *  Set this bit to enable SPI0 and SPI1 ECC 16 bytes data with 2 ECC bytes mode when
+ *  accesses flash.
+ */
+#define SPI_MEM_C_ECC_16TO18_BYTE_EN    (BIT(14))
+#define SPI_MEM_C_ECC_16TO18_BYTE_EN_M  (SPI_MEM_C_ECC_16TO18_BYTE_EN_V << SPI_MEM_C_ECC_16TO18_BYTE_EN_S)
+#define SPI_MEM_C_ECC_16TO18_BYTE_EN_V  0x00000001U
+#define SPI_MEM_C_ECC_16TO18_BYTE_EN_S  14
+/** SPI_MEM_C_SPLIT_TRANS_EN : R/W; bitpos: [24]; default: 0;
+ *  Set this bit to enable SPI0 split one AXI read flash transfer into two SPI
+ *  transfers when one transfer will cross flash or EXT_RAM page corner, valid no
+ *  matter whether there is an ECC region or not.
+ */
+#define SPI_MEM_C_SPLIT_TRANS_EN    (BIT(24))
+#define SPI_MEM_C_SPLIT_TRANS_EN_M  (SPI_MEM_C_SPLIT_TRANS_EN_V << SPI_MEM_C_SPLIT_TRANS_EN_S)
+#define SPI_MEM_C_SPLIT_TRANS_EN_V  0x00000001U
+#define SPI_MEM_C_SPLIT_TRANS_EN_S  24
+/** SPI_MEM_C_CS_HOLD_DELAY : R/W; bitpos: [30:25]; default: 0;
+ *  These bits are used to set the minimum CS high time tSHSL between SPI burst
+ *  transfer when accesses to flash. tSHSL is (SPI_MEM_C_CS_HOLD_DELAY[5:0] + 1) MSPI
+ *  core clock cycles.
+ */
+#define SPI_MEM_C_CS_HOLD_DELAY    0x0000003FU
+#define SPI_MEM_C_CS_HOLD_DELAY_M  (SPI_MEM_C_CS_HOLD_DELAY_V << SPI_MEM_C_CS_HOLD_DELAY_S)
+#define SPI_MEM_C_CS_HOLD_DELAY_V  0x0000003FU
+#define SPI_MEM_C_CS_HOLD_DELAY_S  25
+/** SPI_MEM_C_SYNC_RESET : WT; bitpos: [31]; default: 0;
+ *  The spi0_mst_st and spi0_slv_st will be reset.
+ */
+#define SPI_MEM_C_SYNC_RESET    (BIT(31))
+#define SPI_MEM_C_SYNC_RESET_M  (SPI_MEM_C_SYNC_RESET_V << SPI_MEM_C_SYNC_RESET_S)
+#define SPI_MEM_C_SYNC_RESET_V  0x00000001U
+#define SPI_MEM_C_SYNC_RESET_S  31
+
+/** SPI_MEM_C_CLOCK_REG register
+ *  SPI clock division control register.
+ */
+#define SPI_MEM_C_CLOCK_REG (DR_REG_FLASH_SPI0_BASE + 0x14)
+/** SPI_MEM_C_CLKCNT_L : R/W; bitpos: [7:0]; default: 3;
+ *  In the master mode it must be equal to SPI_MEM_C_CLKCNT_N.
+ */
+#define SPI_MEM_C_CLKCNT_L    0x000000FFU
+#define SPI_MEM_C_CLKCNT_L_M  (SPI_MEM_C_CLKCNT_L_V << SPI_MEM_C_CLKCNT_L_S)
+#define SPI_MEM_C_CLKCNT_L_V  0x000000FFU
+#define SPI_MEM_C_CLKCNT_L_S  0
+/** SPI_MEM_C_CLKCNT_H : R/W; bitpos: [15:8]; default: 1;
+ *  In the master mode it must be floor((SPI_MEM_C_CLKCNT_N+1)/2-1).
+ */
+#define SPI_MEM_C_CLKCNT_H    0x000000FFU
+#define SPI_MEM_C_CLKCNT_H_M  (SPI_MEM_C_CLKCNT_H_V << SPI_MEM_C_CLKCNT_H_S)
+#define SPI_MEM_C_CLKCNT_H_V  0x000000FFU
+#define SPI_MEM_C_CLKCNT_H_S  8
+/** SPI_MEM_C_CLKCNT_N : R/W; bitpos: [23:16]; default: 3;
+ *  In the master mode it is the divider of spi_mem_clk. So spi_mem_clk frequency is
+ *  system/(SPI_MEM_C_CLKCNT_N+1)
+ */
+#define SPI_MEM_C_CLKCNT_N    0x000000FFU
+#define SPI_MEM_C_CLKCNT_N_M  (SPI_MEM_C_CLKCNT_N_V << SPI_MEM_C_CLKCNT_N_S)
+#define SPI_MEM_C_CLKCNT_N_V  0x000000FFU
+#define SPI_MEM_C_CLKCNT_N_S  16
+/** SPI_MEM_C_CLK_EQU_SYSCLK : R/W; bitpos: [31]; default: 0;
+ *  1: 1-division mode, the frequency of SPI bus clock equals to that of MSPI module
+ *  clock.
+ */
+#define SPI_MEM_C_CLK_EQU_SYSCLK    (BIT(31))
+#define SPI_MEM_C_CLK_EQU_SYSCLK_M  (SPI_MEM_C_CLK_EQU_SYSCLK_V << SPI_MEM_C_CLK_EQU_SYSCLK_S)
+#define SPI_MEM_C_CLK_EQU_SYSCLK_V  0x00000001U
+#define SPI_MEM_C_CLK_EQU_SYSCLK_S  31
+
+/** SPI_MEM_C_USER_REG register
+ *  SPI0 user register.
+ */
+#define SPI_MEM_C_USER_REG (DR_REG_FLASH_SPI0_BASE + 0x18)
+/** SPI_MEM_C_CS_HOLD : R/W; bitpos: [6]; default: 0;
+ *  spi cs keep low when spi is in  done  phase. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_CS_HOLD    (BIT(6))
+#define SPI_MEM_C_CS_HOLD_M  (SPI_MEM_C_CS_HOLD_V << SPI_MEM_C_CS_HOLD_S)
+#define SPI_MEM_C_CS_HOLD_V  0x00000001U
+#define SPI_MEM_C_CS_HOLD_S  6
+/** SPI_MEM_C_CS_SETUP : R/W; bitpos: [7]; default: 0;
+ *  spi cs is enable when spi is in  prepare  phase. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_CS_SETUP    (BIT(7))
+#define SPI_MEM_C_CS_SETUP_M  (SPI_MEM_C_CS_SETUP_V << SPI_MEM_C_CS_SETUP_S)
+#define SPI_MEM_C_CS_SETUP_V  0x00000001U
+#define SPI_MEM_C_CS_SETUP_S  7
+/** SPI_MEM_C_CK_OUT_EDGE : R/W; bitpos: [9]; default: 0;
+ *  The bit combined with SPI_MEM_C_CK_IDLE_EDGE bit to control SPI clock mode 0~3.
+ */
+#define SPI_MEM_C_CK_OUT_EDGE    (BIT(9))
+#define SPI_MEM_C_CK_OUT_EDGE_M  (SPI_MEM_C_CK_OUT_EDGE_V << SPI_MEM_C_CK_OUT_EDGE_S)
+#define SPI_MEM_C_CK_OUT_EDGE_V  0x00000001U
+#define SPI_MEM_C_CK_OUT_EDGE_S  9
+/** SPI_MEM_C_USR_DUMMY_IDLE : R/W; bitpos: [26]; default: 0;
+ *  spi clock is disable in dummy phase when the bit is enable.
+ */
+#define SPI_MEM_C_USR_DUMMY_IDLE    (BIT(26))
+#define SPI_MEM_C_USR_DUMMY_IDLE_M  (SPI_MEM_C_USR_DUMMY_IDLE_V << SPI_MEM_C_USR_DUMMY_IDLE_S)
+#define SPI_MEM_C_USR_DUMMY_IDLE_V  0x00000001U
+#define SPI_MEM_C_USR_DUMMY_IDLE_S  26
+/** SPI_MEM_C_USR_DUMMY : R/W; bitpos: [29]; default: 0;
+ *  This bit enable the dummy phase of an operation.
+ */
+#define SPI_MEM_C_USR_DUMMY    (BIT(29))
+#define SPI_MEM_C_USR_DUMMY_M  (SPI_MEM_C_USR_DUMMY_V << SPI_MEM_C_USR_DUMMY_S)
+#define SPI_MEM_C_USR_DUMMY_V  0x00000001U
+#define SPI_MEM_C_USR_DUMMY_S  29
+
+/** SPI_MEM_C_USER1_REG register
+ *  SPI0 user1 register.
+ */
+#define SPI_MEM_C_USER1_REG (DR_REG_FLASH_SPI0_BASE + 0x1c)
+/** SPI_MEM_C_USR_DUMMY_CYCLELEN : R/W; bitpos: [5:0]; default: 7;
+ *  The length in spi_mem_clk cycles of dummy phase. The register value shall be
+ *  (cycle_num-1).
+ */
+#define SPI_MEM_C_USR_DUMMY_CYCLELEN    0x0000003FU
+#define SPI_MEM_C_USR_DUMMY_CYCLELEN_M  (SPI_MEM_C_USR_DUMMY_CYCLELEN_V << SPI_MEM_C_USR_DUMMY_CYCLELEN_S)
+#define SPI_MEM_C_USR_DUMMY_CYCLELEN_V  0x0000003FU
+#define SPI_MEM_C_USR_DUMMY_CYCLELEN_S  0
+/** SPI_MEM_C_USR_DBYTELEN : HRO; bitpos: [11:6]; default: 1;
+ *  SPI0 USR_CMD read or write data byte length -1
+ */
+#define SPI_MEM_C_USR_DBYTELEN    0x0000003FU
+#define SPI_MEM_C_USR_DBYTELEN_M  (SPI_MEM_C_USR_DBYTELEN_V << SPI_MEM_C_USR_DBYTELEN_S)
+#define SPI_MEM_C_USR_DBYTELEN_V  0x0000003FU
+#define SPI_MEM_C_USR_DBYTELEN_S  6
+/** SPI_MEM_C_USR_ADDR_BITLEN : R/W; bitpos: [31:26]; default: 23;
+ *  The length in bits of address phase. The register value shall be (bit_num-1).
+ */
+#define SPI_MEM_C_USR_ADDR_BITLEN    0x0000003FU
+#define SPI_MEM_C_USR_ADDR_BITLEN_M  (SPI_MEM_C_USR_ADDR_BITLEN_V << SPI_MEM_C_USR_ADDR_BITLEN_S)
+#define SPI_MEM_C_USR_ADDR_BITLEN_V  0x0000003FU
+#define SPI_MEM_C_USR_ADDR_BITLEN_S  26
+
+/** SPI_MEM_C_USER2_REG register
+ *  SPI0 user2 register.
+ */
+#define SPI_MEM_C_USER2_REG (DR_REG_FLASH_SPI0_BASE + 0x20)
+/** SPI_MEM_C_USR_COMMAND_VALUE : R/W; bitpos: [15:0]; default: 0;
+ *  The value of  command.
+ */
+#define SPI_MEM_C_USR_COMMAND_VALUE    0x0000FFFFU
+#define SPI_MEM_C_USR_COMMAND_VALUE_M  (SPI_MEM_C_USR_COMMAND_VALUE_V << SPI_MEM_C_USR_COMMAND_VALUE_S)
+#define SPI_MEM_C_USR_COMMAND_VALUE_V  0x0000FFFFU
+#define SPI_MEM_C_USR_COMMAND_VALUE_S  0
+/** SPI_MEM_C_USR_COMMAND_BITLEN : R/W; bitpos: [31:28]; default: 7;
+ *  The length in bits of command phase. The register value shall be (bit_num-1)
+ */
+#define SPI_MEM_C_USR_COMMAND_BITLEN    0x0000000FU
+#define SPI_MEM_C_USR_COMMAND_BITLEN_M  (SPI_MEM_C_USR_COMMAND_BITLEN_V << SPI_MEM_C_USR_COMMAND_BITLEN_S)
+#define SPI_MEM_C_USR_COMMAND_BITLEN_V  0x0000000FU
+#define SPI_MEM_C_USR_COMMAND_BITLEN_S  28
+
+/** SPI_MEM_C_RD_STATUS_REG register
+ *  SPI0 read control register.
+ *  This register is only for internal debugging purposes. Do not use it in
+ *  applications.
+ */
+#define SPI_MEM_C_RD_STATUS_REG (DR_REG_FLASH_SPI0_BASE + 0x2c)
+/** SPI_MEM_C_WB_MODE : R/W; bitpos: [23:16]; default: 0;
+ *  Mode bits in the flash fast read mode  it is combined with spi_mem_fastrd_mode bit.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_WB_MODE    0x000000FFU
+#define SPI_MEM_C_WB_MODE_M  (SPI_MEM_C_WB_MODE_V << SPI_MEM_C_WB_MODE_S)
+#define SPI_MEM_C_WB_MODE_V  0x000000FFU
+#define SPI_MEM_C_WB_MODE_S  16
+/** SPI_MEM_C_WB_MODE_BITLEN : R/W; bitpos: [26:24]; default: 0;
+ *  Mode bits length for flash fast read mode.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_WB_MODE_BITLEN    0x00000007U
+#define SPI_MEM_C_WB_MODE_BITLEN_M  (SPI_MEM_C_WB_MODE_BITLEN_V << SPI_MEM_C_WB_MODE_BITLEN_S)
+#define SPI_MEM_C_WB_MODE_BITLEN_V  0x00000007U
+#define SPI_MEM_C_WB_MODE_BITLEN_S  24
+/** SPI_MEM_C_WB_MODE_EN : R/W; bitpos: [27]; default: 0;
+ *  Mode bits is valid while this bit is enable. 1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_WB_MODE_EN    (BIT(27))
+#define SPI_MEM_C_WB_MODE_EN_M  (SPI_MEM_C_WB_MODE_EN_V << SPI_MEM_C_WB_MODE_EN_S)
+#define SPI_MEM_C_WB_MODE_EN_V  0x00000001U
+#define SPI_MEM_C_WB_MODE_EN_S  27
+
+/** SPI_MEM_C_MISC_REG register
+ *  SPI0 misc register
+ */
+#define SPI_MEM_C_MISC_REG (DR_REG_FLASH_SPI0_BASE + 0x34)
+/** SPI_MEM_C_DQ_OE_CTRL : HRO; bitpos: [4]; default: 1;
+ *  For SPI BUS IO,  APB ctrl IO DQ OE func.1: enable 0: disable.
+ */
+#define SPI_MEM_C_DQ_OE_CTRL    (BIT(4))
+#define SPI_MEM_C_DQ_OE_CTRL_M  (SPI_MEM_C_DQ_OE_CTRL_V << SPI_MEM_C_DQ_OE_CTRL_S)
+#define SPI_MEM_C_DQ_OE_CTRL_V  0x00000001U
+#define SPI_MEM_C_DQ_OE_CTRL_S  4
+/** SPI_MEM_C_CK_OE_CTRL : HRO; bitpos: [5]; default: 1;
+ *  For SPI BUS IO,  APB ctrl IO CK OE func.1: enable 0: disable.
+ */
+#define SPI_MEM_C_CK_OE_CTRL    (BIT(5))
+#define SPI_MEM_C_CK_OE_CTRL_M  (SPI_MEM_C_CK_OE_CTRL_V << SPI_MEM_C_CK_OE_CTRL_S)
+#define SPI_MEM_C_CK_OE_CTRL_V  0x00000001U
+#define SPI_MEM_C_CK_OE_CTRL_S  5
+/** SPI_MEM_C_CS_OE_CTRL : HRO; bitpos: [6]; default: 1;
+ *  For SPI BUS IO,  APB ctrl IO CS OE func.1: enable 0: disable.
+ */
+#define SPI_MEM_C_CS_OE_CTRL    (BIT(6))
+#define SPI_MEM_C_CS_OE_CTRL_M  (SPI_MEM_C_CS_OE_CTRL_V << SPI_MEM_C_CS_OE_CTRL_S)
+#define SPI_MEM_C_CS_OE_CTRL_V  0x00000001U
+#define SPI_MEM_C_CS_OE_CTRL_S  6
+/** SPI_MEM_C_FSUB_PIN : HRO; bitpos: [7]; default: 0;
+ *  For SPI0,  flash is connected to SUBPINs.
+ */
+#define SPI_MEM_C_FSUB_PIN    (BIT(7))
+#define SPI_MEM_C_FSUB_PIN_M  (SPI_MEM_C_FSUB_PIN_V << SPI_MEM_C_FSUB_PIN_S)
+#define SPI_MEM_C_FSUB_PIN_V  0x00000001U
+#define SPI_MEM_C_FSUB_PIN_S  7
+/** SPI_MEM_C_SSUB_PIN : HRO; bitpos: [8]; default: 0;
+ *  For SPI0,  sram is connected to SUBPINs.
+ */
+#define SPI_MEM_C_SSUB_PIN    (BIT(8))
+#define SPI_MEM_C_SSUB_PIN_M  (SPI_MEM_C_SSUB_PIN_V << SPI_MEM_C_SSUB_PIN_S)
+#define SPI_MEM_C_SSUB_PIN_V  0x00000001U
+#define SPI_MEM_C_SSUB_PIN_S  8
+/** SPI_MEM_C_CK_IDLE_EDGE : R/W; bitpos: [9]; default: 0;
+ *  1: SPI_CLK line is high when idle     0: spi clk line is low when idle
+ */
+#define SPI_MEM_C_CK_IDLE_EDGE    (BIT(9))
+#define SPI_MEM_C_CK_IDLE_EDGE_M  (SPI_MEM_C_CK_IDLE_EDGE_V << SPI_MEM_C_CK_IDLE_EDGE_S)
+#define SPI_MEM_C_CK_IDLE_EDGE_V  0x00000001U
+#define SPI_MEM_C_CK_IDLE_EDGE_S  9
+/** SPI_MEM_C_CS_KEEP_ACTIVE : R/W; bitpos: [10]; default: 0;
+ *  SPI_CS line keep low when the bit is set.
+ */
+#define SPI_MEM_C_CS_KEEP_ACTIVE    (BIT(10))
+#define SPI_MEM_C_CS_KEEP_ACTIVE_M  (SPI_MEM_C_CS_KEEP_ACTIVE_V << SPI_MEM_C_CS_KEEP_ACTIVE_S)
+#define SPI_MEM_C_CS_KEEP_ACTIVE_V  0x00000001U
+#define SPI_MEM_C_CS_KEEP_ACTIVE_S  10
+
+/** SPI_MEM_C_CACHE_FCTRL_REG register
+ *  SPI0 bit mode control register.
+ */
+#define SPI_MEM_C_CACHE_FCTRL_REG (DR_REG_FLASH_SPI0_BASE + 0x3c)
+/** SPI_MEM_C_AXI_REQ_EN : R/W; bitpos: [0]; default: 0;
+ *  For SPI0, AXI master access enable, 1: enable, 0:disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_AXI_REQ_EN    (BIT(0))
+#define SPI_MEM_C_AXI_REQ_EN_M  (SPI_MEM_C_AXI_REQ_EN_V << SPI_MEM_C_AXI_REQ_EN_S)
+#define SPI_MEM_C_AXI_REQ_EN_V  0x00000001U
+#define SPI_MEM_C_AXI_REQ_EN_S  0
+/** SPI_MEM_C_CACHE_USR_ADDR_4BYTE : R/W; bitpos: [1]; default: 0;
+ *  For SPI0,  cache  read flash with 4 bytes address, 1: enable, 0:disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_CACHE_USR_ADDR_4BYTE    (BIT(1))
+#define SPI_MEM_C_CACHE_USR_ADDR_4BYTE_M  (SPI_MEM_C_CACHE_USR_ADDR_4BYTE_V << SPI_MEM_C_CACHE_USR_ADDR_4BYTE_S)
+#define SPI_MEM_C_CACHE_USR_ADDR_4BYTE_V  0x00000001U
+#define SPI_MEM_C_CACHE_USR_ADDR_4BYTE_S  1
+/** SPI_MEM_C_CACHE_FLASH_USR_CMD : R/W; bitpos: [2]; default: 0;
+ *  For SPI0,  cache  read flash for user define command, 1: enable, 0:disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_CACHE_FLASH_USR_CMD    (BIT(2))
+#define SPI_MEM_C_CACHE_FLASH_USR_CMD_M  (SPI_MEM_C_CACHE_FLASH_USR_CMD_V << SPI_MEM_C_CACHE_FLASH_USR_CMD_S)
+#define SPI_MEM_C_CACHE_FLASH_USR_CMD_V  0x00000001U
+#define SPI_MEM_C_CACHE_FLASH_USR_CMD_S  2
+/** SPI_MEM_C_FDIN_DUAL : R/W; bitpos: [3]; default: 0;
+ *  For SPI0 flash, din phase apply 2 signals. 1: enable 0: disable. The bit is the
+ *  same with spi_mem_fread_dio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_FDIN_DUAL    (BIT(3))
+#define SPI_MEM_C_FDIN_DUAL_M  (SPI_MEM_C_FDIN_DUAL_V << SPI_MEM_C_FDIN_DUAL_S)
+#define SPI_MEM_C_FDIN_DUAL_V  0x00000001U
+#define SPI_MEM_C_FDIN_DUAL_S  3
+/** SPI_MEM_C_FDOUT_DUAL : R/W; bitpos: [4]; default: 0;
+ *  For SPI0 flash, dout phase apply 2 signals. 1: enable 0: disable. The bit is the
+ *  same with spi_mem_fread_dio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_FDOUT_DUAL    (BIT(4))
+#define SPI_MEM_C_FDOUT_DUAL_M  (SPI_MEM_C_FDOUT_DUAL_V << SPI_MEM_C_FDOUT_DUAL_S)
+#define SPI_MEM_C_FDOUT_DUAL_V  0x00000001U
+#define SPI_MEM_C_FDOUT_DUAL_S  4
+/** SPI_MEM_C_FADDR_DUAL : R/W; bitpos: [5]; default: 0;
+ *  For SPI0 flash, address phase apply 2 signals. 1: enable 0: disable.  The bit is
+ *  the same with spi_mem_fread_dio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_FADDR_DUAL    (BIT(5))
+#define SPI_MEM_C_FADDR_DUAL_M  (SPI_MEM_C_FADDR_DUAL_V << SPI_MEM_C_FADDR_DUAL_S)
+#define SPI_MEM_C_FADDR_DUAL_V  0x00000001U
+#define SPI_MEM_C_FADDR_DUAL_S  5
+/** SPI_MEM_C_FDIN_QUAD : R/W; bitpos: [6]; default: 0;
+ *  For SPI0 flash, din phase apply 4 signals. 1: enable 0: disable.  The bit is the
+ *  same with spi_mem_fread_qio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_FDIN_QUAD    (BIT(6))
+#define SPI_MEM_C_FDIN_QUAD_M  (SPI_MEM_C_FDIN_QUAD_V << SPI_MEM_C_FDIN_QUAD_S)
+#define SPI_MEM_C_FDIN_QUAD_V  0x00000001U
+#define SPI_MEM_C_FDIN_QUAD_S  6
+/** SPI_MEM_C_FDOUT_QUAD : R/W; bitpos: [7]; default: 0;
+ *  For SPI0 flash, dout phase apply 4 signals. 1: enable 0: disable.  The bit is the
+ *  same with spi_mem_fread_qio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_FDOUT_QUAD    (BIT(7))
+#define SPI_MEM_C_FDOUT_QUAD_M  (SPI_MEM_C_FDOUT_QUAD_V << SPI_MEM_C_FDOUT_QUAD_S)
+#define SPI_MEM_C_FDOUT_QUAD_V  0x00000001U
+#define SPI_MEM_C_FDOUT_QUAD_S  7
+/** SPI_MEM_C_FADDR_QUAD : R/W; bitpos: [8]; default: 0;
+ *  For SPI0 flash, address phase apply 4 signals. 1: enable 0: disable.  The bit is
+ *  the same with spi_mem_fread_qio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_FADDR_QUAD    (BIT(8))
+#define SPI_MEM_C_FADDR_QUAD_M  (SPI_MEM_C_FADDR_QUAD_V << SPI_MEM_C_FADDR_QUAD_S)
+#define SPI_MEM_C_FADDR_QUAD_V  0x00000001U
+#define SPI_MEM_C_FADDR_QUAD_S  8
+/** SPI_MEM_C_ARB_WEI_EN : HRO; bitpos: [9]; default: 0;
+ *  To enable SPI0 arbiter weight func while AXI read/write access SPI0  1: enable 0:
+ *  disable.
+ */
+#define SPI_MEM_C_ARB_WEI_EN    (BIT(9))
+#define SPI_MEM_C_ARB_WEI_EN_M  (SPI_MEM_C_ARB_WEI_EN_V << SPI_MEM_C_ARB_WEI_EN_S)
+#define SPI_MEM_C_ARB_WEI_EN_V  0x00000001U
+#define SPI_MEM_C_ARB_WEI_EN_S  9
+/** SPI_MEM_C_ARB_REQ0_PRI : HRO; bitpos: [10]; default: 0;
+ *  To set AXI read priority in SPI0 arbiter. The larger the value, the greater the
+ *  priority.
+ */
+#define SPI_MEM_C_ARB_REQ0_PRI    (BIT(10))
+#define SPI_MEM_C_ARB_REQ0_PRI_M  (SPI_MEM_C_ARB_REQ0_PRI_V << SPI_MEM_C_ARB_REQ0_PRI_S)
+#define SPI_MEM_C_ARB_REQ0_PRI_V  0x00000001U
+#define SPI_MEM_C_ARB_REQ0_PRI_S  10
+/** SPI_MEM_C_ARB_REQ1_PRI : HRO; bitpos: [11]; default: 0;
+ *  To set AXI write priority in SPI0 arbiter. The larger the value, the greater the
+ *  priority.
+ */
+#define SPI_MEM_C_ARB_REQ1_PRI    (BIT(11))
+#define SPI_MEM_C_ARB_REQ1_PRI_M  (SPI_MEM_C_ARB_REQ1_PRI_V << SPI_MEM_C_ARB_REQ1_PRI_S)
+#define SPI_MEM_C_ARB_REQ1_PRI_V  0x00000001U
+#define SPI_MEM_C_ARB_REQ1_PRI_S  11
+/** SPI_MEM_C_ARB_REQ0_WEI : HRO; bitpos: [15:12]; default: 0;
+ *  To set AXI read priority weight in SPI0 arbiter. While the priority are same, the
+ *  larger the value, the greater the weight.
+ */
+#define SPI_MEM_C_ARB_REQ0_WEI    0x0000000FU
+#define SPI_MEM_C_ARB_REQ0_WEI_M  (SPI_MEM_C_ARB_REQ0_WEI_V << SPI_MEM_C_ARB_REQ0_WEI_S)
+#define SPI_MEM_C_ARB_REQ0_WEI_V  0x0000000FU
+#define SPI_MEM_C_ARB_REQ0_WEI_S  12
+/** SPI_MEM_C_ARB_REQ1_WEI : HRO; bitpos: [19:16]; default: 0;
+ *  To set AXI write priority weight in SPI0 arbiter. While the priority are same, the
+ *  larger the value, the greater the weight.
+ */
+#define SPI_MEM_C_ARB_REQ1_WEI    0x0000000FU
+#define SPI_MEM_C_ARB_REQ1_WEI_M  (SPI_MEM_C_ARB_REQ1_WEI_V << SPI_MEM_C_ARB_REQ1_WEI_S)
+#define SPI_MEM_C_ARB_REQ1_WEI_V  0x0000000FU
+#define SPI_MEM_C_ARB_REQ1_WEI_S  16
+/** SPI_SAME_AW_AR_ADDR_CHK_EN : R/W; bitpos: [30]; default: 1;
+ *  Set this bit to check AXI read/write the same address region.
+ */
+#define SPI_SAME_AW_AR_ADDR_CHK_EN    (BIT(30))
+#define SPI_SAME_AW_AR_ADDR_CHK_EN_M  (SPI_SAME_AW_AR_ADDR_CHK_EN_V << SPI_SAME_AW_AR_ADDR_CHK_EN_S)
+#define SPI_SAME_AW_AR_ADDR_CHK_EN_V  0x00000001U
+#define SPI_SAME_AW_AR_ADDR_CHK_EN_S  30
+/** SPI_CLOSE_AXI_INF_EN : R/W; bitpos: [31]; default: 1;
+ *  Set this bit to close AXI read/write transfer to MSPI, which means that only
+ *  SLV_ERR will be replied to BRESP/RRESP.
+ */
+#define SPI_CLOSE_AXI_INF_EN    (BIT(31))
+#define SPI_CLOSE_AXI_INF_EN_M  (SPI_CLOSE_AXI_INF_EN_V << SPI_CLOSE_AXI_INF_EN_S)
+#define SPI_CLOSE_AXI_INF_EN_V  0x00000001U
+#define SPI_CLOSE_AXI_INF_EN_S  31
+
+/** SPI_MEM_C_CACHE_SCTRL_REG register
+ *  SPI0 external RAM control register
+ *  This register is only for internal debugging purposes. Do not use it in
+ *  applications.
+ */
+#define SPI_MEM_C_CACHE_SCTRL_REG (DR_REG_FLASH_SPI0_BASE + 0x40)
+/** SPI_MEM_C_CACHE_USR_SADDR_4BYTE : HRO; bitpos: [0]; default: 0;
+ *  For SPI0, In the external RAM mode, cache read flash with 4 bytes command, 1:
+ *  enable, 0:disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_CACHE_USR_SADDR_4BYTE    (BIT(0))
+#define SPI_MEM_C_CACHE_USR_SADDR_4BYTE_M  (SPI_MEM_C_CACHE_USR_SADDR_4BYTE_V << SPI_MEM_C_CACHE_USR_SADDR_4BYTE_S)
+#define SPI_MEM_C_CACHE_USR_SADDR_4BYTE_V  0x00000001U
+#define SPI_MEM_C_CACHE_USR_SADDR_4BYTE_S  0
+/** SPI_MEM_C_USR_SRAM_DIO : HRO; bitpos: [1]; default: 0;
+ *  For SPI0, In the external RAM mode, spi dual I/O mode enable, 1: enable, 0:disable
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_USR_SRAM_DIO    (BIT(1))
+#define SPI_MEM_C_USR_SRAM_DIO_M  (SPI_MEM_C_USR_SRAM_DIO_V << SPI_MEM_C_USR_SRAM_DIO_S)
+#define SPI_MEM_C_USR_SRAM_DIO_V  0x00000001U
+#define SPI_MEM_C_USR_SRAM_DIO_S  1
+/** SPI_MEM_C_USR_SRAM_QIO : HRO; bitpos: [2]; default: 0;
+ *  For SPI0, In the external RAM mode, spi quad I/O mode enable, 1: enable, 0:disable
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_USR_SRAM_QIO    (BIT(2))
+#define SPI_MEM_C_USR_SRAM_QIO_M  (SPI_MEM_C_USR_SRAM_QIO_V << SPI_MEM_C_USR_SRAM_QIO_S)
+#define SPI_MEM_C_USR_SRAM_QIO_V  0x00000001U
+#define SPI_MEM_C_USR_SRAM_QIO_S  2
+/** SPI_MEM_C_USR_WR_SRAM_DUMMY : HRO; bitpos: [3]; default: 0;
+ *  For SPI0, In the external RAM mode, it is the enable bit of dummy phase for write
+ *  operations.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_USR_WR_SRAM_DUMMY    (BIT(3))
+#define SPI_MEM_C_USR_WR_SRAM_DUMMY_M  (SPI_MEM_C_USR_WR_SRAM_DUMMY_V << SPI_MEM_C_USR_WR_SRAM_DUMMY_S)
+#define SPI_MEM_C_USR_WR_SRAM_DUMMY_V  0x00000001U
+#define SPI_MEM_C_USR_WR_SRAM_DUMMY_S  3
+/** SPI_MEM_C_USR_RD_SRAM_DUMMY : HRO; bitpos: [4]; default: 1;
+ *  For SPI0, In the external RAM mode, it is the enable bit of dummy phase for read
+ *  operations.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_USR_RD_SRAM_DUMMY    (BIT(4))
+#define SPI_MEM_C_USR_RD_SRAM_DUMMY_M  (SPI_MEM_C_USR_RD_SRAM_DUMMY_V << SPI_MEM_C_USR_RD_SRAM_DUMMY_S)
+#define SPI_MEM_C_USR_RD_SRAM_DUMMY_V  0x00000001U
+#define SPI_MEM_C_USR_RD_SRAM_DUMMY_S  4
+/** SPI_MEM_C_CACHE_SRAM_USR_RCMD : HRO; bitpos: [5]; default: 1;
+ *  For SPI0, In the external RAM mode cache read external RAM for user define command.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_CACHE_SRAM_USR_RCMD    (BIT(5))
+#define SPI_MEM_C_CACHE_SRAM_USR_RCMD_M  (SPI_MEM_C_CACHE_SRAM_USR_RCMD_V << SPI_MEM_C_CACHE_SRAM_USR_RCMD_S)
+#define SPI_MEM_C_CACHE_SRAM_USR_RCMD_V  0x00000001U
+#define SPI_MEM_C_CACHE_SRAM_USR_RCMD_S  5
+/** SPI_MEM_C_SRAM_RDUMMY_CYCLELEN : HRO; bitpos: [11:6]; default: 1;
+ *  For SPI0, In the external RAM mode, it is the length in bits of read dummy phase.
+ *  The register value shall be (bit_num-1).
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SRAM_RDUMMY_CYCLELEN    0x0000003FU
+#define SPI_MEM_C_SRAM_RDUMMY_CYCLELEN_M  (SPI_MEM_C_SRAM_RDUMMY_CYCLELEN_V << SPI_MEM_C_SRAM_RDUMMY_CYCLELEN_S)
+#define SPI_MEM_C_SRAM_RDUMMY_CYCLELEN_V  0x0000003FU
+#define SPI_MEM_C_SRAM_RDUMMY_CYCLELEN_S  6
+/** SPI_MEM_C_SRAM_ADDR_BITLEN : HRO; bitpos: [19:14]; default: 23;
+ *  For SPI0, In the external RAM mode, it is the length in bits of address phase. The
+ *  register value shall be (bit_num-1).
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SRAM_ADDR_BITLEN    0x0000003FU
+#define SPI_MEM_C_SRAM_ADDR_BITLEN_M  (SPI_MEM_C_SRAM_ADDR_BITLEN_V << SPI_MEM_C_SRAM_ADDR_BITLEN_S)
+#define SPI_MEM_C_SRAM_ADDR_BITLEN_V  0x0000003FU
+#define SPI_MEM_C_SRAM_ADDR_BITLEN_S  14
+/** SPI_MEM_C_CACHE_SRAM_USR_WCMD : HRO; bitpos: [20]; default: 1;
+ *  For SPI0, In the external RAM mode cache write sram for user define command
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_CACHE_SRAM_USR_WCMD    (BIT(20))
+#define SPI_MEM_C_CACHE_SRAM_USR_WCMD_M  (SPI_MEM_C_CACHE_SRAM_USR_WCMD_V << SPI_MEM_C_CACHE_SRAM_USR_WCMD_S)
+#define SPI_MEM_C_CACHE_SRAM_USR_WCMD_V  0x00000001U
+#define SPI_MEM_C_CACHE_SRAM_USR_WCMD_S  20
+/** SPI_MEM_C_SRAM_OCT : HRO; bitpos: [21]; default: 0;
+ *  reserved
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SRAM_OCT    (BIT(21))
+#define SPI_MEM_C_SRAM_OCT_M  (SPI_MEM_C_SRAM_OCT_V << SPI_MEM_C_SRAM_OCT_S)
+#define SPI_MEM_C_SRAM_OCT_V  0x00000001U
+#define SPI_MEM_C_SRAM_OCT_S  21
+/** SPI_MEM_C_SRAM_WDUMMY_CYCLELEN : HRO; bitpos: [27:22]; default: 1;
+ *  For SPI0, In the external RAM mode, it is the length in bits of write dummy phase.
+ *  The register value shall be (bit_num-1).
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SRAM_WDUMMY_CYCLELEN    0x0000003FU
+#define SPI_MEM_C_SRAM_WDUMMY_CYCLELEN_M  (SPI_MEM_C_SRAM_WDUMMY_CYCLELEN_V << SPI_MEM_C_SRAM_WDUMMY_CYCLELEN_S)
+#define SPI_MEM_C_SRAM_WDUMMY_CYCLELEN_V  0x0000003FU
+#define SPI_MEM_C_SRAM_WDUMMY_CYCLELEN_S  22
+
+/** SPI_MEM_C_SRAM_CMD_REG register
+ *  SPI0 external RAM mode control register
+ */
+#define SPI_MEM_C_SRAM_CMD_REG (DR_REG_FLASH_SPI0_BASE + 0x44)
+/** SPI_MEM_C_SCLK_MODE : HRO; bitpos: [1:0]; default: 0;
+ *  SPI clock mode bits. 0: SPI clock is off when CS inactive 1: SPI clock is delayed
+ *  one cycle after CS inactive 2: SPI clock is delayed two cycles after CS inactive 3:
+ *  SPI clock is always on.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SCLK_MODE    0x00000003U
+#define SPI_MEM_C_SCLK_MODE_M  (SPI_MEM_C_SCLK_MODE_V << SPI_MEM_C_SCLK_MODE_S)
+#define SPI_MEM_C_SCLK_MODE_V  0x00000003U
+#define SPI_MEM_C_SCLK_MODE_S  0
+/** SPI_MEM_C_SWB_MODE : HRO; bitpos: [9:2]; default: 0;
+ *  Mode bits in the external RAM fast read mode  it is combined with
+ *  spi_mem_fastrd_mode bit.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SWB_MODE    0x000000FFU
+#define SPI_MEM_C_SWB_MODE_M  (SPI_MEM_C_SWB_MODE_V << SPI_MEM_C_SWB_MODE_S)
+#define SPI_MEM_C_SWB_MODE_V  0x000000FFU
+#define SPI_MEM_C_SWB_MODE_S  2
+/** SPI_MEM_C_SDIN_DUAL : HRO; bitpos: [10]; default: 0;
+ *  For SPI0 external RAM , din phase apply 2 signals. 1: enable 0: disable. The bit is
+ *  the same with spi_mem_usr_sram_dio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SDIN_DUAL    (BIT(10))
+#define SPI_MEM_C_SDIN_DUAL_M  (SPI_MEM_C_SDIN_DUAL_V << SPI_MEM_C_SDIN_DUAL_S)
+#define SPI_MEM_C_SDIN_DUAL_V  0x00000001U
+#define SPI_MEM_C_SDIN_DUAL_S  10
+/** SPI_MEM_C_SDOUT_DUAL : HRO; bitpos: [11]; default: 0;
+ *  For SPI0 external RAM , dout phase apply 2 signals. 1: enable 0: disable. The bit
+ *  is the same with spi_mem_usr_sram_dio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SDOUT_DUAL    (BIT(11))
+#define SPI_MEM_C_SDOUT_DUAL_M  (SPI_MEM_C_SDOUT_DUAL_V << SPI_MEM_C_SDOUT_DUAL_S)
+#define SPI_MEM_C_SDOUT_DUAL_V  0x00000001U
+#define SPI_MEM_C_SDOUT_DUAL_S  11
+/** SPI_MEM_C_SADDR_DUAL : HRO; bitpos: [12]; default: 0;
+ *  For SPI0 external RAM , address phase apply 2 signals. 1: enable 0: disable. The
+ *  bit is the same with spi_mem_usr_sram_dio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SADDR_DUAL    (BIT(12))
+#define SPI_MEM_C_SADDR_DUAL_M  (SPI_MEM_C_SADDR_DUAL_V << SPI_MEM_C_SADDR_DUAL_S)
+#define SPI_MEM_C_SADDR_DUAL_V  0x00000001U
+#define SPI_MEM_C_SADDR_DUAL_S  12
+/** SPI_MEM_C_SDIN_QUAD : HRO; bitpos: [14]; default: 0;
+ *  For SPI0 external RAM , din phase apply 4 signals. 1: enable 0: disable. The bit is
+ *  the same with spi_mem_usr_sram_qio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SDIN_QUAD    (BIT(14))
+#define SPI_MEM_C_SDIN_QUAD_M  (SPI_MEM_C_SDIN_QUAD_V << SPI_MEM_C_SDIN_QUAD_S)
+#define SPI_MEM_C_SDIN_QUAD_V  0x00000001U
+#define SPI_MEM_C_SDIN_QUAD_S  14
+/** SPI_MEM_C_SDOUT_QUAD : HRO; bitpos: [15]; default: 0;
+ *  For SPI0 external RAM , dout phase apply 4 signals. 1: enable 0: disable. The bit
+ *  is the same with spi_mem_usr_sram_qio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SDOUT_QUAD    (BIT(15))
+#define SPI_MEM_C_SDOUT_QUAD_M  (SPI_MEM_C_SDOUT_QUAD_V << SPI_MEM_C_SDOUT_QUAD_S)
+#define SPI_MEM_C_SDOUT_QUAD_V  0x00000001U
+#define SPI_MEM_C_SDOUT_QUAD_S  15
+/** SPI_MEM_C_SADDR_QUAD : HRO; bitpos: [16]; default: 0;
+ *  For SPI0 external RAM , address phase apply 4 signals. 1: enable 0: disable. The
+ *  bit is the same with spi_mem_usr_sram_qio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SADDR_QUAD    (BIT(16))
+#define SPI_MEM_C_SADDR_QUAD_M  (SPI_MEM_C_SADDR_QUAD_V << SPI_MEM_C_SADDR_QUAD_S)
+#define SPI_MEM_C_SADDR_QUAD_V  0x00000001U
+#define SPI_MEM_C_SADDR_QUAD_S  16
+/** SPI_MEM_C_SCMD_QUAD : HRO; bitpos: [17]; default: 0;
+ *  For SPI0 external RAM , cmd phase apply 4 signals. 1: enable 0: disable. The bit is
+ *  the same with spi_mem_usr_sram_qio.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SCMD_QUAD    (BIT(17))
+#define SPI_MEM_C_SCMD_QUAD_M  (SPI_MEM_C_SCMD_QUAD_V << SPI_MEM_C_SCMD_QUAD_S)
+#define SPI_MEM_C_SCMD_QUAD_V  0x00000001U
+#define SPI_MEM_C_SCMD_QUAD_S  17
+/** SPI_MEM_C_SDIN_OCT : HRO; bitpos: [18]; default: 0;
+ *  For SPI0 external RAM , din phase apply 8 signals. 1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SDIN_OCT    (BIT(18))
+#define SPI_MEM_C_SDIN_OCT_M  (SPI_MEM_C_SDIN_OCT_V << SPI_MEM_C_SDIN_OCT_S)
+#define SPI_MEM_C_SDIN_OCT_V  0x00000001U
+#define SPI_MEM_C_SDIN_OCT_S  18
+/** SPI_MEM_C_SDOUT_OCT : HRO; bitpos: [19]; default: 0;
+ *  For SPI0 external RAM , dout phase apply 8 signals. 1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SDOUT_OCT    (BIT(19))
+#define SPI_MEM_C_SDOUT_OCT_M  (SPI_MEM_C_SDOUT_OCT_V << SPI_MEM_C_SDOUT_OCT_S)
+#define SPI_MEM_C_SDOUT_OCT_V  0x00000001U
+#define SPI_MEM_C_SDOUT_OCT_S  19
+/** SPI_MEM_C_SADDR_OCT : HRO; bitpos: [20]; default: 0;
+ *  For SPI0 external RAM , address phase apply 4 signals. 1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SADDR_OCT    (BIT(20))
+#define SPI_MEM_C_SADDR_OCT_M  (SPI_MEM_C_SADDR_OCT_V << SPI_MEM_C_SADDR_OCT_S)
+#define SPI_MEM_C_SADDR_OCT_V  0x00000001U
+#define SPI_MEM_C_SADDR_OCT_S  20
+/** SPI_MEM_C_SCMD_OCT : HRO; bitpos: [21]; default: 0;
+ *  For SPI0 external RAM , cmd phase apply 8 signals. 1: enable 0: disable.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SCMD_OCT    (BIT(21))
+#define SPI_MEM_C_SCMD_OCT_M  (SPI_MEM_C_SCMD_OCT_V << SPI_MEM_C_SCMD_OCT_S)
+#define SPI_MEM_C_SCMD_OCT_V  0x00000001U
+#define SPI_MEM_C_SCMD_OCT_S  21
+/** SPI_MEM_C_SDUMMY_RIN : R/W; bitpos: [22]; default: 1;
+ *  In the dummy phase of a MSPI read data transfer when accesses to external RAM, the
+ *  signal level of SPI bus is output by the MSPI controller.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SDUMMY_RIN    (BIT(22))
+#define SPI_MEM_C_SDUMMY_RIN_M  (SPI_MEM_C_SDUMMY_RIN_V << SPI_MEM_C_SDUMMY_RIN_S)
+#define SPI_MEM_C_SDUMMY_RIN_V  0x00000001U
+#define SPI_MEM_C_SDUMMY_RIN_S  22
+/** SPI_MEM_C_SDUMMY_WOUT : HRO; bitpos: [23]; default: 0;
+ *  In the dummy phase of a MSPI write data transfer when accesses to external RAM, the
+ *  signal level of SPI bus is output by the MSPI controller.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SDUMMY_WOUT    (BIT(23))
+#define SPI_MEM_C_SDUMMY_WOUT_M  (SPI_MEM_C_SDUMMY_WOUT_V << SPI_MEM_C_SDUMMY_WOUT_S)
+#define SPI_MEM_C_SDUMMY_WOUT_V  0x00000001U
+#define SPI_MEM_C_SDUMMY_WOUT_S  23
+/** SPI_SMEM_C_WDUMMY_DQS_ALWAYS_OUT : HRO; bitpos: [24]; default: 0;
+ *  In the dummy phase of an MSPI write data transfer when accesses to external RAM,
+ *  the level of SPI_DQS is output by the MSPI controller.
+ */
+#define SPI_SMEM_C_WDUMMY_DQS_ALWAYS_OUT    (BIT(24))
+#define SPI_SMEM_C_WDUMMY_DQS_ALWAYS_OUT_M  (SPI_SMEM_C_WDUMMY_DQS_ALWAYS_OUT_V << SPI_SMEM_C_WDUMMY_DQS_ALWAYS_OUT_S)
+#define SPI_SMEM_C_WDUMMY_DQS_ALWAYS_OUT_V  0x00000001U
+#define SPI_SMEM_C_WDUMMY_DQS_ALWAYS_OUT_S  24
+/** SPI_SMEM_C_WDUMMY_ALWAYS_OUT : HRO; bitpos: [25]; default: 0;
+ *  In the dummy phase of an MSPI write data transfer when accesses to external RAM,
+ *  the level of SPI_IO[7:0] is output by the MSPI controller.
+ */
+#define SPI_SMEM_C_WDUMMY_ALWAYS_OUT    (BIT(25))
+#define SPI_SMEM_C_WDUMMY_ALWAYS_OUT_M  (SPI_SMEM_C_WDUMMY_ALWAYS_OUT_V << SPI_SMEM_C_WDUMMY_ALWAYS_OUT_S)
+#define SPI_SMEM_C_WDUMMY_ALWAYS_OUT_V  0x00000001U
+#define SPI_SMEM_C_WDUMMY_ALWAYS_OUT_S  25
+/** SPI_SMEM_C_DQS_IE_ALWAYS_ON : HRO; bitpos: [30]; default: 1;
+ *  When accesses to external RAM, 1: the IE signals of pads connected to SPI_DQS are
+ *  always 1. 0: Others.
+ */
+#define SPI_SMEM_C_DQS_IE_ALWAYS_ON    (BIT(30))
+#define SPI_SMEM_C_DQS_IE_ALWAYS_ON_M  (SPI_SMEM_C_DQS_IE_ALWAYS_ON_V << SPI_SMEM_C_DQS_IE_ALWAYS_ON_S)
+#define SPI_SMEM_C_DQS_IE_ALWAYS_ON_V  0x00000001U
+#define SPI_SMEM_C_DQS_IE_ALWAYS_ON_S  30
+/** SPI_SMEM_C_DATA_IE_ALWAYS_ON : HRO; bitpos: [31]; default: 1;
+ *  When accesses to external RAM, 1: the IE signals of pads connected to SPI_IO[7:0]
+ *  are always 1. 0: Others.
+ */
+#define SPI_SMEM_C_DATA_IE_ALWAYS_ON    (BIT(31))
+#define SPI_SMEM_C_DATA_IE_ALWAYS_ON_M  (SPI_SMEM_C_DATA_IE_ALWAYS_ON_V << SPI_SMEM_C_DATA_IE_ALWAYS_ON_S)
+#define SPI_SMEM_C_DATA_IE_ALWAYS_ON_V  0x00000001U
+#define SPI_SMEM_C_DATA_IE_ALWAYS_ON_S  31
+
+/** SPI_MEM_C_SRAM_DRD_CMD_REG register
+ *  SPI0 external RAM DDR read command control register
+ *  This register is only for internal debugging purposes. Do not use it in
+ *  applications.
+ */
+#define SPI_MEM_C_SRAM_DRD_CMD_REG (DR_REG_FLASH_SPI0_BASE + 0x48)
+/** SPI_MEM_C_CACHE_SRAM_USR_RD_CMD_VALUE : HRO; bitpos: [15:0]; default: 0;
+ *  For SPI0,When cache mode is enable it is the read command value of command phase
+ *  for sram.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_CACHE_SRAM_USR_RD_CMD_VALUE    0x0000FFFFU
+#define SPI_MEM_C_CACHE_SRAM_USR_RD_CMD_VALUE_M  (SPI_MEM_C_CACHE_SRAM_USR_RD_CMD_VALUE_V << SPI_MEM_C_CACHE_SRAM_USR_RD_CMD_VALUE_S)
+#define SPI_MEM_C_CACHE_SRAM_USR_RD_CMD_VALUE_V  0x0000FFFFU
+#define SPI_MEM_C_CACHE_SRAM_USR_RD_CMD_VALUE_S  0
+/** SPI_MEM_C_CACHE_SRAM_USR_RD_CMD_BITLEN : HRO; bitpos: [31:28]; default: 0;
+ *  For SPI0,When cache mode is enable it is the length in bits of command phase for
+ *  sram. The register value shall be (bit_num-1).
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_CACHE_SRAM_USR_RD_CMD_BITLEN    0x0000000FU
+#define SPI_MEM_C_CACHE_SRAM_USR_RD_CMD_BITLEN_M  (SPI_MEM_C_CACHE_SRAM_USR_RD_CMD_BITLEN_V << SPI_MEM_C_CACHE_SRAM_USR_RD_CMD_BITLEN_S)
+#define SPI_MEM_C_CACHE_SRAM_USR_RD_CMD_BITLEN_V  0x0000000FU
+#define SPI_MEM_C_CACHE_SRAM_USR_RD_CMD_BITLEN_S  28
+
+/** SPI_MEM_C_SRAM_DWR_CMD_REG register
+ *  SPI0 external RAM DDR write command control register
+ *  This register is only for internal debugging purposes. Do not use it in
+ *  applications.
+ */
+#define SPI_MEM_C_SRAM_DWR_CMD_REG (DR_REG_FLASH_SPI0_BASE + 0x4c)
+/** SPI_MEM_C_CACHE_SRAM_USR_WR_CMD_VALUE : HRO; bitpos: [15:0]; default: 0;
+ *  For SPI0,When cache mode is enable it is the write command value of command phase
+ *  for sram.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_CACHE_SRAM_USR_WR_CMD_VALUE    0x0000FFFFU
+#define SPI_MEM_C_CACHE_SRAM_USR_WR_CMD_VALUE_M  (SPI_MEM_C_CACHE_SRAM_USR_WR_CMD_VALUE_V << SPI_MEM_C_CACHE_SRAM_USR_WR_CMD_VALUE_S)
+#define SPI_MEM_C_CACHE_SRAM_USR_WR_CMD_VALUE_V  0x0000FFFFU
+#define SPI_MEM_C_CACHE_SRAM_USR_WR_CMD_VALUE_S  0
+/** SPI_MEM_C_CACHE_SRAM_USR_WR_CMD_BITLEN : HRO; bitpos: [31:28]; default: 0;
+ *  For SPI0,When cache mode is enable it is the in bits of command phase  for sram.
+ *  The register value shall be (bit_num-1).
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_CACHE_SRAM_USR_WR_CMD_BITLEN    0x0000000FU
+#define SPI_MEM_C_CACHE_SRAM_USR_WR_CMD_BITLEN_M  (SPI_MEM_C_CACHE_SRAM_USR_WR_CMD_BITLEN_V << SPI_MEM_C_CACHE_SRAM_USR_WR_CMD_BITLEN_S)
+#define SPI_MEM_C_CACHE_SRAM_USR_WR_CMD_BITLEN_V  0x0000000FU
+#define SPI_MEM_C_CACHE_SRAM_USR_WR_CMD_BITLEN_S  28
+
+/** SPI_MEM_C_SRAM_CLK_REG register
+ *  SPI0 external RAM clock control register
+ *  This register is only for internal debugging purposes. Do not use it in
+ *  applications.
+ */
+#define SPI_MEM_C_SRAM_CLK_REG (DR_REG_FLASH_SPI0_BASE + 0x50)
+/** SPI_MEM_C_SCLKCNT_L : HRO; bitpos: [7:0]; default: 3;
+ *  For SPI0 external RAM  interface, it must be equal to SPI_MEM_C_SCLKCNT_N.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SCLKCNT_L    0x000000FFU
+#define SPI_MEM_C_SCLKCNT_L_M  (SPI_MEM_C_SCLKCNT_L_V << SPI_MEM_C_SCLKCNT_L_S)
+#define SPI_MEM_C_SCLKCNT_L_V  0x000000FFU
+#define SPI_MEM_C_SCLKCNT_L_S  0
+/** SPI_MEM_C_SCLKCNT_H : HRO; bitpos: [15:8]; default: 1;
+ *  For SPI0 external RAM  interface, it must be floor((SPI_MEM_C_SCLKCNT_N+1)/2-1).
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SCLKCNT_H    0x000000FFU
+#define SPI_MEM_C_SCLKCNT_H_M  (SPI_MEM_C_SCLKCNT_H_V << SPI_MEM_C_SCLKCNT_H_S)
+#define SPI_MEM_C_SCLKCNT_H_V  0x000000FFU
+#define SPI_MEM_C_SCLKCNT_H_S  8
+/** SPI_MEM_C_SCLKCNT_N : HRO; bitpos: [23:16]; default: 3;
+ *  For SPI0 external RAM  interface, it is the divider of spi_mem_clk. So spi_mem_clk
+ *  frequency is system/(SPI_MEM_C_SCLKCNT_N+1)
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SCLKCNT_N    0x000000FFU
+#define SPI_MEM_C_SCLKCNT_N_M  (SPI_MEM_C_SCLKCNT_N_V << SPI_MEM_C_SCLKCNT_N_S)
+#define SPI_MEM_C_SCLKCNT_N_V  0x000000FFU
+#define SPI_MEM_C_SCLKCNT_N_S  16
+/** SPI_MEM_C_SCLK_EQU_SYSCLK : HRO; bitpos: [31]; default: 0;
+ *  For SPI0 external RAM  interface, 1: spi_mem_clk is equal to system 0: spi_mem_clk
+ *  is divided from system clock.
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_SCLK_EQU_SYSCLK    (BIT(31))
+#define SPI_MEM_C_SCLK_EQU_SYSCLK_M  (SPI_MEM_C_SCLK_EQU_SYSCLK_V << SPI_MEM_C_SCLK_EQU_SYSCLK_S)
+#define SPI_MEM_C_SCLK_EQU_SYSCLK_V  0x00000001U
+#define SPI_MEM_C_SCLK_EQU_SYSCLK_S  31
+
+/** SPI_MEM_C_FSM_REG register
+ *  SPI0 FSM status register
+ */
+#define SPI_MEM_C_FSM_REG (DR_REG_FLASH_SPI0_BASE + 0x54)
+/** SPI_MEM_C_LOCK_DELAY_TIME : R/W; bitpos: [18:7]; default: 4;
+ *  The lock delay time of SPI0/1 arbiter by spi0_slv_st, after PER is sent by SPI1.
+ */
+#define SPI_MEM_C_LOCK_DELAY_TIME    0x00000FFFU
+#define SPI_MEM_C_LOCK_DELAY_TIME_M  (SPI_MEM_C_LOCK_DELAY_TIME_V << SPI_MEM_C_LOCK_DELAY_TIME_S)
+#define SPI_MEM_C_LOCK_DELAY_TIME_V  0x00000FFFU
+#define SPI_MEM_C_LOCK_DELAY_TIME_S  7
+/** SPI_MEM_C_FLASH_LOCK_EN : R/W; bitpos: [19]; default: 0;
+ *  The lock enable for FLASH to lock spi0 trans req.1: Enable. 0: Disable.
+ */
+#define SPI_MEM_C_FLASH_LOCK_EN    (BIT(19))
+#define SPI_MEM_C_FLASH_LOCK_EN_M  (SPI_MEM_C_FLASH_LOCK_EN_V << SPI_MEM_C_FLASH_LOCK_EN_S)
+#define SPI_MEM_C_FLASH_LOCK_EN_V  0x00000001U
+#define SPI_MEM_C_FLASH_LOCK_EN_S  19
+/** SPI_MEM_C_SRAM_LOCK_EN : R/W; bitpos: [20]; default: 0;
+ *  The lock enable for external RAM to lock spi0 trans req.1: Enable. 0: Disable.
+ */
+#define SPI_MEM_C_SRAM_LOCK_EN    (BIT(20))
+#define SPI_MEM_C_SRAM_LOCK_EN_M  (SPI_MEM_C_SRAM_LOCK_EN_V << SPI_MEM_C_SRAM_LOCK_EN_S)
+#define SPI_MEM_C_SRAM_LOCK_EN_V  0x00000001U
+#define SPI_MEM_C_SRAM_LOCK_EN_S  20
+
+/** SPI_MEM_C_INT_ENA_REG register
+ *  SPI0 interrupt enable register
+ */
+#define SPI_MEM_C_INT_ENA_REG (DR_REG_FLASH_SPI0_BASE + 0xc0)
+/** SPI_MEM_C_SLV_ST_END_INT_ENA : R/W; bitpos: [3]; default: 0;
+ *  The enable bit for SPI_MEM_C_SLV_ST_END_INT interrupt.
+ */
+#define SPI_MEM_C_SLV_ST_END_INT_ENA    (BIT(3))
+#define SPI_MEM_C_SLV_ST_END_INT_ENA_M  (SPI_MEM_C_SLV_ST_END_INT_ENA_V << SPI_MEM_C_SLV_ST_END_INT_ENA_S)
+#define SPI_MEM_C_SLV_ST_END_INT_ENA_V  0x00000001U
+#define SPI_MEM_C_SLV_ST_END_INT_ENA_S  3
+/** SPI_MEM_C_MST_ST_END_INT_ENA : R/W; bitpos: [4]; default: 0;
+ *  The enable bit for SPI_MEM_C_MST_ST_END_INT interrupt.
+ */
+#define SPI_MEM_C_MST_ST_END_INT_ENA    (BIT(4))
+#define SPI_MEM_C_MST_ST_END_INT_ENA_M  (SPI_MEM_C_MST_ST_END_INT_ENA_V << SPI_MEM_C_MST_ST_END_INT_ENA_S)
+#define SPI_MEM_C_MST_ST_END_INT_ENA_V  0x00000001U
+#define SPI_MEM_C_MST_ST_END_INT_ENA_S  4
+/** SPI_MEM_C_ECC_ERR_INT_ENA : HRO; bitpos: [5]; default: 0;
+ *  The enable bit for SPI_MEM_C_ECC_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_ECC_ERR_INT_ENA    (BIT(5))
+#define SPI_MEM_C_ECC_ERR_INT_ENA_M  (SPI_MEM_C_ECC_ERR_INT_ENA_V << SPI_MEM_C_ECC_ERR_INT_ENA_S)
+#define SPI_MEM_C_ECC_ERR_INT_ENA_V  0x00000001U
+#define SPI_MEM_C_ECC_ERR_INT_ENA_S  5
+/** SPI_MEM_C_PMS_REJECT_INT_ENA : R/W; bitpos: [6]; default: 0;
+ *  The enable bit for SPI_MEM_C_PMS_REJECT_INT interrupt.
+ */
+#define SPI_MEM_C_PMS_REJECT_INT_ENA    (BIT(6))
+#define SPI_MEM_C_PMS_REJECT_INT_ENA_M  (SPI_MEM_C_PMS_REJECT_INT_ENA_V << SPI_MEM_C_PMS_REJECT_INT_ENA_S)
+#define SPI_MEM_C_PMS_REJECT_INT_ENA_V  0x00000001U
+#define SPI_MEM_C_PMS_REJECT_INT_ENA_S  6
+/** SPI_MEM_C_AXI_RADDR_ERR_INT_ENA : R/W; bitpos: [7]; default: 0;
+ *  The enable bit for SPI_MEM_C_AXI_RADDR_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_ENA    (BIT(7))
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_ENA_M  (SPI_MEM_C_AXI_RADDR_ERR_INT_ENA_V << SPI_MEM_C_AXI_RADDR_ERR_INT_ENA_S)
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_ENA_V  0x00000001U
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_ENA_S  7
+/** SPI_MEM_C_AXI_WR_FLASH_ERR_INT_ENA : R/W; bitpos: [8]; default: 0;
+ *  The enable bit for SPI_MEM_C_AXI_WR_FALSH_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_ENA    (BIT(8))
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_ENA_M  (SPI_MEM_C_AXI_WR_FLASH_ERR_INT_ENA_V << SPI_MEM_C_AXI_WR_FLASH_ERR_INT_ENA_S)
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_ENA_V  0x00000001U
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_ENA_S  8
+/** SPI_MEM_C_AXI_WADDR_ERR_INT__ENA : R/W; bitpos: [9]; default: 0;
+ *  The enable bit for SPI_MEM_C_AXI_WADDR_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_AXI_WADDR_ERR_INT__ENA    (BIT(9))
+#define SPI_MEM_C_AXI_WADDR_ERR_INT__ENA_M  (SPI_MEM_C_AXI_WADDR_ERR_INT__ENA_V << SPI_MEM_C_AXI_WADDR_ERR_INT__ENA_S)
+#define SPI_MEM_C_AXI_WADDR_ERR_INT__ENA_V  0x00000001U
+#define SPI_MEM_C_AXI_WADDR_ERR_INT__ENA_S  9
+/** SPI_MEM_C_NANDFLASH_PE_FAIL_INT_ENA : R/W; bitpos: [11]; default: 0;
+ *  The enable bit for SPI_MEM_C_NANDFLASH_PE_FAIL_INT interrupt.
+ */
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_ENA    (BIT(11))
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_ENA_M  (SPI_MEM_C_NANDFLASH_PE_FAIL_INT_ENA_V << SPI_MEM_C_NANDFLASH_PE_FAIL_INT_ENA_S)
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_ENA_V  0x00000001U
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_ENA_S  11
+/** SPI_MEM_C_NANDFLASH_ECC_ERR_INT_ENA : R/W; bitpos: [12]; default: 0;
+ *  The enable bit for SPI_MEM_C_NANDFLASH_ECC_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_ENA    (BIT(12))
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_ENA_M  (SPI_MEM_C_NANDFLASH_ECC_ERR_INT_ENA_V << SPI_MEM_C_NANDFLASH_ECC_ERR_INT_ENA_S)
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_ENA_V  0x00000001U
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_ENA_S  12
+/** SPI_MEM_C_XTS_FAULT_DETECTED_INT_ENA : R/W; bitpos: [13]; default: 0;
+ *  The enable  bit for SPI_MEM_C_XTS_FAULT_DETECTED_INT interrupt.
+ */
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_ENA    (BIT(13))
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_ENA_M  (SPI_MEM_C_XTS_FAULT_DETECTED_INT_ENA_V << SPI_MEM_C_XTS_FAULT_DETECTED_INT_ENA_S)
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_ENA_V  0x00000001U
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_ENA_S  13
+/** SPI_MEM_C_RX_TRANS_OVF_INT_ENA : HRO; bitpos: [26]; default: 0;
+ *  The enable bit for SPI_MEM_C_RX_TRANS_OVF_INT interrupt.
+ */
+#define SPI_MEM_C_RX_TRANS_OVF_INT_ENA    (BIT(26))
+#define SPI_MEM_C_RX_TRANS_OVF_INT_ENA_M  (SPI_MEM_C_RX_TRANS_OVF_INT_ENA_V << SPI_MEM_C_RX_TRANS_OVF_INT_ENA_S)
+#define SPI_MEM_C_RX_TRANS_OVF_INT_ENA_V  0x00000001U
+#define SPI_MEM_C_RX_TRANS_OVF_INT_ENA_S  26
+/** SPI_MEM_C_TX_TRANS_UDF_INT_ENA : HRO; bitpos: [27]; default: 0;
+ *  The enable bit for SPI_MEM_C_TX_TRANS_UDF_INT interrupt.
+ */
+#define SPI_MEM_C_TX_TRANS_UDF_INT_ENA    (BIT(27))
+#define SPI_MEM_C_TX_TRANS_UDF_INT_ENA_M  (SPI_MEM_C_TX_TRANS_UDF_INT_ENA_V << SPI_MEM_C_TX_TRANS_UDF_INT_ENA_S)
+#define SPI_MEM_C_TX_TRANS_UDF_INT_ENA_V  0x00000001U
+#define SPI_MEM_C_TX_TRANS_UDF_INT_ENA_S  27
+
+/** SPI_MEM_C_INT_CLR_REG register
+ *  SPI0 interrupt clear register
+ */
+#define SPI_MEM_C_INT_CLR_REG (DR_REG_FLASH_SPI0_BASE + 0xc4)
+/** SPI_MEM_C_SLV_ST_END_INT_CLR : WT; bitpos: [3]; default: 0;
+ *  The clear bit for SPI_MEM_C_SLV_ST_END_INT interrupt.
+ */
+#define SPI_MEM_C_SLV_ST_END_INT_CLR    (BIT(3))
+#define SPI_MEM_C_SLV_ST_END_INT_CLR_M  (SPI_MEM_C_SLV_ST_END_INT_CLR_V << SPI_MEM_C_SLV_ST_END_INT_CLR_S)
+#define SPI_MEM_C_SLV_ST_END_INT_CLR_V  0x00000001U
+#define SPI_MEM_C_SLV_ST_END_INT_CLR_S  3
+/** SPI_MEM_C_MST_ST_END_INT_CLR : WT; bitpos: [4]; default: 0;
+ *  The clear bit for SPI_MEM_C_MST_ST_END_INT interrupt.
+ */
+#define SPI_MEM_C_MST_ST_END_INT_CLR    (BIT(4))
+#define SPI_MEM_C_MST_ST_END_INT_CLR_M  (SPI_MEM_C_MST_ST_END_INT_CLR_V << SPI_MEM_C_MST_ST_END_INT_CLR_S)
+#define SPI_MEM_C_MST_ST_END_INT_CLR_V  0x00000001U
+#define SPI_MEM_C_MST_ST_END_INT_CLR_S  4
+/** SPI_MEM_C_ECC_ERR_INT_CLR : HRO; bitpos: [5]; default: 0;
+ *  The clear bit for SPI_MEM_C_ECC_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_ECC_ERR_INT_CLR    (BIT(5))
+#define SPI_MEM_C_ECC_ERR_INT_CLR_M  (SPI_MEM_C_ECC_ERR_INT_CLR_V << SPI_MEM_C_ECC_ERR_INT_CLR_S)
+#define SPI_MEM_C_ECC_ERR_INT_CLR_V  0x00000001U
+#define SPI_MEM_C_ECC_ERR_INT_CLR_S  5
+/** SPI_MEM_C_PMS_REJECT_INT_CLR : WT; bitpos: [6]; default: 0;
+ *  The clear bit for SPI_MEM_C_PMS_REJECT_INT interrupt.
+ */
+#define SPI_MEM_C_PMS_REJECT_INT_CLR    (BIT(6))
+#define SPI_MEM_C_PMS_REJECT_INT_CLR_M  (SPI_MEM_C_PMS_REJECT_INT_CLR_V << SPI_MEM_C_PMS_REJECT_INT_CLR_S)
+#define SPI_MEM_C_PMS_REJECT_INT_CLR_V  0x00000001U
+#define SPI_MEM_C_PMS_REJECT_INT_CLR_S  6
+/** SPI_MEM_C_AXI_RADDR_ERR_INT_CLR : WT; bitpos: [7]; default: 0;
+ *  The clear bit for SPI_MEM_C_AXI_RADDR_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_CLR    (BIT(7))
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_CLR_M  (SPI_MEM_C_AXI_RADDR_ERR_INT_CLR_V << SPI_MEM_C_AXI_RADDR_ERR_INT_CLR_S)
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_CLR_V  0x00000001U
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_CLR_S  7
+/** SPI_MEM_C_AXI_WR_FLASH_ERR_INT_CLR : WT; bitpos: [8]; default: 0;
+ *  The clear bit for SPI_MEM_C_AXI_WR_FALSH_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_CLR    (BIT(8))
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_CLR_M  (SPI_MEM_C_AXI_WR_FLASH_ERR_INT_CLR_V << SPI_MEM_C_AXI_WR_FLASH_ERR_INT_CLR_S)
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_CLR_V  0x00000001U
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_CLR_S  8
+/** SPI_MEM_C_AXI_WADDR_ERR_INT_CLR : WT; bitpos: [9]; default: 0;
+ *  The clear bit for SPI_MEM_C_AXI_WADDR_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_AXI_WADDR_ERR_INT_CLR    (BIT(9))
+#define SPI_MEM_C_AXI_WADDR_ERR_INT_CLR_M  (SPI_MEM_C_AXI_WADDR_ERR_INT_CLR_V << SPI_MEM_C_AXI_WADDR_ERR_INT_CLR_S)
+#define SPI_MEM_C_AXI_WADDR_ERR_INT_CLR_V  0x00000001U
+#define SPI_MEM_C_AXI_WADDR_ERR_INT_CLR_S  9
+/** SPI_MEM_C_NANDFLASH_PE_FAIL_INT_CLR : WT; bitpos: [11]; default: 0;
+ *  The clear bit for SPI_MEM_C_NANDFLASH_PE_FAIL_INT interrupt.
+ */
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_CLR    (BIT(11))
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_CLR_M  (SPI_MEM_C_NANDFLASH_PE_FAIL_INT_CLR_V << SPI_MEM_C_NANDFLASH_PE_FAIL_INT_CLR_S)
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_CLR_V  0x00000001U
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_CLR_S  11
+/** SPI_MEM_C_NANDFLASH_ECC_ERR_INT_CLR : WT; bitpos: [12]; default: 0;
+ *  The clear bit for SPI_MEM_C_NANDFLASH_ECC_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_CLR    (BIT(12))
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_CLR_M  (SPI_MEM_C_NANDFLASH_ECC_ERR_INT_CLR_V << SPI_MEM_C_NANDFLASH_ECC_ERR_INT_CLR_S)
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_CLR_V  0x00000001U
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_CLR_S  12
+/** SPI_MEM_C_XTS_FAULT_DETECTED_INT_CLR : WT; bitpos: [13]; default: 0;
+ *  The clear  bit for SPI_MEM_C_XTS_FAULT_DETECTED_INT interrupt.
+ */
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_CLR    (BIT(13))
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_CLR_M  (SPI_MEM_C_XTS_FAULT_DETECTED_INT_CLR_V << SPI_MEM_C_XTS_FAULT_DETECTED_INT_CLR_S)
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_CLR_V  0x00000001U
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_CLR_S  13
+/** SPI_MEM_C_RX_TRANS_OVF_INT_CLR : HRO; bitpos: [26]; default: 0;
+ *  The clear bit for SPI_MEM_C_RX_TRANS_OVF_INT interrupt.
+ */
+#define SPI_MEM_C_RX_TRANS_OVF_INT_CLR    (BIT(26))
+#define SPI_MEM_C_RX_TRANS_OVF_INT_CLR_M  (SPI_MEM_C_RX_TRANS_OVF_INT_CLR_V << SPI_MEM_C_RX_TRANS_OVF_INT_CLR_S)
+#define SPI_MEM_C_RX_TRANS_OVF_INT_CLR_V  0x00000001U
+#define SPI_MEM_C_RX_TRANS_OVF_INT_CLR_S  26
+/** SPI_MEM_C_TX_TRANS_UDF_INT_CLR : HRO; bitpos: [27]; default: 0;
+ *  The clear bit for SPI_MEM_C_TX_TRANS_UDF_INT interrupt.
+ */
+#define SPI_MEM_C_TX_TRANS_UDF_INT_CLR    (BIT(27))
+#define SPI_MEM_C_TX_TRANS_UDF_INT_CLR_M  (SPI_MEM_C_TX_TRANS_UDF_INT_CLR_V << SPI_MEM_C_TX_TRANS_UDF_INT_CLR_S)
+#define SPI_MEM_C_TX_TRANS_UDF_INT_CLR_V  0x00000001U
+#define SPI_MEM_C_TX_TRANS_UDF_INT_CLR_S  27
+
+/** SPI_MEM_C_INT_RAW_REG register
+ *  SPI0 interrupt raw register
+ */
+#define SPI_MEM_C_INT_RAW_REG (DR_REG_FLASH_SPI0_BASE + 0xc8)
+/** SPI_MEM_C_SLV_ST_END_INT_RAW : R/WTC/SS; bitpos: [3]; default: 0;
+ *  The raw bit for SPI_MEM_C_SLV_ST_END_INT interrupt. 1: Triggered when spi0_slv_st is
+ *  changed from non idle state to idle state. It means that SPI_CS raises high. 0:
+ *  Others
+ */
+#define SPI_MEM_C_SLV_ST_END_INT_RAW    (BIT(3))
+#define SPI_MEM_C_SLV_ST_END_INT_RAW_M  (SPI_MEM_C_SLV_ST_END_INT_RAW_V << SPI_MEM_C_SLV_ST_END_INT_RAW_S)
+#define SPI_MEM_C_SLV_ST_END_INT_RAW_V  0x00000001U
+#define SPI_MEM_C_SLV_ST_END_INT_RAW_S  3
+/** SPI_MEM_C_MST_ST_END_INT_RAW : R/WTC/SS; bitpos: [4]; default: 0;
+ *  The raw bit for SPI_MEM_C_MST_ST_END_INT interrupt. 1: Triggered when spi0_mst_st is
+ *  changed from non idle state to idle state. 0: Others.
+ */
+#define SPI_MEM_C_MST_ST_END_INT_RAW    (BIT(4))
+#define SPI_MEM_C_MST_ST_END_INT_RAW_M  (SPI_MEM_C_MST_ST_END_INT_RAW_V << SPI_MEM_C_MST_ST_END_INT_RAW_S)
+#define SPI_MEM_C_MST_ST_END_INT_RAW_V  0x00000001U
+#define SPI_MEM_C_MST_ST_END_INT_RAW_S  4
+/** SPI_MEM_C_ECC_ERR_INT_RAW : HRO; bitpos: [5]; default: 0;
+ *  The raw bit for SPI_MEM_C_ECC_ERR_INT interrupt. When SPI_FMEM_C_ECC_ERR_INT_EN is set
+ *  and  SPI_SMEM_C_ECC_ERR_INT_EN is cleared, this bit is triggered when the error times
+ *  of SPI0/1 ECC read flash are equal or bigger than SPI_MEM_C_ECC_ERR_INT_NUM. When
+ *  SPI_FMEM_C_ECC_ERR_INT_EN is cleared and  SPI_SMEM_C_ECC_ERR_INT_EN is set, this bit is
+ *  triggered when the error times of SPI0/1 ECC read external RAM are equal or bigger
+ *  than SPI_MEM_C_ECC_ERR_INT_NUM. When SPI_FMEM_C_ECC_ERR_INT_EN and
+ *  SPI_SMEM_C_ECC_ERR_INT_EN are set, this bit is triggered when the total error times
+ *  of SPI0/1 ECC read external RAM and flash are equal or bigger than
+ *  SPI_MEM_C_ECC_ERR_INT_NUM. When SPI_FMEM_C_ECC_ERR_INT_EN and  SPI_SMEM_C_ECC_ERR_INT_EN
+ *  are cleared, this bit will not be triggered.
+ */
+#define SPI_MEM_C_ECC_ERR_INT_RAW    (BIT(5))
+#define SPI_MEM_C_ECC_ERR_INT_RAW_M  (SPI_MEM_C_ECC_ERR_INT_RAW_V << SPI_MEM_C_ECC_ERR_INT_RAW_S)
+#define SPI_MEM_C_ECC_ERR_INT_RAW_V  0x00000001U
+#define SPI_MEM_C_ECC_ERR_INT_RAW_S  5
+/** SPI_MEM_C_PMS_REJECT_INT_RAW : R/WTC/SS; bitpos: [6]; default: 0;
+ *  The raw bit for SPI_MEM_C_PMS_REJECT_INT interrupt. 1: Triggered when SPI1 access is
+ *  rejected. 0: Others.
+ */
+#define SPI_MEM_C_PMS_REJECT_INT_RAW    (BIT(6))
+#define SPI_MEM_C_PMS_REJECT_INT_RAW_M  (SPI_MEM_C_PMS_REJECT_INT_RAW_V << SPI_MEM_C_PMS_REJECT_INT_RAW_S)
+#define SPI_MEM_C_PMS_REJECT_INT_RAW_V  0x00000001U
+#define SPI_MEM_C_PMS_REJECT_INT_RAW_S  6
+/** SPI_MEM_C_AXI_RADDR_ERR_INT_RAW : R/WTC/SS; bitpos: [7]; default: 0;
+ *  The raw bit for SPI_MEM_C_AXI_RADDR_ERR_INT interrupt. 1: Triggered when AXI read
+ *  address is invalid by compared to MMU configuration. 0: Others.
+ */
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_RAW    (BIT(7))
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_RAW_M  (SPI_MEM_C_AXI_RADDR_ERR_INT_RAW_V << SPI_MEM_C_AXI_RADDR_ERR_INT_RAW_S)
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_RAW_V  0x00000001U
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_RAW_S  7
+/** SPI_MEM_C_AXI_WR_FLASH_ERR_INT_RAW : R/WTC/SS; bitpos: [8]; default: 0;
+ *  The raw bit for SPI_MEM_C_AXI_WR_FALSH_ERR_INT interrupt. 1: Triggered when AXI write
+ *  flash request is received. 0: Others.
+ */
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_RAW    (BIT(8))
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_RAW_M  (SPI_MEM_C_AXI_WR_FLASH_ERR_INT_RAW_V << SPI_MEM_C_AXI_WR_FLASH_ERR_INT_RAW_S)
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_RAW_V  0x00000001U
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_RAW_S  8
+/** SPI_MEM_C_AXI_WADDR_ERR_INT_RAW : R/WTC/SS; bitpos: [9]; default: 0;
+ *  The raw bit for SPI_MEM_C_AXI_WADDR_ERR_INT interrupt. 1: Triggered when AXI write
+ *  address is invalid by compared to MMU configuration. 0: Others.
+ */
+#define SPI_MEM_C_AXI_WADDR_ERR_INT_RAW    (BIT(9))
+#define SPI_MEM_C_AXI_WADDR_ERR_INT_RAW_M  (SPI_MEM_C_AXI_WADDR_ERR_INT_RAW_V << SPI_MEM_C_AXI_WADDR_ERR_INT_RAW_S)
+#define SPI_MEM_C_AXI_WADDR_ERR_INT_RAW_V  0x00000001U
+#define SPI_MEM_C_AXI_WADDR_ERR_INT_RAW_S  9
+/** SPI_MEM_C_NANDFLASH_PE_FAIL_INT_RAW : R/WTC/SS; bitpos: [11]; default: 0;
+ *  The raw bit for SPI_MEM_C_NANDFLASH_PE_FAIL_INT interrupt. 1: Triggered when NAND
+ *  FLASH SPI SEQ found P/E_FAIL bits is err when RDSR. 0: Others.
+ */
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_RAW    (BIT(11))
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_RAW_M  (SPI_MEM_C_NANDFLASH_PE_FAIL_INT_RAW_V << SPI_MEM_C_NANDFLASH_PE_FAIL_INT_RAW_S)
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_RAW_V  0x00000001U
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_RAW_S  11
+/** SPI_MEM_C_NANDFLASH_ECC_ERR_INT_RAW : R/WTC/SS; bitpos: [12]; default: 0;
+ *  The raw bit for SPI_MEM_C_NANDFLASH_ECC_ERR_INT interrupt. 1: Triggered when NAND
+ *  FLASH SPI SEQ found ECCS bits is err when RDSR. 0: Others.
+ */
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_RAW    (BIT(12))
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_RAW_M  (SPI_MEM_C_NANDFLASH_ECC_ERR_INT_RAW_V << SPI_MEM_C_NANDFLASH_ECC_ERR_INT_RAW_S)
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_RAW_V  0x00000001U
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_RAW_S  12
+/** SPI_MEM_C_XTS_FAULT_DETECTED_INT_RAW : R/WTC/SS; bitpos: [13]; default: 0;
+ *  The raw bit for SPI_MEM_C_XTS_FAULT_DETECTED_INT interrupt. 1: Triggered when xts aes
+ *  core detected fault injection attack. 0: Others.
+ */
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_RAW    (BIT(13))
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_RAW_M  (SPI_MEM_C_XTS_FAULT_DETECTED_INT_RAW_V << SPI_MEM_C_XTS_FAULT_DETECTED_INT_RAW_S)
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_RAW_V  0x00000001U
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_RAW_S  13
+/** SPI_MEM_C_RX_TRANS_OVF_INT_RAW : R/WTC/SS; bitpos: [26]; default: 0;
+ *  The raw bit for  SPI_MEM_C_RX_TRANS_OVF_INT interrupt. 1: Triggered when the rx fifo
+ *  to spi bus is overrflow.
+ */
+#define SPI_MEM_C_RX_TRANS_OVF_INT_RAW    (BIT(26))
+#define SPI_MEM_C_RX_TRANS_OVF_INT_RAW_M  (SPI_MEM_C_RX_TRANS_OVF_INT_RAW_V << SPI_MEM_C_RX_TRANS_OVF_INT_RAW_S)
+#define SPI_MEM_C_RX_TRANS_OVF_INT_RAW_V  0x00000001U
+#define SPI_MEM_C_RX_TRANS_OVF_INT_RAW_S  26
+/** SPI_MEM_C_TX_TRANS_UDF_INT_RAW : R/WTC/SS; bitpos: [27]; default: 0;
+ *  The raw bit for SPI_MEM_C_TX_TRANS_UDF_INT interrupt. 1: Triggered when the tx fifo
+ *  to spi bus is underflow.
+ */
+#define SPI_MEM_C_TX_TRANS_UDF_INT_RAW    (BIT(27))
+#define SPI_MEM_C_TX_TRANS_UDF_INT_RAW_M  (SPI_MEM_C_TX_TRANS_UDF_INT_RAW_V << SPI_MEM_C_TX_TRANS_UDF_INT_RAW_S)
+#define SPI_MEM_C_TX_TRANS_UDF_INT_RAW_V  0x00000001U
+#define SPI_MEM_C_TX_TRANS_UDF_INT_RAW_S  27
+
+/** SPI_MEM_C_INT_ST_REG register
+ *  SPI0 interrupt status register
+ */
+#define SPI_MEM_C_INT_ST_REG (DR_REG_FLASH_SPI0_BASE + 0xcc)
+/** SPI_MEM_C_SLV_ST_END_INT_ST : RO; bitpos: [3]; default: 0;
+ *  The status bit for SPI_MEM_C_SLV_ST_END_INT interrupt.
+ */
+#define SPI_MEM_C_SLV_ST_END_INT_ST    (BIT(3))
+#define SPI_MEM_C_SLV_ST_END_INT_ST_M  (SPI_MEM_C_SLV_ST_END_INT_ST_V << SPI_MEM_C_SLV_ST_END_INT_ST_S)
+#define SPI_MEM_C_SLV_ST_END_INT_ST_V  0x00000001U
+#define SPI_MEM_C_SLV_ST_END_INT_ST_S  3
+/** SPI_MEM_C_MST_ST_END_INT_ST : RO; bitpos: [4]; default: 0;
+ *  The status bit for SPI_MEM_C_MST_ST_END_INT interrupt.
+ */
+#define SPI_MEM_C_MST_ST_END_INT_ST    (BIT(4))
+#define SPI_MEM_C_MST_ST_END_INT_ST_M  (SPI_MEM_C_MST_ST_END_INT_ST_V << SPI_MEM_C_MST_ST_END_INT_ST_S)
+#define SPI_MEM_C_MST_ST_END_INT_ST_V  0x00000001U
+#define SPI_MEM_C_MST_ST_END_INT_ST_S  4
+/** SPI_MEM_C_ECC_ERR_INT_ST : RO; bitpos: [5]; default: 0;
+ *  The status bit for SPI_MEM_C_ECC_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_ECC_ERR_INT_ST    (BIT(5))
+#define SPI_MEM_C_ECC_ERR_INT_ST_M  (SPI_MEM_C_ECC_ERR_INT_ST_V << SPI_MEM_C_ECC_ERR_INT_ST_S)
+#define SPI_MEM_C_ECC_ERR_INT_ST_V  0x00000001U
+#define SPI_MEM_C_ECC_ERR_INT_ST_S  5
+/** SPI_MEM_C_PMS_REJECT_INT_ST : RO; bitpos: [6]; default: 0;
+ *  The status bit for SPI_MEM_C_PMS_REJECT_INT interrupt.
+ */
+#define SPI_MEM_C_PMS_REJECT_INT_ST    (BIT(6))
+#define SPI_MEM_C_PMS_REJECT_INT_ST_M  (SPI_MEM_C_PMS_REJECT_INT_ST_V << SPI_MEM_C_PMS_REJECT_INT_ST_S)
+#define SPI_MEM_C_PMS_REJECT_INT_ST_V  0x00000001U
+#define SPI_MEM_C_PMS_REJECT_INT_ST_S  6
+/** SPI_MEM_C_AXI_RADDR_ERR_INT_ST : RO; bitpos: [7]; default: 0;
+ *  The status bit for SPI_MEM_C_AXI_RADDR_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_ST    (BIT(7))
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_ST_M  (SPI_MEM_C_AXI_RADDR_ERR_INT_ST_V << SPI_MEM_C_AXI_RADDR_ERR_INT_ST_S)
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_ST_V  0x00000001U
+#define SPI_MEM_C_AXI_RADDR_ERR_INT_ST_S  7
+/** SPI_MEM_C_AXI_WR_FLASH_ERR_INT_ST : RO; bitpos: [8]; default: 0;
+ *  The status bit for SPI_MEM_C_AXI_WR_FALSH_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_ST    (BIT(8))
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_ST_M  (SPI_MEM_C_AXI_WR_FLASH_ERR_INT_ST_V << SPI_MEM_C_AXI_WR_FLASH_ERR_INT_ST_S)
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_ST_V  0x00000001U
+#define SPI_MEM_C_AXI_WR_FLASH_ERR_INT_ST_S  8
+/** SPI_MEM_C_AXI_WADDR_ERR_INT_ST : RO; bitpos: [9]; default: 0;
+ *  The status bit for SPI_MEM_C_AXI_WADDR_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_AXI_WADDR_ERR_INT_ST    (BIT(9))
+#define SPI_MEM_C_AXI_WADDR_ERR_INT_ST_M  (SPI_MEM_C_AXI_WADDR_ERR_INT_ST_V << SPI_MEM_C_AXI_WADDR_ERR_INT_ST_S)
+#define SPI_MEM_C_AXI_WADDR_ERR_INT_ST_V  0x00000001U
+#define SPI_MEM_C_AXI_WADDR_ERR_INT_ST_S  9
+/** SPI_MEM_C_NANDFLASH_PE_FAIL_INT_ST : RO; bitpos: [11]; default: 0;
+ *  The status bit for SPI_MEM_C_NANDFLASH_PE_FAIL_INT interrupt.
+ */
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_ST    (BIT(11))
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_ST_M  (SPI_MEM_C_NANDFLASH_PE_FAIL_INT_ST_V << SPI_MEM_C_NANDFLASH_PE_FAIL_INT_ST_S)
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_ST_V  0x00000001U
+#define SPI_MEM_C_NANDFLASH_PE_FAIL_INT_ST_S  11
+/** SPI_MEM_C_NANDFLASH_ECC_ERR_INT_ST : RO; bitpos: [12]; default: 0;
+ *  The status bit for SPI_MEM_C_NANDFLASH_ECC_ERR_INT interrupt.
+ */
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_ST    (BIT(12))
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_ST_M  (SPI_MEM_C_NANDFLASH_ECC_ERR_INT_ST_V << SPI_MEM_C_NANDFLASH_ECC_ERR_INT_ST_S)
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_ST_V  0x00000001U
+#define SPI_MEM_C_NANDFLASH_ECC_ERR_INT_ST_S  12
+/** SPI_MEM_C_XTS_FAULT_DETECTED_INT_ST : RO; bitpos: [13]; default: 0;
+ *  The status bit for SPI_MEM_C_XTS_FAULT_DETECTED_INT interrupt.
+ */
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_ST    (BIT(13))
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_ST_M  (SPI_MEM_C_XTS_FAULT_DETECTED_INT_ST_V << SPI_MEM_C_XTS_FAULT_DETECTED_INT_ST_S)
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_ST_V  0x00000001U
+#define SPI_MEM_C_XTS_FAULT_DETECTED_INT_ST_S  13
+/** SPI_MEM_C_RX_TRANS_OVF_INT_ST : HRO; bitpos: [26]; default: 0;
+ *  The status bit for  SPI_MEM_C_RX_TRANS_OVF_INT interrupt.
+ */
+#define SPI_MEM_C_RX_TRANS_OVF_INT_ST    (BIT(26))
+#define SPI_MEM_C_RX_TRANS_OVF_INT_ST_M  (SPI_MEM_C_RX_TRANS_OVF_INT_ST_V << SPI_MEM_C_RX_TRANS_OVF_INT_ST_S)
+#define SPI_MEM_C_RX_TRANS_OVF_INT_ST_V  0x00000001U
+#define SPI_MEM_C_RX_TRANS_OVF_INT_ST_S  26
+/** SPI_MEM_C_TX_TRANS_UDF_INT_ST : HRO; bitpos: [27]; default: 0;
+ *  The status bit for SPI_MEM_C_TX_TRANS_UDF_INT interrupt.
+ */
+#define SPI_MEM_C_TX_TRANS_UDF_INT_ST    (BIT(27))
+#define SPI_MEM_C_TX_TRANS_UDF_INT_ST_M  (SPI_MEM_C_TX_TRANS_UDF_INT_ST_V << SPI_MEM_C_TX_TRANS_UDF_INT_ST_S)
+#define SPI_MEM_C_TX_TRANS_UDF_INT_ST_V  0x00000001U
+#define SPI_MEM_C_TX_TRANS_UDF_INT_ST_S  27
+
+/** SPI_MEM_C_DDR_REG register
+ *  SPI0 flash DDR mode control register
+ */
+#define SPI_MEM_C_DDR_REG (DR_REG_FLASH_SPI0_BASE + 0xd4)
+/** SPI_FMEM_C_DDR_EN : R/W; bitpos: [0]; default: 0;
+ *  1: in DDR mode,  0 in SDR mode
+ */
+#define SPI_FMEM_C_DDR_EN    (BIT(0))
+#define SPI_FMEM_C_DDR_EN_M  (SPI_FMEM_C_DDR_EN_V << SPI_FMEM_C_DDR_EN_S)
+#define SPI_FMEM_C_DDR_EN_V  0x00000001U
+#define SPI_FMEM_C_DDR_EN_S  0
+/** SPI_FMEM_C_VAR_DUMMY : HRO; bitpos: [1]; default: 0;
+ *  Set the bit to enable variable dummy cycle in spi DDR mode.
+ */
+#define SPI_FMEM_C_VAR_DUMMY    (BIT(1))
+#define SPI_FMEM_C_VAR_DUMMY_M  (SPI_FMEM_C_VAR_DUMMY_V << SPI_FMEM_C_VAR_DUMMY_S)
+#define SPI_FMEM_C_VAR_DUMMY_V  0x00000001U
+#define SPI_FMEM_C_VAR_DUMMY_S  1
+/** SPI_FMEM_C_DDR_RDAT_SWP : HRO; bitpos: [2]; default: 0;
+ *  Set the bit to reorder rx data of the word in spi DDR mode.
+ */
+#define SPI_FMEM_C_DDR_RDAT_SWP    (BIT(2))
+#define SPI_FMEM_C_DDR_RDAT_SWP_M  (SPI_FMEM_C_DDR_RDAT_SWP_V << SPI_FMEM_C_DDR_RDAT_SWP_S)
+#define SPI_FMEM_C_DDR_RDAT_SWP_V  0x00000001U
+#define SPI_FMEM_C_DDR_RDAT_SWP_S  2
+/** SPI_FMEM_C_DDR_WDAT_SWP : HRO; bitpos: [3]; default: 0;
+ *  Set the bit to reorder tx data of the word in spi DDR mode.
+ */
+#define SPI_FMEM_C_DDR_WDAT_SWP    (BIT(3))
+#define SPI_FMEM_C_DDR_WDAT_SWP_M  (SPI_FMEM_C_DDR_WDAT_SWP_V << SPI_FMEM_C_DDR_WDAT_SWP_S)
+#define SPI_FMEM_C_DDR_WDAT_SWP_V  0x00000001U
+#define SPI_FMEM_C_DDR_WDAT_SWP_S  3
+/** SPI_FMEM_C_DDR_CMD_DIS : R/W; bitpos: [4]; default: 0;
+ *  the bit is used to disable dual edge in command phase when DDR mode.
+ */
+#define SPI_FMEM_C_DDR_CMD_DIS    (BIT(4))
+#define SPI_FMEM_C_DDR_CMD_DIS_M  (SPI_FMEM_C_DDR_CMD_DIS_V << SPI_FMEM_C_DDR_CMD_DIS_S)
+#define SPI_FMEM_C_DDR_CMD_DIS_V  0x00000001U
+#define SPI_FMEM_C_DDR_CMD_DIS_S  4
+/** SPI_FMEM_C_OUTMINBYTELEN : HRO; bitpos: [11:5]; default: 1;
+ *  It is the minimum output data length in the panda device.
+ */
+#define SPI_FMEM_C_OUTMINBYTELEN    0x0000007FU
+#define SPI_FMEM_C_OUTMINBYTELEN_M  (SPI_FMEM_C_OUTMINBYTELEN_V << SPI_FMEM_C_OUTMINBYTELEN_S)
+#define SPI_FMEM_C_OUTMINBYTELEN_V  0x0000007FU
+#define SPI_FMEM_C_OUTMINBYTELEN_S  5
+/** SPI_FMEM_C_TX_DDR_MSK_EN : R/W; bitpos: [12]; default: 1;
+ *  Set this bit to mask the first or the last byte in SPI0 ECC DDR write mode, when
+ *  accesses to flash.
+ */
+#define SPI_FMEM_C_TX_DDR_MSK_EN    (BIT(12))
+#define SPI_FMEM_C_TX_DDR_MSK_EN_M  (SPI_FMEM_C_TX_DDR_MSK_EN_V << SPI_FMEM_C_TX_DDR_MSK_EN_S)
+#define SPI_FMEM_C_TX_DDR_MSK_EN_V  0x00000001U
+#define SPI_FMEM_C_TX_DDR_MSK_EN_S  12
+/** SPI_FMEM_C_RX_DDR_MSK_EN : R/W; bitpos: [13]; default: 1;
+ *  Set this bit to mask the first or the last byte in SPI0 ECC DDR read mode, when
+ *  accesses to flash.
+ */
+#define SPI_FMEM_C_RX_DDR_MSK_EN    (BIT(13))
+#define SPI_FMEM_C_RX_DDR_MSK_EN_M  (SPI_FMEM_C_RX_DDR_MSK_EN_V << SPI_FMEM_C_RX_DDR_MSK_EN_S)
+#define SPI_FMEM_C_RX_DDR_MSK_EN_V  0x00000001U
+#define SPI_FMEM_C_RX_DDR_MSK_EN_S  13
+/** SPI_FMEM_C_USR_DDR_DQS_THD : HRO; bitpos: [20:14]; default: 0;
+ *  The delay number of data strobe which from memory based on SPI clock.
+ */
+#define SPI_FMEM_C_USR_DDR_DQS_THD    0x0000007FU
+#define SPI_FMEM_C_USR_DDR_DQS_THD_M  (SPI_FMEM_C_USR_DDR_DQS_THD_V << SPI_FMEM_C_USR_DDR_DQS_THD_S)
+#define SPI_FMEM_C_USR_DDR_DQS_THD_V  0x0000007FU
+#define SPI_FMEM_C_USR_DDR_DQS_THD_S  14
+/** SPI_FMEM_C_DDR_DQS_LOOP : HRO; bitpos: [21]; default: 0;
+ *  1: Do not need the input of SPI_DQS signal, SPI0 starts to receive data when
+ *  spi0_slv_st is in SPI_MEM_C_DIN state. It is used when there is no SPI_DQS signal or
+ *  SPI_DQS signal is not stable. 0: SPI0 starts to store data at the positive and
+ *  negative edge of SPI_DQS.
+ */
+#define SPI_FMEM_C_DDR_DQS_LOOP    (BIT(21))
+#define SPI_FMEM_C_DDR_DQS_LOOP_M  (SPI_FMEM_C_DDR_DQS_LOOP_V << SPI_FMEM_C_DDR_DQS_LOOP_S)
+#define SPI_FMEM_C_DDR_DQS_LOOP_V  0x00000001U
+#define SPI_FMEM_C_DDR_DQS_LOOP_S  21
+/** SPI_FMEM_C_CLK_DIFF_EN : HRO; bitpos: [24]; default: 0;
+ *  Set this bit to enable the differential SPI_CLK#.
+ */
+#define SPI_FMEM_C_CLK_DIFF_EN    (BIT(24))
+#define SPI_FMEM_C_CLK_DIFF_EN_M  (SPI_FMEM_C_CLK_DIFF_EN_V << SPI_FMEM_C_CLK_DIFF_EN_S)
+#define SPI_FMEM_C_CLK_DIFF_EN_V  0x00000001U
+#define SPI_FMEM_C_CLK_DIFF_EN_S  24
+/** SPI_FMEM_C_DQS_CA_IN : HRO; bitpos: [26]; default: 0;
+ *  Set this bit to enable the input of SPI_DQS signal in SPI phases of CMD and ADDR.
+ */
+#define SPI_FMEM_C_DQS_CA_IN    (BIT(26))
+#define SPI_FMEM_C_DQS_CA_IN_M  (SPI_FMEM_C_DQS_CA_IN_V << SPI_FMEM_C_DQS_CA_IN_S)
+#define SPI_FMEM_C_DQS_CA_IN_V  0x00000001U
+#define SPI_FMEM_C_DQS_CA_IN_S  26
+/** SPI_FMEM_C_HYPERBUS_DUMMY_2X : HRO; bitpos: [27]; default: 0;
+ *  Set this bit to enable the vary dummy function in SPI HyperBus mode, when SPI0
+ *  accesses flash or SPI1 accesses flash or sram.
+ */
+#define SPI_FMEM_C_HYPERBUS_DUMMY_2X    (BIT(27))
+#define SPI_FMEM_C_HYPERBUS_DUMMY_2X_M  (SPI_FMEM_C_HYPERBUS_DUMMY_2X_V << SPI_FMEM_C_HYPERBUS_DUMMY_2X_S)
+#define SPI_FMEM_C_HYPERBUS_DUMMY_2X_V  0x00000001U
+#define SPI_FMEM_C_HYPERBUS_DUMMY_2X_S  27
+/** SPI_FMEM_C_CLK_DIFF_INV : HRO; bitpos: [28]; default: 0;
+ *  Set this bit to invert SPI_DIFF when accesses to flash. .
+ */
+#define SPI_FMEM_C_CLK_DIFF_INV    (BIT(28))
+#define SPI_FMEM_C_CLK_DIFF_INV_M  (SPI_FMEM_C_CLK_DIFF_INV_V << SPI_FMEM_C_CLK_DIFF_INV_S)
+#define SPI_FMEM_C_CLK_DIFF_INV_V  0x00000001U
+#define SPI_FMEM_C_CLK_DIFF_INV_S  28
+/** SPI_FMEM_C_OCTA_RAM_ADDR : HRO; bitpos: [29]; default: 0;
+ *  Set this bit to enable octa_ram address out when accesses to flash, which means
+ *  ADDR_OUT[31:0] = {spi_usr_addr_value[25:4], 6'd0, spi_usr_addr_value[3:1], 1'b0}.
+ */
+#define SPI_FMEM_C_OCTA_RAM_ADDR    (BIT(29))
+#define SPI_FMEM_C_OCTA_RAM_ADDR_M  (SPI_FMEM_C_OCTA_RAM_ADDR_V << SPI_FMEM_C_OCTA_RAM_ADDR_S)
+#define SPI_FMEM_C_OCTA_RAM_ADDR_V  0x00000001U
+#define SPI_FMEM_C_OCTA_RAM_ADDR_S  29
+/** SPI_FMEM_C_HYPERBUS_CA : HRO; bitpos: [30]; default: 0;
+ *  Set this bit to enable HyperRAM address out when accesses to flash, which means
+ *  ADDR_OUT[31:0] = {spi_usr_addr_value[19:4], 13'd0, spi_usr_addr_value[3:1]}.
+ */
+#define SPI_FMEM_C_HYPERBUS_CA    (BIT(30))
+#define SPI_FMEM_C_HYPERBUS_CA_M  (SPI_FMEM_C_HYPERBUS_CA_V << SPI_FMEM_C_HYPERBUS_CA_S)
+#define SPI_FMEM_C_HYPERBUS_CA_V  0x00000001U
+#define SPI_FMEM_C_HYPERBUS_CA_S  30
+
+/** SPI_SMEM_C_DDR_REG register
+ *  SPI0 external RAM DDR mode control register
+ */
+#define SPI_SMEM_C_DDR_REG (DR_REG_FLASH_SPI0_BASE + 0xd8)
+/** SPI_SMEM_C_DDR_EN : HRO; bitpos: [0]; default: 0;
+ *  1: in DDR mode,  0 in SDR mode
+ */
+#define SPI_SMEM_C_DDR_EN    (BIT(0))
+#define SPI_SMEM_C_DDR_EN_M  (SPI_SMEM_C_DDR_EN_V << SPI_SMEM_C_DDR_EN_S)
+#define SPI_SMEM_C_DDR_EN_V  0x00000001U
+#define SPI_SMEM_C_DDR_EN_S  0
+/** SPI_SMEM_C_VAR_DUMMY : HRO; bitpos: [1]; default: 0;
+ *  Set the bit to enable variable dummy cycle in spi DDR mode.
+ */
+#define SPI_SMEM_C_VAR_DUMMY    (BIT(1))
+#define SPI_SMEM_C_VAR_DUMMY_M  (SPI_SMEM_C_VAR_DUMMY_V << SPI_SMEM_C_VAR_DUMMY_S)
+#define SPI_SMEM_C_VAR_DUMMY_V  0x00000001U
+#define SPI_SMEM_C_VAR_DUMMY_S  1
+/** SPI_SMEM_C_DDR_RDAT_SWP : HRO; bitpos: [2]; default: 0;
+ *  Set the bit to reorder rx data of the word in spi DDR mode.
+ */
+#define SPI_SMEM_C_DDR_RDAT_SWP    (BIT(2))
+#define SPI_SMEM_C_DDR_RDAT_SWP_M  (SPI_SMEM_C_DDR_RDAT_SWP_V << SPI_SMEM_C_DDR_RDAT_SWP_S)
+#define SPI_SMEM_C_DDR_RDAT_SWP_V  0x00000001U
+#define SPI_SMEM_C_DDR_RDAT_SWP_S  2
+/** SPI_SMEM_C_DDR_WDAT_SWP : HRO; bitpos: [3]; default: 0;
+ *  Set the bit to reorder tx data of the word in spi DDR mode.
+ */
+#define SPI_SMEM_C_DDR_WDAT_SWP    (BIT(3))
+#define SPI_SMEM_C_DDR_WDAT_SWP_M  (SPI_SMEM_C_DDR_WDAT_SWP_V << SPI_SMEM_C_DDR_WDAT_SWP_S)
+#define SPI_SMEM_C_DDR_WDAT_SWP_V  0x00000001U
+#define SPI_SMEM_C_DDR_WDAT_SWP_S  3
+/** SPI_SMEM_C_DDR_CMD_DIS : HRO; bitpos: [4]; default: 0;
+ *  the bit is used to disable dual edge in command phase when DDR mode.
+ */
+#define SPI_SMEM_C_DDR_CMD_DIS    (BIT(4))
+#define SPI_SMEM_C_DDR_CMD_DIS_M  (SPI_SMEM_C_DDR_CMD_DIS_V << SPI_SMEM_C_DDR_CMD_DIS_S)
+#define SPI_SMEM_C_DDR_CMD_DIS_V  0x00000001U
+#define SPI_SMEM_C_DDR_CMD_DIS_S  4
+/** SPI_SMEM_C_OUTMINBYTELEN : HRO; bitpos: [11:5]; default: 1;
+ *  It is the minimum output data length in the DDR psram.
+ */
+#define SPI_SMEM_C_OUTMINBYTELEN    0x0000007FU
+#define SPI_SMEM_C_OUTMINBYTELEN_M  (SPI_SMEM_C_OUTMINBYTELEN_V << SPI_SMEM_C_OUTMINBYTELEN_S)
+#define SPI_SMEM_C_OUTMINBYTELEN_V  0x0000007FU
+#define SPI_SMEM_C_OUTMINBYTELEN_S  5
+/** SPI_SMEM_C_TX_DDR_MSK_EN : HRO; bitpos: [12]; default: 1;
+ *  Set this bit to mask the first or the last byte in SPI0 ECC DDR write mode, when
+ *  accesses to external RAM.
+ */
+#define SPI_SMEM_C_TX_DDR_MSK_EN    (BIT(12))
+#define SPI_SMEM_C_TX_DDR_MSK_EN_M  (SPI_SMEM_C_TX_DDR_MSK_EN_V << SPI_SMEM_C_TX_DDR_MSK_EN_S)
+#define SPI_SMEM_C_TX_DDR_MSK_EN_V  0x00000001U
+#define SPI_SMEM_C_TX_DDR_MSK_EN_S  12
+/** SPI_SMEM_C_RX_DDR_MSK_EN : HRO; bitpos: [13]; default: 1;
+ *  Set this bit to mask the first or the last byte in SPI0 ECC DDR read mode, when
+ *  accesses to external RAM.
+ */
+#define SPI_SMEM_C_RX_DDR_MSK_EN    (BIT(13))
+#define SPI_SMEM_C_RX_DDR_MSK_EN_M  (SPI_SMEM_C_RX_DDR_MSK_EN_V << SPI_SMEM_C_RX_DDR_MSK_EN_S)
+#define SPI_SMEM_C_RX_DDR_MSK_EN_V  0x00000001U
+#define SPI_SMEM_C_RX_DDR_MSK_EN_S  13
+/** SPI_SMEM_C_USR_DDR_DQS_THD : HRO; bitpos: [20:14]; default: 0;
+ *  The delay number of data strobe which from memory based on SPI clock.
+ */
+#define SPI_SMEM_C_USR_DDR_DQS_THD    0x0000007FU
+#define SPI_SMEM_C_USR_DDR_DQS_THD_M  (SPI_SMEM_C_USR_DDR_DQS_THD_V << SPI_SMEM_C_USR_DDR_DQS_THD_S)
+#define SPI_SMEM_C_USR_DDR_DQS_THD_V  0x0000007FU
+#define SPI_SMEM_C_USR_DDR_DQS_THD_S  14
+/** SPI_SMEM_C_DDR_DQS_LOOP : HRO; bitpos: [21]; default: 0;
+ *  1: Do not need the input of SPI_DQS signal, SPI0 starts to receive data when
+ *  spi0_slv_st is in SPI_MEM_C_DIN state. It is used when there is no SPI_DQS signal or
+ *  SPI_DQS signal is not stable. 0: SPI0 starts to store data at the positive and
+ *  negative edge of SPI_DQS.
+ */
+#define SPI_SMEM_C_DDR_DQS_LOOP    (BIT(21))
+#define SPI_SMEM_C_DDR_DQS_LOOP_M  (SPI_SMEM_C_DDR_DQS_LOOP_V << SPI_SMEM_C_DDR_DQS_LOOP_S)
+#define SPI_SMEM_C_DDR_DQS_LOOP_V  0x00000001U
+#define SPI_SMEM_C_DDR_DQS_LOOP_S  21
+/** SPI_SMEM_C_CLK_DIFF_EN : HRO; bitpos: [24]; default: 0;
+ *  Set this bit to enable the differential SPI_CLK#.
+ */
+#define SPI_SMEM_C_CLK_DIFF_EN    (BIT(24))
+#define SPI_SMEM_C_CLK_DIFF_EN_M  (SPI_SMEM_C_CLK_DIFF_EN_V << SPI_SMEM_C_CLK_DIFF_EN_S)
+#define SPI_SMEM_C_CLK_DIFF_EN_V  0x00000001U
+#define SPI_SMEM_C_CLK_DIFF_EN_S  24
+/** SPI_SMEM_C_DQS_CA_IN : HRO; bitpos: [26]; default: 0;
+ *  Set this bit to enable the input of SPI_DQS signal in SPI phases of CMD and ADDR.
+ */
+#define SPI_SMEM_C_DQS_CA_IN    (BIT(26))
+#define SPI_SMEM_C_DQS_CA_IN_M  (SPI_SMEM_C_DQS_CA_IN_V << SPI_SMEM_C_DQS_CA_IN_S)
+#define SPI_SMEM_C_DQS_CA_IN_V  0x00000001U
+#define SPI_SMEM_C_DQS_CA_IN_S  26
+/** SPI_SMEM_C_HYPERBUS_DUMMY_2X : HRO; bitpos: [27]; default: 0;
+ *  Set this bit to enable the vary dummy function in SPI HyperBus mode, when SPI0
+ *  accesses flash or SPI1 accesses flash or sram.
+ */
+#define SPI_SMEM_C_HYPERBUS_DUMMY_2X    (BIT(27))
+#define SPI_SMEM_C_HYPERBUS_DUMMY_2X_M  (SPI_SMEM_C_HYPERBUS_DUMMY_2X_V << SPI_SMEM_C_HYPERBUS_DUMMY_2X_S)
+#define SPI_SMEM_C_HYPERBUS_DUMMY_2X_V  0x00000001U
+#define SPI_SMEM_C_HYPERBUS_DUMMY_2X_S  27
+/** SPI_SMEM_C_CLK_DIFF_INV : HRO; bitpos: [28]; default: 0;
+ *  Set this bit to invert SPI_DIFF when accesses to external RAM. .
+ */
+#define SPI_SMEM_C_CLK_DIFF_INV    (BIT(28))
+#define SPI_SMEM_C_CLK_DIFF_INV_M  (SPI_SMEM_C_CLK_DIFF_INV_V << SPI_SMEM_C_CLK_DIFF_INV_S)
+#define SPI_SMEM_C_CLK_DIFF_INV_V  0x00000001U
+#define SPI_SMEM_C_CLK_DIFF_INV_S  28
+/** SPI_SMEM_C_OCTA_RAM_ADDR : HRO; bitpos: [29]; default: 0;
+ *  Set this bit to enable octa_ram address out when accesses to external RAM, which
+ *  means ADDR_OUT[31:0] = {spi_usr_addr_value[25:4], 6'd0, spi_usr_addr_value[3:1],
+ *  1'b0}.
+ */
+#define SPI_SMEM_C_OCTA_RAM_ADDR    (BIT(29))
+#define SPI_SMEM_C_OCTA_RAM_ADDR_M  (SPI_SMEM_C_OCTA_RAM_ADDR_V << SPI_SMEM_C_OCTA_RAM_ADDR_S)
+#define SPI_SMEM_C_OCTA_RAM_ADDR_V  0x00000001U
+#define SPI_SMEM_C_OCTA_RAM_ADDR_S  29
+/** SPI_SMEM_C_HYPERBUS_CA : HRO; bitpos: [30]; default: 0;
+ *  Set this bit to enable HyperRAM address out when accesses to external RAM, which
+ *  means ADDR_OUT[31:0] = {spi_usr_addr_value[19:4], 13'd0, spi_usr_addr_value[3:1]}.
+ */
+#define SPI_SMEM_C_HYPERBUS_CA    (BIT(30))
+#define SPI_SMEM_C_HYPERBUS_CA_M  (SPI_SMEM_C_HYPERBUS_CA_V << SPI_SMEM_C_HYPERBUS_CA_S)
+#define SPI_SMEM_C_HYPERBUS_CA_V  0x00000001U
+#define SPI_SMEM_C_HYPERBUS_CA_S  30
+
+/** SPI_MEM_C_DLL_DLY_DB_REG register
+ *  MSPI DLL function and debug configuration register
+ */
+#define SPI_MEM_C_DLL_DLY_DB_REG (DR_REG_FLASH_SPI0_BASE + 0xdc)
+/** SPI_MEM_C_DLL_DB_CFG_VLD_CNT : HRO; bitpos: [7:0]; default: 0;
+ *  Configures the end time of the debug window.
+ */
+#define SPI_MEM_C_DLL_DB_CFG_VLD_CNT    0x000000FFU
+#define SPI_MEM_C_DLL_DB_CFG_VLD_CNT_M  (SPI_MEM_C_DLL_DB_CFG_VLD_CNT_V << SPI_MEM_C_DLL_DB_CFG_VLD_CNT_S)
+#define SPI_MEM_C_DLL_DB_CFG_VLD_CNT_V  0x000000FFU
+#define SPI_MEM_C_DLL_DB_CFG_VLD_CNT_S  0
+/** SPI_MEM_C_DLL_DB_CNT_MODE_SEL : HRO; bitpos: [11:8]; default: 0;
+ *  [3]:1-spi_din[15:8]. 0-spi_din[7:0]. [2]:1-only shift wptr or rptr. 0-both shift
+ *  wptr and rptr. [1]:1-wprt[3:0] and rptr[3:0]. 0-rptr[3:0] and wprt[3:0].
+ *  [0]:1-neg_ptr[3:0]. 0-pos_prt[3:0].
+ */
+#define SPI_MEM_C_DLL_DB_CNT_MODE_SEL    0x0000000FU
+#define SPI_MEM_C_DLL_DB_CNT_MODE_SEL_M  (SPI_MEM_C_DLL_DB_CNT_MODE_SEL_V << SPI_MEM_C_DLL_DB_CNT_MODE_SEL_S)
+#define SPI_MEM_C_DLL_DB_CNT_MODE_SEL_V  0x0000000FU
+#define SPI_MEM_C_DLL_DB_CNT_MODE_SEL_S  8
+/** SPI_MEM_C_DLL_DB_CNT_CLR : HRO; bitpos: [12]; default: 0;
+ *  Configures the start time of the debug window. 1: Clear db_vld_cnt to 0 and Get
+ *  ready for debug. 0: No debug.
+ */
+#define SPI_MEM_C_DLL_DB_CNT_CLR    (BIT(12))
+#define SPI_MEM_C_DLL_DB_CNT_CLR_M  (SPI_MEM_C_DLL_DB_CNT_CLR_V << SPI_MEM_C_DLL_DB_CNT_CLR_S)
+#define SPI_MEM_C_DLL_DB_CNT_CLR_V  0x00000001U
+#define SPI_MEM_C_DLL_DB_CNT_CLR_S  12
+/** SPI_MEM_C_DLL_DIN_DLY_SEL : HRO; bitpos: [13]; default: 0;
+ *  Configures the din channel. 1: Use  delayed data. 0: Do not use delayed data.
+ */
+#define SPI_MEM_C_DLL_DIN_DLY_SEL    (BIT(13))
+#define SPI_MEM_C_DLL_DIN_DLY_SEL_M  (SPI_MEM_C_DLL_DIN_DLY_SEL_V << SPI_MEM_C_DLL_DIN_DLY_SEL_S)
+#define SPI_MEM_C_DLL_DIN_DLY_SEL_V  0x00000001U
+#define SPI_MEM_C_DLL_DIN_DLY_SEL_S  13
+
+/** SPI_MEM_C_DLL_DB_ST0_REG register
+ *  MSPI DLL debug status0 register
+ */
+#define SPI_MEM_C_DLL_DB_ST0_REG (DR_REG_FLASH_SPI0_BASE + 0xe0)
+/** SPI_MEM_C_DB_FIFO_CNT_H : RO; bitpos: [31:0]; default: 0;
+ *  Debug  for DLL FIFO pointer. Use a 64bits shift register to record pointer changes
+ *  during the debug window. db_fifo_cnt[63:32]
+ */
+#define SPI_MEM_C_DB_FIFO_CNT_H    0xFFFFFFFFU
+#define SPI_MEM_C_DB_FIFO_CNT_H_M  (SPI_MEM_C_DB_FIFO_CNT_H_V << SPI_MEM_C_DB_FIFO_CNT_H_S)
+#define SPI_MEM_C_DB_FIFO_CNT_H_V  0xFFFFFFFFU
+#define SPI_MEM_C_DB_FIFO_CNT_H_S  0
+
+/** SPI_MEM_C_DLL_DB_ST1_REG register
+ *  MSPI DLL debug status1 register
+ */
+#define SPI_MEM_C_DLL_DB_ST1_REG (DR_REG_FLASH_SPI0_BASE + 0xe4)
+/** SPI_MEM_C_DB_FIFO_CNT_L : RO; bitpos: [31:0]; default: 0;
+ *  Debug  for DLL FIFO pointer. Use a 64bits shift register to record pointer changes
+ *  during the debug window. db_fifo_cnt[31:0]
+ */
+#define SPI_MEM_C_DB_FIFO_CNT_L    0xFFFFFFFFU
+#define SPI_MEM_C_DB_FIFO_CNT_L_M  (SPI_MEM_C_DB_FIFO_CNT_L_V << SPI_MEM_C_DB_FIFO_CNT_L_S)
+#define SPI_MEM_C_DB_FIFO_CNT_L_V  0xFFFFFFFFU
+#define SPI_MEM_C_DB_FIFO_CNT_L_S  0
+
+/** SPI_FMEM_C_PMS0_ATTR_REG register
+ *  SPI1 flash PMS section 0 attribute register
+ */
+#define SPI_FMEM_C_PMS0_ATTR_REG (DR_REG_FLASH_SPI0_BASE + 0x100)
+/** SPI_FMEM_C_PMS0_RD_ATTR : R/W; bitpos: [0]; default: 1;
+ *  1: SPI1 flash PMS section 0 read accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS0_RD_ATTR    (BIT(0))
+#define SPI_FMEM_C_PMS0_RD_ATTR_M  (SPI_FMEM_C_PMS0_RD_ATTR_V << SPI_FMEM_C_PMS0_RD_ATTR_S)
+#define SPI_FMEM_C_PMS0_RD_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS0_RD_ATTR_S  0
+/** SPI_FMEM_C_PMS0_WR_ATTR : R/W; bitpos: [1]; default: 1;
+ *  1: SPI1 flash PMS section 0 write accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS0_WR_ATTR    (BIT(1))
+#define SPI_FMEM_C_PMS0_WR_ATTR_M  (SPI_FMEM_C_PMS0_WR_ATTR_V << SPI_FMEM_C_PMS0_WR_ATTR_S)
+#define SPI_FMEM_C_PMS0_WR_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS0_WR_ATTR_S  1
+/** SPI_FMEM_C_PMS0_ECC : R/W; bitpos: [2]; default: 0;
+ *  SPI1 flash PMS section 0 ECC mode, 1: enable ECC mode. 0: Disable it. The flash PMS
+ *  section 0 is configured by registers SPI_FMEM_C_PMS0_ADDR_REG and
+ *  SPI_FMEM_C_PMS0_SIZE_REG.
+ */
+#define SPI_FMEM_C_PMS0_ECC    (BIT(2))
+#define SPI_FMEM_C_PMS0_ECC_M  (SPI_FMEM_C_PMS0_ECC_V << SPI_FMEM_C_PMS0_ECC_S)
+#define SPI_FMEM_C_PMS0_ECC_V  0x00000001U
+#define SPI_FMEM_C_PMS0_ECC_S  2
+/** SPI_FMEM_C_PMS0_NONSECURE_RD_ATTR : R/W; bitpos: [3]; default: 1;
+ *  1: SPI1 flash  non-secure PMS section 0 read accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS0_NONSECURE_RD_ATTR    (BIT(3))
+#define SPI_FMEM_C_PMS0_NONSECURE_RD_ATTR_M  (SPI_FMEM_C_PMS0_NONSECURE_RD_ATTR_V << SPI_FMEM_C_PMS0_NONSECURE_RD_ATTR_S)
+#define SPI_FMEM_C_PMS0_NONSECURE_RD_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS0_NONSECURE_RD_ATTR_S  3
+/** SPI_FMEM_C_PMS0_NONSECURE_WR_ATTR : R/W; bitpos: [4]; default: 1;
+ *  1: SPI1 flash non-secure PMS section 0 write accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS0_NONSECURE_WR_ATTR    (BIT(4))
+#define SPI_FMEM_C_PMS0_NONSECURE_WR_ATTR_M  (SPI_FMEM_C_PMS0_NONSECURE_WR_ATTR_V << SPI_FMEM_C_PMS0_NONSECURE_WR_ATTR_S)
+#define SPI_FMEM_C_PMS0_NONSECURE_WR_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS0_NONSECURE_WR_ATTR_S  4
+/** SPI_FMEM_C_PMS0_NONSECURE_ECC : R/W; bitpos: [5]; default: 0;
+ *  SPI1 flash non-secure PMS section 0 ECC mode, 1: enable ECC mode. 0: Disable it.
+ *  The flash PMS section 0 is configured by registers SPI_FMEM_C_PMS0_ADDR_REG and
+ *  SPI_FMEM_C_PMS0_SIZE_REG.
+ */
+#define SPI_FMEM_C_PMS0_NONSECURE_ECC    (BIT(5))
+#define SPI_FMEM_C_PMS0_NONSECURE_ECC_M  (SPI_FMEM_C_PMS0_NONSECURE_ECC_V << SPI_FMEM_C_PMS0_NONSECURE_ECC_S)
+#define SPI_FMEM_C_PMS0_NONSECURE_ECC_V  0x00000001U
+#define SPI_FMEM_C_PMS0_NONSECURE_ECC_S  5
+
+/** SPI_FMEM_C_PMS1_ATTR_REG register
+ *  SPI1 flash PMS section 1 attribute register
+ */
+#define SPI_FMEM_C_PMS1_ATTR_REG (DR_REG_FLASH_SPI0_BASE + 0x104)
+/** SPI_FMEM_C_PMS1_RD_ATTR : R/W; bitpos: [0]; default: 1;
+ *  1: SPI1 flash PMS section 1 read accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS1_RD_ATTR    (BIT(0))
+#define SPI_FMEM_C_PMS1_RD_ATTR_M  (SPI_FMEM_C_PMS1_RD_ATTR_V << SPI_FMEM_C_PMS1_RD_ATTR_S)
+#define SPI_FMEM_C_PMS1_RD_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS1_RD_ATTR_S  0
+/** SPI_FMEM_C_PMS1_WR_ATTR : R/W; bitpos: [1]; default: 1;
+ *  1: SPI1 flash PMS section 1 write accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS1_WR_ATTR    (BIT(1))
+#define SPI_FMEM_C_PMS1_WR_ATTR_M  (SPI_FMEM_C_PMS1_WR_ATTR_V << SPI_FMEM_C_PMS1_WR_ATTR_S)
+#define SPI_FMEM_C_PMS1_WR_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS1_WR_ATTR_S  1
+/** SPI_FMEM_C_PMS1_ECC : R/W; bitpos: [2]; default: 0;
+ *  SPI1 flash PMS section 1 ECC mode, 1: enable ECC mode. 0: Disable it. The flash PMS
+ *  section 1 is configured by registers SPI_FMEM_C_PMS1_ADDR_REG and
+ *  SPI_FMEM_C_PMS1_SIZE_REG.
+ */
+#define SPI_FMEM_C_PMS1_ECC    (BIT(2))
+#define SPI_FMEM_C_PMS1_ECC_M  (SPI_FMEM_C_PMS1_ECC_V << SPI_FMEM_C_PMS1_ECC_S)
+#define SPI_FMEM_C_PMS1_ECC_V  0x00000001U
+#define SPI_FMEM_C_PMS1_ECC_S  2
+/** SPI_FMEM_C_PMS1_NONSECURE_RD_ATTR : R/W; bitpos: [3]; default: 1;
+ *  1: SPI1 flash  non-secure PMS section 1 read accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS1_NONSECURE_RD_ATTR    (BIT(3))
+#define SPI_FMEM_C_PMS1_NONSECURE_RD_ATTR_M  (SPI_FMEM_C_PMS1_NONSECURE_RD_ATTR_V << SPI_FMEM_C_PMS1_NONSECURE_RD_ATTR_S)
+#define SPI_FMEM_C_PMS1_NONSECURE_RD_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS1_NONSECURE_RD_ATTR_S  3
+/** SPI_FMEM_C_PMS1_NONSECURE_WR_ATTR : R/W; bitpos: [4]; default: 1;
+ *  1: SPI1 flash non-secure PMS section 1 write accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS1_NONSECURE_WR_ATTR    (BIT(4))
+#define SPI_FMEM_C_PMS1_NONSECURE_WR_ATTR_M  (SPI_FMEM_C_PMS1_NONSECURE_WR_ATTR_V << SPI_FMEM_C_PMS1_NONSECURE_WR_ATTR_S)
+#define SPI_FMEM_C_PMS1_NONSECURE_WR_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS1_NONSECURE_WR_ATTR_S  4
+/** SPI_FMEM_C_PMS1_NONSECURE_ECC : R/W; bitpos: [5]; default: 0;
+ *  SPI1 flash non-secure PMS section 1 ECC mode, 1: enable ECC mode. 0: Disable it.
+ *  The flash PMS section 1 is configured by registers SPI_FMEM_C_PMS1_ADDR_REG and
+ *  SPI_FMEM_C_PMS1_SIZE_REG.
+ */
+#define SPI_FMEM_C_PMS1_NONSECURE_ECC    (BIT(5))
+#define SPI_FMEM_C_PMS1_NONSECURE_ECC_M  (SPI_FMEM_C_PMS1_NONSECURE_ECC_V << SPI_FMEM_C_PMS1_NONSECURE_ECC_S)
+#define SPI_FMEM_C_PMS1_NONSECURE_ECC_V  0x00000001U
+#define SPI_FMEM_C_PMS1_NONSECURE_ECC_S  5
+
+/** SPI_FMEM_C_PMS2_ATTR_REG register
+ *  SPI1 flash PMS section 2 attribute register
+ */
+#define SPI_FMEM_C_PMS2_ATTR_REG (DR_REG_FLASH_SPI0_BASE + 0x108)
+/** SPI_FMEM_C_PMS2_RD_ATTR : R/W; bitpos: [0]; default: 1;
+ *  1: SPI1 flash PMS section 2 read accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS2_RD_ATTR    (BIT(0))
+#define SPI_FMEM_C_PMS2_RD_ATTR_M  (SPI_FMEM_C_PMS2_RD_ATTR_V << SPI_FMEM_C_PMS2_RD_ATTR_S)
+#define SPI_FMEM_C_PMS2_RD_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS2_RD_ATTR_S  0
+/** SPI_FMEM_C_PMS2_WR_ATTR : R/W; bitpos: [1]; default: 1;
+ *  1: SPI1 flash PMS section 2 write accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS2_WR_ATTR    (BIT(1))
+#define SPI_FMEM_C_PMS2_WR_ATTR_M  (SPI_FMEM_C_PMS2_WR_ATTR_V << SPI_FMEM_C_PMS2_WR_ATTR_S)
+#define SPI_FMEM_C_PMS2_WR_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS2_WR_ATTR_S  1
+/** SPI_FMEM_C_PMS2_ECC : R/W; bitpos: [2]; default: 0;
+ *  SPI1 flash PMS section 2 ECC mode, 1: enable ECC mode. 0: Disable it. The flash PMS
+ *  section 2 is configured by registers SPI_FMEM_C_PMS2_ADDR_REG and
+ *  SPI_FMEM_C_PMS2_SIZE_REG.
+ */
+#define SPI_FMEM_C_PMS2_ECC    (BIT(2))
+#define SPI_FMEM_C_PMS2_ECC_M  (SPI_FMEM_C_PMS2_ECC_V << SPI_FMEM_C_PMS2_ECC_S)
+#define SPI_FMEM_C_PMS2_ECC_V  0x00000001U
+#define SPI_FMEM_C_PMS2_ECC_S  2
+/** SPI_FMEM_C_PMS2_NONSECURE_RD_ATTR : R/W; bitpos: [3]; default: 1;
+ *  1: SPI1 flash  non-secure PMS section 2 read accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS2_NONSECURE_RD_ATTR    (BIT(3))
+#define SPI_FMEM_C_PMS2_NONSECURE_RD_ATTR_M  (SPI_FMEM_C_PMS2_NONSECURE_RD_ATTR_V << SPI_FMEM_C_PMS2_NONSECURE_RD_ATTR_S)
+#define SPI_FMEM_C_PMS2_NONSECURE_RD_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS2_NONSECURE_RD_ATTR_S  3
+/** SPI_FMEM_C_PMS2_NONSECURE_WR_ATTR : R/W; bitpos: [4]; default: 1;
+ *  1: SPI1 flash non-secure PMS section 2 write accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS2_NONSECURE_WR_ATTR    (BIT(4))
+#define SPI_FMEM_C_PMS2_NONSECURE_WR_ATTR_M  (SPI_FMEM_C_PMS2_NONSECURE_WR_ATTR_V << SPI_FMEM_C_PMS2_NONSECURE_WR_ATTR_S)
+#define SPI_FMEM_C_PMS2_NONSECURE_WR_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS2_NONSECURE_WR_ATTR_S  4
+/** SPI_FMEM_C_PMS2_NONSECURE_ECC : R/W; bitpos: [5]; default: 0;
+ *  SPI1 flash non-secure PMS section 2 ECC mode, 1: enable ECC mode. 0: Disable it.
+ *  The flash PMS section 2 is configured by registers SPI_FMEM_C_PMS2_ADDR_REG and
+ *  SPI_FMEM_C_PMS2_SIZE_REG.
+ */
+#define SPI_FMEM_C_PMS2_NONSECURE_ECC    (BIT(5))
+#define SPI_FMEM_C_PMS2_NONSECURE_ECC_M  (SPI_FMEM_C_PMS2_NONSECURE_ECC_V << SPI_FMEM_C_PMS2_NONSECURE_ECC_S)
+#define SPI_FMEM_C_PMS2_NONSECURE_ECC_V  0x00000001U
+#define SPI_FMEM_C_PMS2_NONSECURE_ECC_S  5
+
+/** SPI_FMEM_C_PMS3_ATTR_REG register
+ *  SPI1 flash PMS section 3 attribute register
+ */
+#define SPI_FMEM_C_PMS3_ATTR_REG (DR_REG_FLASH_SPI0_BASE + 0x10c)
+/** SPI_FMEM_C_PMS3_RD_ATTR : R/W; bitpos: [0]; default: 1;
+ *  1: SPI1 flash PMS section 3 read accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS3_RD_ATTR    (BIT(0))
+#define SPI_FMEM_C_PMS3_RD_ATTR_M  (SPI_FMEM_C_PMS3_RD_ATTR_V << SPI_FMEM_C_PMS3_RD_ATTR_S)
+#define SPI_FMEM_C_PMS3_RD_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS3_RD_ATTR_S  0
+/** SPI_FMEM_C_PMS3_WR_ATTR : R/W; bitpos: [1]; default: 1;
+ *  1: SPI1 flash PMS section 3 write accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS3_WR_ATTR    (BIT(1))
+#define SPI_FMEM_C_PMS3_WR_ATTR_M  (SPI_FMEM_C_PMS3_WR_ATTR_V << SPI_FMEM_C_PMS3_WR_ATTR_S)
+#define SPI_FMEM_C_PMS3_WR_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS3_WR_ATTR_S  1
+/** SPI_FMEM_C_PMS3_ECC : R/W; bitpos: [2]; default: 0;
+ *  SPI1 flash PMS section 3 ECC mode, 1: enable ECC mode. 0: Disable it. The flash PMS
+ *  section 3 is configured by registers SPI_FMEM_C_PMS3_ADDR_REG and
+ *  SPI_FMEM_C_PMS3_SIZE_REG.
+ */
+#define SPI_FMEM_C_PMS3_ECC    (BIT(2))
+#define SPI_FMEM_C_PMS3_ECC_M  (SPI_FMEM_C_PMS3_ECC_V << SPI_FMEM_C_PMS3_ECC_S)
+#define SPI_FMEM_C_PMS3_ECC_V  0x00000001U
+#define SPI_FMEM_C_PMS3_ECC_S  2
+/** SPI_FMEM_C_PMS3_NONSECURE_RD_ATTR : R/W; bitpos: [3]; default: 1;
+ *  1: SPI1 flash  non-secure PMS section 3 read accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS3_NONSECURE_RD_ATTR    (BIT(3))
+#define SPI_FMEM_C_PMS3_NONSECURE_RD_ATTR_M  (SPI_FMEM_C_PMS3_NONSECURE_RD_ATTR_V << SPI_FMEM_C_PMS3_NONSECURE_RD_ATTR_S)
+#define SPI_FMEM_C_PMS3_NONSECURE_RD_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS3_NONSECURE_RD_ATTR_S  3
+/** SPI_FMEM_C_PMS3_NONSECURE_WR_ATTR : R/W; bitpos: [4]; default: 1;
+ *  1: SPI1 flash non-secure PMS section 3 write accessible. 0: Not allowed.
+ */
+#define SPI_FMEM_C_PMS3_NONSECURE_WR_ATTR    (BIT(4))
+#define SPI_FMEM_C_PMS3_NONSECURE_WR_ATTR_M  (SPI_FMEM_C_PMS3_NONSECURE_WR_ATTR_V << SPI_FMEM_C_PMS3_NONSECURE_WR_ATTR_S)
+#define SPI_FMEM_C_PMS3_NONSECURE_WR_ATTR_V  0x00000001U
+#define SPI_FMEM_C_PMS3_NONSECURE_WR_ATTR_S  4
+/** SPI_FMEM_C_PMS3_NONSECURE_ECC : R/W; bitpos: [5]; default: 0;
+ *  SPI1 flash non-secure PMS section 3 ECC mode, 1: enable ECC mode. 0: Disable it.
+ *  The flash PMS section 3 is configured by registers SPI_FMEM_C_PMS3_ADDR_REG and
+ *  SPI_FMEM_C_PMS3_SIZE_REG.
+ */
+#define SPI_FMEM_C_PMS3_NONSECURE_ECC    (BIT(5))
+#define SPI_FMEM_C_PMS3_NONSECURE_ECC_M  (SPI_FMEM_C_PMS3_NONSECURE_ECC_V << SPI_FMEM_C_PMS3_NONSECURE_ECC_S)
+#define SPI_FMEM_C_PMS3_NONSECURE_ECC_V  0x00000001U
+#define SPI_FMEM_C_PMS3_NONSECURE_ECC_S  5
+
+/** SPI_FMEM_C_PMS0_ADDR_REG register
+ *  SPI1 flash PMS section 0 start address register
+ */
+#define SPI_FMEM_C_PMS0_ADDR_REG (DR_REG_FLASH_SPI0_BASE + 0x110)
+/** SPI_FMEM_C_PMS0_ADDR_S : R/W; bitpos: [28:0]; default: 0;
+ *  SPI1 flash PMS section 0 start address value
+ */
+#define SPI_FMEM_C_PMS0_ADDR_S    0x1FFFFFFFU
+#define SPI_FMEM_C_PMS0_ADDR_S_M  (SPI_FMEM_C_PMS0_ADDR_S_V << SPI_FMEM_C_PMS0_ADDR_S_S)
+#define SPI_FMEM_C_PMS0_ADDR_S_V  0x1FFFFFFFU
+#define SPI_FMEM_C_PMS0_ADDR_S_S  0
+
+/** SPI_FMEM_C_PMS1_ADDR_REG register
+ *  SPI1 flash PMS section 1 start address register
+ */
+#define SPI_FMEM_C_PMS1_ADDR_REG (DR_REG_FLASH_SPI0_BASE + 0x114)
+/** SPI_FMEM_C_PMS1_ADDR_S : R/W; bitpos: [28:0]; default: 0;
+ *  SPI1 flash PMS section 1 start address value
+ */
+#define SPI_FMEM_C_PMS1_ADDR_S    0x1FFFFFFFU
+#define SPI_FMEM_C_PMS1_ADDR_S_M  (SPI_FMEM_C_PMS1_ADDR_S_V << SPI_FMEM_C_PMS1_ADDR_S_S)
+#define SPI_FMEM_C_PMS1_ADDR_S_V  0x1FFFFFFFU
+#define SPI_FMEM_C_PMS1_ADDR_S_S  0
+
+/** SPI_FMEM_C_PMS2_ADDR_REG register
+ *  SPI1 flash PMS section 2 start address register
+ */
+#define SPI_FMEM_C_PMS2_ADDR_REG (DR_REG_FLASH_SPI0_BASE + 0x118)
+/** SPI_FMEM_C_PMS2_ADDR_S : R/W; bitpos: [28:0]; default: 0;
+ *  SPI1 flash PMS section 2 start address value
+ */
+#define SPI_FMEM_C_PMS2_ADDR_S    0x1FFFFFFFU
+#define SPI_FMEM_C_PMS2_ADDR_S_M  (SPI_FMEM_C_PMS2_ADDR_S_V << SPI_FMEM_C_PMS2_ADDR_S_S)
+#define SPI_FMEM_C_PMS2_ADDR_S_V  0x1FFFFFFFU
+#define SPI_FMEM_C_PMS2_ADDR_S_S  0
+
+/** SPI_FMEM_C_PMS3_ADDR_REG register
+ *  SPI1 flash PMS section 3 start address register
+ */
+#define SPI_FMEM_C_PMS3_ADDR_REG (DR_REG_FLASH_SPI0_BASE + 0x11c)
+/** SPI_FMEM_C_PMS3_ADDR_S : R/W; bitpos: [28:0]; default: 0;
+ *  SPI1 flash PMS section 3 start address value
+ */
+#define SPI_FMEM_C_PMS3_ADDR_S    0x1FFFFFFFU
+#define SPI_FMEM_C_PMS3_ADDR_S_M  (SPI_FMEM_C_PMS3_ADDR_S_V << SPI_FMEM_C_PMS3_ADDR_S_S)
+#define SPI_FMEM_C_PMS3_ADDR_S_V  0x1FFFFFFFU
+#define SPI_FMEM_C_PMS3_ADDR_S_S  0
+
+/** SPI_FMEM_C_PMS0_SIZE_REG register
+ *  SPI1 flash PMS section 0 start address register
+ */
+#define SPI_FMEM_C_PMS0_SIZE_REG (DR_REG_FLASH_SPI0_BASE + 0x120)
+/** SPI_FMEM_C_PMS0_SIZE : R/W; bitpos: [16:0]; default: 4096;
+ *  SPI1 flash PMS section 0 address region is (SPI_FMEM_C_PMS0_ADDR_S,
+ *  SPI_FMEM_C_PMS0_ADDR_S + SPI_FMEM_C_PMS0_SIZE)
+ */
+#define SPI_FMEM_C_PMS0_SIZE    0x0001FFFFU
+#define SPI_FMEM_C_PMS0_SIZE_M  (SPI_FMEM_C_PMS0_SIZE_V << SPI_FMEM_C_PMS0_SIZE_S)
+#define SPI_FMEM_C_PMS0_SIZE_V  0x0001FFFFU
+#define SPI_FMEM_C_PMS0_SIZE_S  0
+
+/** SPI_FMEM_C_PMS1_SIZE_REG register
+ *  SPI1 flash PMS section 1 start address register
+ */
+#define SPI_FMEM_C_PMS1_SIZE_REG (DR_REG_FLASH_SPI0_BASE + 0x124)
+/** SPI_FMEM_C_PMS1_SIZE : R/W; bitpos: [16:0]; default: 4096;
+ *  SPI1 flash PMS section 1 address region is (SPI_FMEM_C_PMS1_ADDR_S,
+ *  SPI_FMEM_C_PMS1_ADDR_S + SPI_FMEM_C_PMS1_SIZE)
+ */
+#define SPI_FMEM_C_PMS1_SIZE    0x0001FFFFU
+#define SPI_FMEM_C_PMS1_SIZE_M  (SPI_FMEM_C_PMS1_SIZE_V << SPI_FMEM_C_PMS1_SIZE_S)
+#define SPI_FMEM_C_PMS1_SIZE_V  0x0001FFFFU
+#define SPI_FMEM_C_PMS1_SIZE_S  0
+
+/** SPI_FMEM_C_PMS2_SIZE_REG register
+ *  SPI1 flash PMS section 2 start address register
+ */
+#define SPI_FMEM_C_PMS2_SIZE_REG (DR_REG_FLASH_SPI0_BASE + 0x128)
+/** SPI_FMEM_C_PMS2_SIZE : R/W; bitpos: [16:0]; default: 4096;
+ *  SPI1 flash PMS section 2 address region is (SPI_FMEM_C_PMS2_ADDR_S,
+ *  SPI_FMEM_C_PMS2_ADDR_S + SPI_FMEM_C_PMS2_SIZE)
+ */
+#define SPI_FMEM_C_PMS2_SIZE    0x0001FFFFU
+#define SPI_FMEM_C_PMS2_SIZE_M  (SPI_FMEM_C_PMS2_SIZE_V << SPI_FMEM_C_PMS2_SIZE_S)
+#define SPI_FMEM_C_PMS2_SIZE_V  0x0001FFFFU
+#define SPI_FMEM_C_PMS2_SIZE_S  0
+
+/** SPI_FMEM_C_PMS3_SIZE_REG register
+ *  SPI1 flash PMS section 3 start address register
+ */
+#define SPI_FMEM_C_PMS3_SIZE_REG (DR_REG_FLASH_SPI0_BASE + 0x12c)
+/** SPI_FMEM_C_PMS3_SIZE : R/W; bitpos: [16:0]; default: 4096;
+ *  SPI1 flash PMS section 3 address region is (SPI_FMEM_C_PMS3_ADDR_S,
+ *  SPI_FMEM_C_PMS3_ADDR_S + SPI_FMEM_C_PMS3_SIZE)
+ */
+#define SPI_FMEM_C_PMS3_SIZE    0x0001FFFFU
+#define SPI_FMEM_C_PMS3_SIZE_M  (SPI_FMEM_C_PMS3_SIZE_V << SPI_FMEM_C_PMS3_SIZE_S)
+#define SPI_FMEM_C_PMS3_SIZE_V  0x0001FFFFU
+#define SPI_FMEM_C_PMS3_SIZE_S  0
+
+/** SPI_SMEM_C_PMS0_ATTR_REG register
+ *  SPI1 external RAM PMS section 0 attribute register
+ */
+#define SPI_SMEM_C_PMS0_ATTR_REG (DR_REG_FLASH_SPI0_BASE + 0x130)
+/** SPI_SMEM_C_PMS0_RD_ATTR : R/W; bitpos: [0]; default: 1;
+ *  1: SPI1 external RAM PMS section 0 read accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS0_RD_ATTR    (BIT(0))
+#define SPI_SMEM_C_PMS0_RD_ATTR_M  (SPI_SMEM_C_PMS0_RD_ATTR_V << SPI_SMEM_C_PMS0_RD_ATTR_S)
+#define SPI_SMEM_C_PMS0_RD_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS0_RD_ATTR_S  0
+/** SPI_SMEM_C_PMS0_WR_ATTR : R/W; bitpos: [1]; default: 1;
+ *  1: SPI1 external RAM PMS section 0 write accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS0_WR_ATTR    (BIT(1))
+#define SPI_SMEM_C_PMS0_WR_ATTR_M  (SPI_SMEM_C_PMS0_WR_ATTR_V << SPI_SMEM_C_PMS0_WR_ATTR_S)
+#define SPI_SMEM_C_PMS0_WR_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS0_WR_ATTR_S  1
+/** SPI_SMEM_C_PMS0_ECC : R/W; bitpos: [2]; default: 0;
+ *  SPI1 external RAM PMS section 0 ECC mode, 1: enable ECC mode. 0: Disable it. The
+ *  external RAM PMS section 0 is configured by registers SPI_SMEM_C_PMS0_ADDR_REG and
+ *  SPI_SMEM_C_PMS0_SIZE_REG.
+ */
+#define SPI_SMEM_C_PMS0_ECC    (BIT(2))
+#define SPI_SMEM_C_PMS0_ECC_M  (SPI_SMEM_C_PMS0_ECC_V << SPI_SMEM_C_PMS0_ECC_S)
+#define SPI_SMEM_C_PMS0_ECC_V  0x00000001U
+#define SPI_SMEM_C_PMS0_ECC_S  2
+/** SPI_SMEM_C_PMS0_NONSECURE_RD_ATTR : R/W; bitpos: [3]; default: 1;
+ *  1: SPI1 external RAM non-secure PMS section 0 read accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS0_NONSECURE_RD_ATTR    (BIT(3))
+#define SPI_SMEM_C_PMS0_NONSECURE_RD_ATTR_M  (SPI_SMEM_C_PMS0_NONSECURE_RD_ATTR_V << SPI_SMEM_C_PMS0_NONSECURE_RD_ATTR_S)
+#define SPI_SMEM_C_PMS0_NONSECURE_RD_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS0_NONSECURE_RD_ATTR_S  3
+/** SPI_SMEM_C_PMS0_NONSECURE_WR_ATTR : R/W; bitpos: [4]; default: 1;
+ *  1: SPI1 external RAM non-secure PMS section 0 write accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS0_NONSECURE_WR_ATTR    (BIT(4))
+#define SPI_SMEM_C_PMS0_NONSECURE_WR_ATTR_M  (SPI_SMEM_C_PMS0_NONSECURE_WR_ATTR_V << SPI_SMEM_C_PMS0_NONSECURE_WR_ATTR_S)
+#define SPI_SMEM_C_PMS0_NONSECURE_WR_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS0_NONSECURE_WR_ATTR_S  4
+/** SPI_SMEM_C_PMS0_NONSECURE_ECC : R/W; bitpos: [5]; default: 0;
+ *  SPI1 external RAM non-secure PMS section 0 ECC mode, 1: enable ECC mode. 0: Disable
+ *  it. The external RAM PMS section 0 is configured by registers
+ *  SPI_SMEM_C_PMS0_ADDR_REG and SPI_SMEM_C_PMS0_SIZE_REG.
+ */
+#define SPI_SMEM_C_PMS0_NONSECURE_ECC    (BIT(5))
+#define SPI_SMEM_C_PMS0_NONSECURE_ECC_M  (SPI_SMEM_C_PMS0_NONSECURE_ECC_V << SPI_SMEM_C_PMS0_NONSECURE_ECC_S)
+#define SPI_SMEM_C_PMS0_NONSECURE_ECC_V  0x00000001U
+#define SPI_SMEM_C_PMS0_NONSECURE_ECC_S  5
+
+/** SPI_SMEM_C_PMS1_ATTR_REG register
+ *  SPI1 external RAM PMS section 1 attribute register
+ */
+#define SPI_SMEM_C_PMS1_ATTR_REG (DR_REG_FLASH_SPI0_BASE + 0x134)
+/** SPI_SMEM_C_PMS1_RD_ATTR : R/W; bitpos: [0]; default: 1;
+ *  1: SPI1 external RAM PMS section 1 read accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS1_RD_ATTR    (BIT(0))
+#define SPI_SMEM_C_PMS1_RD_ATTR_M  (SPI_SMEM_C_PMS1_RD_ATTR_V << SPI_SMEM_C_PMS1_RD_ATTR_S)
+#define SPI_SMEM_C_PMS1_RD_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS1_RD_ATTR_S  0
+/** SPI_SMEM_C_PMS1_WR_ATTR : R/W; bitpos: [1]; default: 1;
+ *  1: SPI1 external RAM PMS section 1 write accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS1_WR_ATTR    (BIT(1))
+#define SPI_SMEM_C_PMS1_WR_ATTR_M  (SPI_SMEM_C_PMS1_WR_ATTR_V << SPI_SMEM_C_PMS1_WR_ATTR_S)
+#define SPI_SMEM_C_PMS1_WR_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS1_WR_ATTR_S  1
+/** SPI_SMEM_C_PMS1_ECC : R/W; bitpos: [2]; default: 0;
+ *  SPI1 external RAM PMS section 1 ECC mode, 1: enable ECC mode. 0: Disable it. The
+ *  external RAM PMS section 1 is configured by registers SPI_SMEM_C_PMS1_ADDR_REG and
+ *  SPI_SMEM_C_PMS1_SIZE_REG.
+ */
+#define SPI_SMEM_C_PMS1_ECC    (BIT(2))
+#define SPI_SMEM_C_PMS1_ECC_M  (SPI_SMEM_C_PMS1_ECC_V << SPI_SMEM_C_PMS1_ECC_S)
+#define SPI_SMEM_C_PMS1_ECC_V  0x00000001U
+#define SPI_SMEM_C_PMS1_ECC_S  2
+/** SPI_SMEM_C_PMS1_NONSECURE_RD_ATTR : R/W; bitpos: [3]; default: 1;
+ *  1: SPI1 external RAM non-secure PMS section 1 read accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS1_NONSECURE_RD_ATTR    (BIT(3))
+#define SPI_SMEM_C_PMS1_NONSECURE_RD_ATTR_M  (SPI_SMEM_C_PMS1_NONSECURE_RD_ATTR_V << SPI_SMEM_C_PMS1_NONSECURE_RD_ATTR_S)
+#define SPI_SMEM_C_PMS1_NONSECURE_RD_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS1_NONSECURE_RD_ATTR_S  3
+/** SPI_SMEM_C_PMS1_NONSECURE_WR_ATTR : R/W; bitpos: [4]; default: 1;
+ *  1: SPI1 external RAM non-secure PMS section 1 write accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS1_NONSECURE_WR_ATTR    (BIT(4))
+#define SPI_SMEM_C_PMS1_NONSECURE_WR_ATTR_M  (SPI_SMEM_C_PMS1_NONSECURE_WR_ATTR_V << SPI_SMEM_C_PMS1_NONSECURE_WR_ATTR_S)
+#define SPI_SMEM_C_PMS1_NONSECURE_WR_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS1_NONSECURE_WR_ATTR_S  4
+/** SPI_SMEM_C_PMS1_NONSECURE_ECC : R/W; bitpos: [5]; default: 0;
+ *  SPI1 external RAM non-secure PMS section 1 ECC mode, 1: enable ECC mode. 0: Disable
+ *  it. The external RAM PMS section 1 is configured by registers
+ *  SPI_SMEM_C_PMS1_ADDR_REG and SPI_SMEM_C_PMS1_SIZE_REG.
+ */
+#define SPI_SMEM_C_PMS1_NONSECURE_ECC    (BIT(5))
+#define SPI_SMEM_C_PMS1_NONSECURE_ECC_M  (SPI_SMEM_C_PMS1_NONSECURE_ECC_V << SPI_SMEM_C_PMS1_NONSECURE_ECC_S)
+#define SPI_SMEM_C_PMS1_NONSECURE_ECC_V  0x00000001U
+#define SPI_SMEM_C_PMS1_NONSECURE_ECC_S  5
+
+/** SPI_SMEM_C_PMS2_ATTR_REG register
+ *  SPI1 external RAM PMS section 2 attribute register
+ */
+#define SPI_SMEM_C_PMS2_ATTR_REG (DR_REG_FLASH_SPI0_BASE + 0x138)
+/** SPI_SMEM_C_PMS2_RD_ATTR : R/W; bitpos: [0]; default: 1;
+ *  1: SPI1 external RAM PMS section 2 read accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS2_RD_ATTR    (BIT(0))
+#define SPI_SMEM_C_PMS2_RD_ATTR_M  (SPI_SMEM_C_PMS2_RD_ATTR_V << SPI_SMEM_C_PMS2_RD_ATTR_S)
+#define SPI_SMEM_C_PMS2_RD_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS2_RD_ATTR_S  0
+/** SPI_SMEM_C_PMS2_WR_ATTR : R/W; bitpos: [1]; default: 1;
+ *  1: SPI1 external RAM PMS section 2 write accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS2_WR_ATTR    (BIT(1))
+#define SPI_SMEM_C_PMS2_WR_ATTR_M  (SPI_SMEM_C_PMS2_WR_ATTR_V << SPI_SMEM_C_PMS2_WR_ATTR_S)
+#define SPI_SMEM_C_PMS2_WR_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS2_WR_ATTR_S  1
+/** SPI_SMEM_C_PMS2_ECC : R/W; bitpos: [2]; default: 0;
+ *  SPI1 external RAM PMS section 2 ECC mode, 1: enable ECC mode. 0: Disable it. The
+ *  external RAM PMS section 2 is configured by registers SPI_SMEM_C_PMS2_ADDR_REG and
+ *  SPI_SMEM_C_PMS2_SIZE_REG.
+ */
+#define SPI_SMEM_C_PMS2_ECC    (BIT(2))
+#define SPI_SMEM_C_PMS2_ECC_M  (SPI_SMEM_C_PMS2_ECC_V << SPI_SMEM_C_PMS2_ECC_S)
+#define SPI_SMEM_C_PMS2_ECC_V  0x00000001U
+#define SPI_SMEM_C_PMS2_ECC_S  2
+/** SPI_SMEM_C_PMS2_NONSECURE_RD_ATTR : R/W; bitpos: [3]; default: 1;
+ *  1: SPI1 external RAM non-secure PMS section 2 read accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS2_NONSECURE_RD_ATTR    (BIT(3))
+#define SPI_SMEM_C_PMS2_NONSECURE_RD_ATTR_M  (SPI_SMEM_C_PMS2_NONSECURE_RD_ATTR_V << SPI_SMEM_C_PMS2_NONSECURE_RD_ATTR_S)
+#define SPI_SMEM_C_PMS2_NONSECURE_RD_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS2_NONSECURE_RD_ATTR_S  3
+/** SPI_SMEM_C_PMS2_NONSECURE_WR_ATTR : R/W; bitpos: [4]; default: 1;
+ *  1: SPI1 external RAM non-secure PMS section 2 write accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS2_NONSECURE_WR_ATTR    (BIT(4))
+#define SPI_SMEM_C_PMS2_NONSECURE_WR_ATTR_M  (SPI_SMEM_C_PMS2_NONSECURE_WR_ATTR_V << SPI_SMEM_C_PMS2_NONSECURE_WR_ATTR_S)
+#define SPI_SMEM_C_PMS2_NONSECURE_WR_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS2_NONSECURE_WR_ATTR_S  4
+/** SPI_SMEM_C_PMS2_NONSECURE_ECC : R/W; bitpos: [5]; default: 0;
+ *  SPI1 external RAM non-secure PMS section 2 ECC mode, 1: enable ECC mode. 0: Disable
+ *  it. The external RAM PMS section 2 is configured by registers
+ *  SPI_SMEM_C_PMS2_ADDR_REG and SPI_SMEM_C_PMS2_SIZE_REG.
+ */
+#define SPI_SMEM_C_PMS2_NONSECURE_ECC    (BIT(5))
+#define SPI_SMEM_C_PMS2_NONSECURE_ECC_M  (SPI_SMEM_C_PMS2_NONSECURE_ECC_V << SPI_SMEM_C_PMS2_NONSECURE_ECC_S)
+#define SPI_SMEM_C_PMS2_NONSECURE_ECC_V  0x00000001U
+#define SPI_SMEM_C_PMS2_NONSECURE_ECC_S  5
+
+/** SPI_SMEM_C_PMS3_ATTR_REG register
+ *  SPI1 external RAM PMS section 3 attribute register
+ */
+#define SPI_SMEM_C_PMS3_ATTR_REG (DR_REG_FLASH_SPI0_BASE + 0x13c)
+/** SPI_SMEM_C_PMS3_RD_ATTR : R/W; bitpos: [0]; default: 1;
+ *  1: SPI1 external RAM PMS section 3 read accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS3_RD_ATTR    (BIT(0))
+#define SPI_SMEM_C_PMS3_RD_ATTR_M  (SPI_SMEM_C_PMS3_RD_ATTR_V << SPI_SMEM_C_PMS3_RD_ATTR_S)
+#define SPI_SMEM_C_PMS3_RD_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS3_RD_ATTR_S  0
+/** SPI_SMEM_C_PMS3_WR_ATTR : R/W; bitpos: [1]; default: 1;
+ *  1: SPI1 external RAM PMS section 3 write accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS3_WR_ATTR    (BIT(1))
+#define SPI_SMEM_C_PMS3_WR_ATTR_M  (SPI_SMEM_C_PMS3_WR_ATTR_V << SPI_SMEM_C_PMS3_WR_ATTR_S)
+#define SPI_SMEM_C_PMS3_WR_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS3_WR_ATTR_S  1
+/** SPI_SMEM_C_PMS3_ECC : R/W; bitpos: [2]; default: 0;
+ *  SPI1 external RAM PMS section 3 ECC mode, 1: enable ECC mode. 0: Disable it. The
+ *  external RAM PMS section 3 is configured by registers SPI_SMEM_C_PMS3_ADDR_REG and
+ *  SPI_SMEM_C_PMS3_SIZE_REG.
+ */
+#define SPI_SMEM_C_PMS3_ECC    (BIT(2))
+#define SPI_SMEM_C_PMS3_ECC_M  (SPI_SMEM_C_PMS3_ECC_V << SPI_SMEM_C_PMS3_ECC_S)
+#define SPI_SMEM_C_PMS3_ECC_V  0x00000001U
+#define SPI_SMEM_C_PMS3_ECC_S  2
+/** SPI_SMEM_C_PMS3_NONSECURE_RD_ATTR : R/W; bitpos: [3]; default: 1;
+ *  1: SPI1 external RAM non-secure PMS section 3 read accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS3_NONSECURE_RD_ATTR    (BIT(3))
+#define SPI_SMEM_C_PMS3_NONSECURE_RD_ATTR_M  (SPI_SMEM_C_PMS3_NONSECURE_RD_ATTR_V << SPI_SMEM_C_PMS3_NONSECURE_RD_ATTR_S)
+#define SPI_SMEM_C_PMS3_NONSECURE_RD_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS3_NONSECURE_RD_ATTR_S  3
+/** SPI_SMEM_C_PMS3_NONSECURE_WR_ATTR : R/W; bitpos: [4]; default: 1;
+ *  1: SPI1 external RAM non-secure PMS section 3 write accessible. 0: Not allowed.
+ */
+#define SPI_SMEM_C_PMS3_NONSECURE_WR_ATTR    (BIT(4))
+#define SPI_SMEM_C_PMS3_NONSECURE_WR_ATTR_M  (SPI_SMEM_C_PMS3_NONSECURE_WR_ATTR_V << SPI_SMEM_C_PMS3_NONSECURE_WR_ATTR_S)
+#define SPI_SMEM_C_PMS3_NONSECURE_WR_ATTR_V  0x00000001U
+#define SPI_SMEM_C_PMS3_NONSECURE_WR_ATTR_S  4
+/** SPI_SMEM_C_PMS3_NONSECURE_ECC : R/W; bitpos: [5]; default: 0;
+ *  SPI1 external RAM non-secure PMS section 3 ECC mode, 1: enable ECC mode. 0: Disable
+ *  it. The external RAM PMS section 3 is configured by registers
+ *  SPI_SMEM_C_PMS3_ADDR_REG and SPI_SMEM_C_PMS3_SIZE_REG.
+ */
+#define SPI_SMEM_C_PMS3_NONSECURE_ECC    (BIT(5))
+#define SPI_SMEM_C_PMS3_NONSECURE_ECC_M  (SPI_SMEM_C_PMS3_NONSECURE_ECC_V << SPI_SMEM_C_PMS3_NONSECURE_ECC_S)
+#define SPI_SMEM_C_PMS3_NONSECURE_ECC_V  0x00000001U
+#define SPI_SMEM_C_PMS3_NONSECURE_ECC_S  5
+
+/** SPI_SMEM_C_PMS0_ADDR_REG register
+ *  SPI1 external RAM PMS section 0 start address register
+ */
+#define SPI_SMEM_C_PMS0_ADDR_REG (DR_REG_FLASH_SPI0_BASE + 0x140)
+/** SPI_SMEM_C_PMS0_ADDR_S : HRO; bitpos: [28:0]; default: 0;
+ *  SPI1 external RAM PMS section 0 start address value
+ */
+#define SPI_SMEM_C_PMS0_ADDR_S    0x1FFFFFFFU
+#define SPI_SMEM_C_PMS0_ADDR_S_M  (SPI_SMEM_C_PMS0_ADDR_S_V << SPI_SMEM_C_PMS0_ADDR_S_S)
+#define SPI_SMEM_C_PMS0_ADDR_S_V  0x1FFFFFFFU
+#define SPI_SMEM_C_PMS0_ADDR_S_S  0
+
+/** SPI_SMEM_C_PMS1_ADDR_REG register
+ *  SPI1 external RAM PMS section 1 start address register
+ */
+#define SPI_SMEM_C_PMS1_ADDR_REG (DR_REG_FLASH_SPI0_BASE + 0x144)
+/** SPI_SMEM_C_PMS1_ADDR_S : HRO; bitpos: [28:0]; default: 0;
+ *  SPI1 external RAM PMS section 1 start address value
+ */
+#define SPI_SMEM_C_PMS1_ADDR_S    0x1FFFFFFFU
+#define SPI_SMEM_C_PMS1_ADDR_S_M  (SPI_SMEM_C_PMS1_ADDR_S_V << SPI_SMEM_C_PMS1_ADDR_S_S)
+#define SPI_SMEM_C_PMS1_ADDR_S_V  0x1FFFFFFFU
+#define SPI_SMEM_C_PMS1_ADDR_S_S  0
+
+/** SPI_SMEM_C_PMS2_ADDR_REG register
+ *  SPI1 external RAM PMS section 2 start address register
+ */
+#define SPI_SMEM_C_PMS2_ADDR_REG (DR_REG_FLASH_SPI0_BASE + 0x148)
+/** SPI_SMEM_C_PMS2_ADDR_S : HRO; bitpos: [28:0]; default: 0;
+ *  SPI1 external RAM PMS section 2 start address value
+ */
+#define SPI_SMEM_C_PMS2_ADDR_S    0x1FFFFFFFU
+#define SPI_SMEM_C_PMS2_ADDR_S_M  (SPI_SMEM_C_PMS2_ADDR_S_V << SPI_SMEM_C_PMS2_ADDR_S_S)
+#define SPI_SMEM_C_PMS2_ADDR_S_V  0x1FFFFFFFU
+#define SPI_SMEM_C_PMS2_ADDR_S_S  0
+
+/** SPI_SMEM_C_PMS3_ADDR_REG register
+ *  SPI1 external RAM PMS section 3 start address register
+ */
+#define SPI_SMEM_C_PMS3_ADDR_REG (DR_REG_FLASH_SPI0_BASE + 0x14c)
+/** SPI_SMEM_C_PMS3_ADDR_S : HRO; bitpos: [28:0]; default: 0;
+ *  SPI1 external RAM PMS section 3 start address value
+ */
+#define SPI_SMEM_C_PMS3_ADDR_S    0x1FFFFFFFU
+#define SPI_SMEM_C_PMS3_ADDR_S_M  (SPI_SMEM_C_PMS3_ADDR_S_V << SPI_SMEM_C_PMS3_ADDR_S_S)
+#define SPI_SMEM_C_PMS3_ADDR_S_V  0x1FFFFFFFU
+#define SPI_SMEM_C_PMS3_ADDR_S_S  0
+
+/** SPI_SMEM_C_PMS0_SIZE_REG register
+ *  SPI1 external RAM PMS section 0 start address register
+ */
+#define SPI_SMEM_C_PMS0_SIZE_REG (DR_REG_FLASH_SPI0_BASE + 0x150)
+/** SPI_SMEM_C_PMS0_SIZE : HRO; bitpos: [16:0]; default: 4096;
+ *  SPI1 external RAM PMS section 0 address region is (SPI_SMEM_C_PMS0_ADDR_S,
+ *  SPI_SMEM_C_PMS0_ADDR_S + SPI_SMEM_C_PMS0_SIZE)
+ */
+#define SPI_SMEM_C_PMS0_SIZE    0x0001FFFFU
+#define SPI_SMEM_C_PMS0_SIZE_M  (SPI_SMEM_C_PMS0_SIZE_V << SPI_SMEM_C_PMS0_SIZE_S)
+#define SPI_SMEM_C_PMS0_SIZE_V  0x0001FFFFU
+#define SPI_SMEM_C_PMS0_SIZE_S  0
+
+/** SPI_SMEM_C_PMS1_SIZE_REG register
+ *  SPI1 external RAM PMS section 1 start address register
+ */
+#define SPI_SMEM_C_PMS1_SIZE_REG (DR_REG_FLASH_SPI0_BASE + 0x154)
+/** SPI_SMEM_C_PMS1_SIZE : HRO; bitpos: [16:0]; default: 4096;
+ *  SPI1 external RAM PMS section 1 address region is (SPI_SMEM_C_PMS1_ADDR_S,
+ *  SPI_SMEM_C_PMS1_ADDR_S + SPI_SMEM_C_PMS1_SIZE)
+ */
+#define SPI_SMEM_C_PMS1_SIZE    0x0001FFFFU
+#define SPI_SMEM_C_PMS1_SIZE_M  (SPI_SMEM_C_PMS1_SIZE_V << SPI_SMEM_C_PMS1_SIZE_S)
+#define SPI_SMEM_C_PMS1_SIZE_V  0x0001FFFFU
+#define SPI_SMEM_C_PMS1_SIZE_S  0
+
+/** SPI_SMEM_C_PMS2_SIZE_REG register
+ *  SPI1 external RAM PMS section 2 start address register
+ */
+#define SPI_SMEM_C_PMS2_SIZE_REG (DR_REG_FLASH_SPI0_BASE + 0x158)
+/** SPI_SMEM_C_PMS2_SIZE : HRO; bitpos: [16:0]; default: 4096;
+ *  SPI1 external RAM PMS section 2 address region is (SPI_SMEM_C_PMS2_ADDR_S,
+ *  SPI_SMEM_C_PMS2_ADDR_S + SPI_SMEM_C_PMS2_SIZE)
+ */
+#define SPI_SMEM_C_PMS2_SIZE    0x0001FFFFU
+#define SPI_SMEM_C_PMS2_SIZE_M  (SPI_SMEM_C_PMS2_SIZE_V << SPI_SMEM_C_PMS2_SIZE_S)
+#define SPI_SMEM_C_PMS2_SIZE_V  0x0001FFFFU
+#define SPI_SMEM_C_PMS2_SIZE_S  0
+
+/** SPI_SMEM_C_PMS3_SIZE_REG register
+ *  SPI1 external RAM PMS section 3 start address register
+ */
+#define SPI_SMEM_C_PMS3_SIZE_REG (DR_REG_FLASH_SPI0_BASE + 0x15c)
+/** SPI_SMEM_C_PMS3_SIZE : HRO; bitpos: [16:0]; default: 4096;
+ *  SPI1 external RAM PMS section 3 address region is (SPI_SMEM_C_PMS3_ADDR_S,
+ *  SPI_SMEM_C_PMS3_ADDR_S + SPI_SMEM_C_PMS3_SIZE)
+ */
+#define SPI_SMEM_C_PMS3_SIZE    0x0001FFFFU
+#define SPI_SMEM_C_PMS3_SIZE_M  (SPI_SMEM_C_PMS3_SIZE_V << SPI_SMEM_C_PMS3_SIZE_S)
+#define SPI_SMEM_C_PMS3_SIZE_V  0x0001FFFFU
+#define SPI_SMEM_C_PMS3_SIZE_S  0
+
+/** SPI_MEM_C_PMS_REJECT_REG register
+ *  SPI1 access reject register
+ */
+#define SPI_MEM_C_PMS_REJECT_REG (DR_REG_FLASH_SPI0_BASE + 0x160)
+/** SPI_MEM_C_PM_EN : R/W; bitpos: [27]; default: 0;
+ *  Set this bit to enable SPI0/1 transfer permission control function.
+ */
+#define SPI_MEM_C_PM_EN    (BIT(27))
+#define SPI_MEM_C_PM_EN_M  (SPI_MEM_C_PM_EN_V << SPI_MEM_C_PM_EN_S)
+#define SPI_MEM_C_PM_EN_V  0x00000001U
+#define SPI_MEM_C_PM_EN_S  27
+/** SPI_MEM_C_PMS_LD : R/SS/WTC; bitpos: [28]; default: 0;
+ *  1: SPI1 write access error. 0: No write access error. It is cleared by when
+ *  SPI_MEM_C_PMS_REJECT_INT_CLR bit is set.
+ */
+#define SPI_MEM_C_PMS_LD    (BIT(28))
+#define SPI_MEM_C_PMS_LD_M  (SPI_MEM_C_PMS_LD_V << SPI_MEM_C_PMS_LD_S)
+#define SPI_MEM_C_PMS_LD_V  0x00000001U
+#define SPI_MEM_C_PMS_LD_S  28
+/** SPI_MEM_C_PMS_ST : R/SS/WTC; bitpos: [29]; default: 0;
+ *  1: SPI1 read access error. 0: No read access error. It is cleared by when
+ *  SPI_MEM_C_PMS_REJECT_INT_CLR bit is set.
+ */
+#define SPI_MEM_C_PMS_ST    (BIT(29))
+#define SPI_MEM_C_PMS_ST_M  (SPI_MEM_C_PMS_ST_V << SPI_MEM_C_PMS_ST_S)
+#define SPI_MEM_C_PMS_ST_V  0x00000001U
+#define SPI_MEM_C_PMS_ST_S  29
+/** SPI_MEM_C_PMS_MULTI_HIT : R/SS/WTC; bitpos: [30]; default: 0;
+ *  1: SPI1 access is rejected because of address miss. 0: No address miss error. It is
+ *  cleared by when  SPI_MEM_C_PMS_REJECT_INT_CLR bit is set.
+ */
+#define SPI_MEM_C_PMS_MULTI_HIT    (BIT(30))
+#define SPI_MEM_C_PMS_MULTI_HIT_M  (SPI_MEM_C_PMS_MULTI_HIT_V << SPI_MEM_C_PMS_MULTI_HIT_S)
+#define SPI_MEM_C_PMS_MULTI_HIT_V  0x00000001U
+#define SPI_MEM_C_PMS_MULTI_HIT_S  30
+/** SPI_MEM_C_PMS_IVD : R/SS/WTC; bitpos: [31]; default: 0;
+ *  1: SPI1 access is rejected because of address multi-hit. 0: No address multi-hit
+ *  error. It is cleared by when  SPI_MEM_C_PMS_REJECT_INT_CLR bit is set.
+ */
+#define SPI_MEM_C_PMS_IVD    (BIT(31))
+#define SPI_MEM_C_PMS_IVD_M  (SPI_MEM_C_PMS_IVD_V << SPI_MEM_C_PMS_IVD_S)
+#define SPI_MEM_C_PMS_IVD_V  0x00000001U
+#define SPI_MEM_C_PMS_IVD_S  31
+
+/** SPI_MEM_C_PMS_REJECT_ADDR_REG register
+ *  SPI1 access reject addr register
+ */
+#define SPI_MEM_C_PMS_REJECT_ADDR_REG (DR_REG_FLASH_SPI0_BASE + 0x164)
+/** SPI_MEM_C_REJECT_ADDR : R/SS/WTC; bitpos: [28:0]; default: 0;
+ *  This bits show the first SPI1 access error address. It is cleared by when
+ *  SPI_MEM_C_PMS_REJECT_INT_CLR bit is set.
+ */
+#define SPI_MEM_C_REJECT_ADDR    0x1FFFFFFFU
+#define SPI_MEM_C_REJECT_ADDR_M  (SPI_MEM_C_REJECT_ADDR_V << SPI_MEM_C_REJECT_ADDR_S)
+#define SPI_MEM_C_REJECT_ADDR_V  0x1FFFFFFFU
+#define SPI_MEM_C_REJECT_ADDR_S  0
+
+/** SPI_MEM_C_ECC_CTRL_REG register
+ *  MSPI ECC control register
+ */
+#define SPI_MEM_C_ECC_CTRL_REG (DR_REG_FLASH_SPI0_BASE + 0x168)
+/** SPI_MEM_C_ECC_ERR_CNT : HRO; bitpos: [10:5]; default: 0;
+ *  This bits show the error times of MSPI ECC read. It is cleared by when
+ *  SPI_MEM_C_ECC_ERR_INT_CLR bit is set.
+ */
+#define SPI_MEM_C_ECC_ERR_CNT    0x0000003FU
+#define SPI_MEM_C_ECC_ERR_CNT_M  (SPI_MEM_C_ECC_ERR_CNT_V << SPI_MEM_C_ECC_ERR_CNT_S)
+#define SPI_MEM_C_ECC_ERR_CNT_V  0x0000003FU
+#define SPI_MEM_C_ECC_ERR_CNT_S  5
+/** SPI_FMEM_C_ECC_ERR_INT_NUM : HRO; bitpos: [16:11]; default: 10;
+ *  Set the error times of MSPI ECC read to generate MSPI SPI_MEM_C_ECC_ERR_INT interrupt.
+ */
+#define SPI_FMEM_C_ECC_ERR_INT_NUM    0x0000003FU
+#define SPI_FMEM_C_ECC_ERR_INT_NUM_M  (SPI_FMEM_C_ECC_ERR_INT_NUM_V << SPI_FMEM_C_ECC_ERR_INT_NUM_S)
+#define SPI_FMEM_C_ECC_ERR_INT_NUM_V  0x0000003FU
+#define SPI_FMEM_C_ECC_ERR_INT_NUM_S  11
+/** SPI_FMEM_C_ECC_ERR_INT_EN : HRO; bitpos: [17]; default: 0;
+ *  Set this bit to calculate the error times of MSPI ECC read when accesses to flash.
+ */
+#define SPI_FMEM_C_ECC_ERR_INT_EN    (BIT(17))
+#define SPI_FMEM_C_ECC_ERR_INT_EN_M  (SPI_FMEM_C_ECC_ERR_INT_EN_V << SPI_FMEM_C_ECC_ERR_INT_EN_S)
+#define SPI_FMEM_C_ECC_ERR_INT_EN_V  0x00000001U
+#define SPI_FMEM_C_ECC_ERR_INT_EN_S  17
+/** SPI_FMEM_C_PAGE_SIZE : R/W; bitpos: [20:18]; default: 0;
+ *  Set the page size of the flash accessed by MSPI. 0: 256 bytes. 1: 512 bytes. 2:
+ *  1024 bytes. 3: 2048 bytes. 4: 4096 bytes.
+ */
+#define SPI_FMEM_C_PAGE_SIZE    0x00000007U
+#define SPI_FMEM_C_PAGE_SIZE_M  (SPI_FMEM_C_PAGE_SIZE_V << SPI_FMEM_C_PAGE_SIZE_S)
+#define SPI_FMEM_C_PAGE_SIZE_V  0x00000007U
+#define SPI_FMEM_C_PAGE_SIZE_S  18
+/** SPI_FMEM_C_ECC_ADDR_EN : HRO; bitpos: [21]; default: 0;
+ *  Set this bit to enable MSPI ECC address conversion, no matter MSPI accesses to the
+ *  ECC region or non-ECC region of flash. If there is no ECC region in flash, this bit
+ *  should be 0. Otherwise, this bit should be 1.
+ */
+#define SPI_FMEM_C_ECC_ADDR_EN    (BIT(21))
+#define SPI_FMEM_C_ECC_ADDR_EN_M  (SPI_FMEM_C_ECC_ADDR_EN_V << SPI_FMEM_C_ECC_ADDR_EN_S)
+#define SPI_FMEM_C_ECC_ADDR_EN_V  0x00000001U
+#define SPI_FMEM_C_ECC_ADDR_EN_S  21
+/** SPI_MEM_C_USR_ECC_ADDR_EN : HRO; bitpos: [22]; default: 0;
+ *  Set this bit to enable ECC address convert in SPI0/1 USR_CMD transfer.
+ */
+#define SPI_MEM_C_USR_ECC_ADDR_EN    (BIT(22))
+#define SPI_MEM_C_USR_ECC_ADDR_EN_M  (SPI_MEM_C_USR_ECC_ADDR_EN_V << SPI_MEM_C_USR_ECC_ADDR_EN_S)
+#define SPI_MEM_C_USR_ECC_ADDR_EN_V  0x00000001U
+#define SPI_MEM_C_USR_ECC_ADDR_EN_S  22
+/** SPI_MEM_C_ECC_CONTINUE_RECORD_ERR_EN : HRO; bitpos: [24]; default: 1;
+ *  1: The error information in SPI_MEM_C_ECC_ERR_BITS and SPI_MEM_C_ECC_ERR_ADDR is
+ *  updated when there is an ECC error. 0: SPI_MEM_C_ECC_ERR_BITS and
+ *  SPI_MEM_C_ECC_ERR_ADDR record the first ECC error information.
+ */
+#define SPI_MEM_C_ECC_CONTINUE_RECORD_ERR_EN    (BIT(24))
+#define SPI_MEM_C_ECC_CONTINUE_RECORD_ERR_EN_M  (SPI_MEM_C_ECC_CONTINUE_RECORD_ERR_EN_V << SPI_MEM_C_ECC_CONTINUE_RECORD_ERR_EN_S)
+#define SPI_MEM_C_ECC_CONTINUE_RECORD_ERR_EN_V  0x00000001U
+#define SPI_MEM_C_ECC_CONTINUE_RECORD_ERR_EN_S  24
+/** SPI_MEM_C_ECC_ERR_BITS : HRO; bitpos: [31:25]; default: 0;
+ *  Records the first ECC error bit number in the 16 bytes(From 0~127, corresponding to
+ *  byte 0 bit 0 to byte 15 bit 7)
+ */
+#define SPI_MEM_C_ECC_ERR_BITS    0x0000007FU
+#define SPI_MEM_C_ECC_ERR_BITS_M  (SPI_MEM_C_ECC_ERR_BITS_V << SPI_MEM_C_ECC_ERR_BITS_S)
+#define SPI_MEM_C_ECC_ERR_BITS_V  0x0000007FU
+#define SPI_MEM_C_ECC_ERR_BITS_S  25
+
+/** SPI_MEM_C_ECC_ERR_ADDR_REG register
+ *  MSPI ECC error address register
+ */
+#define SPI_MEM_C_ECC_ERR_ADDR_REG (DR_REG_FLASH_SPI0_BASE + 0x16c)
+/** SPI_MEM_C_ECC_ERR_ADDR : HRO; bitpos: [28:0]; default: 0;
+ *  This bits show the first MSPI ECC error address. It is cleared by when
+ *  SPI_MEM_C_ECC_ERR_INT_CLR bit is set.
+ */
+#define SPI_MEM_C_ECC_ERR_ADDR    0x1FFFFFFFU
+#define SPI_MEM_C_ECC_ERR_ADDR_M  (SPI_MEM_C_ECC_ERR_ADDR_V << SPI_MEM_C_ECC_ERR_ADDR_S)
+#define SPI_MEM_C_ECC_ERR_ADDR_V  0x1FFFFFFFU
+#define SPI_MEM_C_ECC_ERR_ADDR_S  0
+
+/** SPI_MEM_C_AXI_ERR_ADDR_REG register
+ *  SPI0 AXI request error address.
+ */
+#define SPI_MEM_C_AXI_ERR_ADDR_REG (DR_REG_FLASH_SPI0_BASE + 0x170)
+/** SPI_MEM_C_AXI_ERR_ADDR : R/SS/WTC; bitpos: [28:0]; default: 0;
+ *  This bits show the first AXI write/read invalid error or AXI write flash error
+ *  address. It is cleared by when SPI_MEM_C_AXI_WADDR_ERR_INT_CLR,
+ *  SPI_MEM_C_AXI_WR_FLASH_ERR_IN_CLR or SPI_MEM_C_AXI_RADDR_ERR_IN_CLR bit is set.
+ */
+#define SPI_MEM_C_AXI_ERR_ADDR    0x1FFFFFFFU
+#define SPI_MEM_C_AXI_ERR_ADDR_M  (SPI_MEM_C_AXI_ERR_ADDR_V << SPI_MEM_C_AXI_ERR_ADDR_S)
+#define SPI_MEM_C_AXI_ERR_ADDR_V  0x1FFFFFFFU
+#define SPI_MEM_C_AXI_ERR_ADDR_S  0
+
+/** SPI_SMEM_C_ECC_CTRL_REG register
+ *  MSPI ECC control register
+ */
+#define SPI_SMEM_C_ECC_CTRL_REG (DR_REG_FLASH_SPI0_BASE + 0x174)
+/** SPI_SMEM_C_ECC_ERR_INT_EN : HRO; bitpos: [17]; default: 0;
+ *  Set this bit to calculate the error times of MSPI ECC read when accesses to
+ *  external RAM.
+ */
+#define SPI_SMEM_C_ECC_ERR_INT_EN    (BIT(17))
+#define SPI_SMEM_C_ECC_ERR_INT_EN_M  (SPI_SMEM_C_ECC_ERR_INT_EN_V << SPI_SMEM_C_ECC_ERR_INT_EN_S)
+#define SPI_SMEM_C_ECC_ERR_INT_EN_V  0x00000001U
+#define SPI_SMEM_C_ECC_ERR_INT_EN_S  17
+/** SPI_SMEM_C_PAGE_SIZE : HRO; bitpos: [19:18]; default: 2;
+ *  Set the page size of the external RAM accessed by MSPI. 0: 256 bytes. 1: 512 bytes.
+ *  2: 1024 bytes. 3: 2048 bytes.
+ */
+#define SPI_SMEM_C_PAGE_SIZE    0x00000003U
+#define SPI_SMEM_C_PAGE_SIZE_M  (SPI_SMEM_C_PAGE_SIZE_V << SPI_SMEM_C_PAGE_SIZE_S)
+#define SPI_SMEM_C_PAGE_SIZE_V  0x00000003U
+#define SPI_SMEM_C_PAGE_SIZE_S  18
+/** SPI_SMEM_C_ECC_ADDR_EN : HRO; bitpos: [20]; default: 0;
+ *  Set this bit to enable MSPI ECC address conversion, no matter MSPI accesses to the
+ *  ECC region or non-ECC region of external RAM. If there is no ECC region in external
+ *  RAM, this bit should be 0. Otherwise, this bit should be 1.
+ */
+#define SPI_SMEM_C_ECC_ADDR_EN    (BIT(20))
+#define SPI_SMEM_C_ECC_ADDR_EN_M  (SPI_SMEM_C_ECC_ADDR_EN_V << SPI_SMEM_C_ECC_ADDR_EN_S)
+#define SPI_SMEM_C_ECC_ADDR_EN_V  0x00000001U
+#define SPI_SMEM_C_ECC_ADDR_EN_S  20
+
+/** SPI_SMEM_C_AXI_ADDR_CTRL_REG register
+ *  SPI0 AXI address control register
+ */
+#define SPI_SMEM_C_AXI_ADDR_CTRL_REG (DR_REG_FLASH_SPI0_BASE + 0x178)
+/** SPI_MEM_C_ALL_FIFO_EMPTY : RO; bitpos: [26]; default: 1;
+ *  The empty status of all AFIFO and SYNC_FIFO in MSPI module. 1: All AXI transfers
+ *  and SPI0 transfers are done. 0: Others.
+ */
+#define SPI_MEM_C_ALL_FIFO_EMPTY    (BIT(26))
+#define SPI_MEM_C_ALL_FIFO_EMPTY_M  (SPI_MEM_C_ALL_FIFO_EMPTY_V << SPI_MEM_C_ALL_FIFO_EMPTY_S)
+#define SPI_MEM_C_ALL_FIFO_EMPTY_V  0x00000001U
+#define SPI_MEM_C_ALL_FIFO_EMPTY_S  26
+/** SPI_RDATA_AFIFO_REMPTY : RO; bitpos: [27]; default: 1;
+ *  1: RDATA_AFIFO is empty. 0: At least one AXI read transfer is pending.
+ */
+#define SPI_RDATA_AFIFO_REMPTY    (BIT(27))
+#define SPI_RDATA_AFIFO_REMPTY_M  (SPI_RDATA_AFIFO_REMPTY_V << SPI_RDATA_AFIFO_REMPTY_S)
+#define SPI_RDATA_AFIFO_REMPTY_V  0x00000001U
+#define SPI_RDATA_AFIFO_REMPTY_S  27
+/** SPI_RADDR_AFIFO_REMPTY : RO; bitpos: [28]; default: 1;
+ *  1: AXI_RADDR_CTL_AFIFO is empty. 0: At least one AXI read transfer is pending.
+ */
+#define SPI_RADDR_AFIFO_REMPTY    (BIT(28))
+#define SPI_RADDR_AFIFO_REMPTY_M  (SPI_RADDR_AFIFO_REMPTY_V << SPI_RADDR_AFIFO_REMPTY_S)
+#define SPI_RADDR_AFIFO_REMPTY_V  0x00000001U
+#define SPI_RADDR_AFIFO_REMPTY_S  28
+/** SPI_WDATA_AFIFO_REMPTY : RO; bitpos: [29]; default: 1;
+ *  1: WDATA_AFIFO is empty. 0: At least one AXI write transfer is pending.
+ */
+#define SPI_WDATA_AFIFO_REMPTY    (BIT(29))
+#define SPI_WDATA_AFIFO_REMPTY_M  (SPI_WDATA_AFIFO_REMPTY_V << SPI_WDATA_AFIFO_REMPTY_S)
+#define SPI_WDATA_AFIFO_REMPTY_V  0x00000001U
+#define SPI_WDATA_AFIFO_REMPTY_S  29
+/** SPI_WBLEN_AFIFO_REMPTY : RO; bitpos: [30]; default: 1;
+ *  1: WBLEN_AFIFO is empty. 0: At least one AXI write transfer is pending.
+ */
+#define SPI_WBLEN_AFIFO_REMPTY    (BIT(30))
+#define SPI_WBLEN_AFIFO_REMPTY_M  (SPI_WBLEN_AFIFO_REMPTY_V << SPI_WBLEN_AFIFO_REMPTY_S)
+#define SPI_WBLEN_AFIFO_REMPTY_V  0x00000001U
+#define SPI_WBLEN_AFIFO_REMPTY_S  30
+/** SPI_ALL_AXI_TRANS_AFIFO_EMPTY : RO; bitpos: [31]; default: 1;
+ *  This bit is set when WADDR_AFIFO, WBLEN_AFIFO, WDATA_AFIFO, AXI_RADDR_CTL_AFIFO and
+ *  RDATA_AFIFO are empty and spi0_mst_st is IDLE.
+ */
+#define SPI_ALL_AXI_TRANS_AFIFO_EMPTY    (BIT(31))
+#define SPI_ALL_AXI_TRANS_AFIFO_EMPTY_M  (SPI_ALL_AXI_TRANS_AFIFO_EMPTY_V << SPI_ALL_AXI_TRANS_AFIFO_EMPTY_S)
+#define SPI_ALL_AXI_TRANS_AFIFO_EMPTY_V  0x00000001U
+#define SPI_ALL_AXI_TRANS_AFIFO_EMPTY_S  31
+
+/** SPI_MEM_C_AXI_ERR_RESP_EN_REG register
+ *  SPI0 AXI error response enable register
+ */
+#define SPI_MEM_C_AXI_ERR_RESP_EN_REG (DR_REG_FLASH_SPI0_BASE + 0x17c)
+/** SPI_MEM_C_AW_RESP_EN_MMU_VLD : R/W; bitpos: [0]; default: 0;
+ *  Set this bit  to enable AXI response function for mmu valid err in axi write trans.
+ */
+#define SPI_MEM_C_AW_RESP_EN_MMU_VLD    (BIT(0))
+#define SPI_MEM_C_AW_RESP_EN_MMU_VLD_M  (SPI_MEM_C_AW_RESP_EN_MMU_VLD_V << SPI_MEM_C_AW_RESP_EN_MMU_VLD_S)
+#define SPI_MEM_C_AW_RESP_EN_MMU_VLD_V  0x00000001U
+#define SPI_MEM_C_AW_RESP_EN_MMU_VLD_S  0
+/** SPI_MEM_C_AW_RESP_EN_MMU_GID : R/W; bitpos: [1]; default: 0;
+ *  Set this bit  to enable AXI response function for mmu gid err in axi write trans.
+ */
+#define SPI_MEM_C_AW_RESP_EN_MMU_GID    (BIT(1))
+#define SPI_MEM_C_AW_RESP_EN_MMU_GID_M  (SPI_MEM_C_AW_RESP_EN_MMU_GID_V << SPI_MEM_C_AW_RESP_EN_MMU_GID_S)
+#define SPI_MEM_C_AW_RESP_EN_MMU_GID_V  0x00000001U
+#define SPI_MEM_C_AW_RESP_EN_MMU_GID_S  1
+/** SPI_MEM_C_AW_RESP_EN_AXI_SIZE : R/W; bitpos: [2]; default: 0;
+ *  Set this bit  to enable AXI response function for axi size err in axi write trans.
+ */
+#define SPI_MEM_C_AW_RESP_EN_AXI_SIZE    (BIT(2))
+#define SPI_MEM_C_AW_RESP_EN_AXI_SIZE_M  (SPI_MEM_C_AW_RESP_EN_AXI_SIZE_V << SPI_MEM_C_AW_RESP_EN_AXI_SIZE_S)
+#define SPI_MEM_C_AW_RESP_EN_AXI_SIZE_V  0x00000001U
+#define SPI_MEM_C_AW_RESP_EN_AXI_SIZE_S  2
+/** SPI_MEM_C_AW_RESP_EN_AXI_FLASH : R/W; bitpos: [3]; default: 0;
+ *  Set this bit  to enable AXI response function for axi flash err in axi write trans.
+ */
+#define SPI_MEM_C_AW_RESP_EN_AXI_FLASH    (BIT(3))
+#define SPI_MEM_C_AW_RESP_EN_AXI_FLASH_M  (SPI_MEM_C_AW_RESP_EN_AXI_FLASH_V << SPI_MEM_C_AW_RESP_EN_AXI_FLASH_S)
+#define SPI_MEM_C_AW_RESP_EN_AXI_FLASH_V  0x00000001U
+#define SPI_MEM_C_AW_RESP_EN_AXI_FLASH_S  3
+/** SPI_MEM_C_AW_RESP_EN_MMU_ECC : R/W; bitpos: [4]; default: 0;
+ *  Set this bit  to enable AXI response function for mmu ecc err in axi write trans.
+ */
+#define SPI_MEM_C_AW_RESP_EN_MMU_ECC    (BIT(4))
+#define SPI_MEM_C_AW_RESP_EN_MMU_ECC_M  (SPI_MEM_C_AW_RESP_EN_MMU_ECC_V << SPI_MEM_C_AW_RESP_EN_MMU_ECC_S)
+#define SPI_MEM_C_AW_RESP_EN_MMU_ECC_V  0x00000001U
+#define SPI_MEM_C_AW_RESP_EN_MMU_ECC_S  4
+/** SPI_MEM_C_AW_RESP_EN_MMU_SENS : R/W; bitpos: [5]; default: 0;
+ *  Set this bit  to enable AXI response function for mmu sens in err axi write trans.
+ */
+#define SPI_MEM_C_AW_RESP_EN_MMU_SENS    (BIT(5))
+#define SPI_MEM_C_AW_RESP_EN_MMU_SENS_M  (SPI_MEM_C_AW_RESP_EN_MMU_SENS_V << SPI_MEM_C_AW_RESP_EN_MMU_SENS_S)
+#define SPI_MEM_C_AW_RESP_EN_MMU_SENS_V  0x00000001U
+#define SPI_MEM_C_AW_RESP_EN_MMU_SENS_S  5
+/** SPI_MEM_C_AW_RESP_EN_AXI_WSTRB : R/W; bitpos: [6]; default: 0;
+ *  Set this bit  to enable AXI response function for axi wstrb err in axi write trans.
+ */
+#define SPI_MEM_C_AW_RESP_EN_AXI_WSTRB    (BIT(6))
+#define SPI_MEM_C_AW_RESP_EN_AXI_WSTRB_M  (SPI_MEM_C_AW_RESP_EN_AXI_WSTRB_V << SPI_MEM_C_AW_RESP_EN_AXI_WSTRB_S)
+#define SPI_MEM_C_AW_RESP_EN_AXI_WSTRB_V  0x00000001U
+#define SPI_MEM_C_AW_RESP_EN_AXI_WSTRB_S  6
+/** SPI_MEM_C_AR_RESP_EN_MMU_VLD : R/W; bitpos: [7]; default: 0;
+ *  Set this bit  to enable AXI response function for mmu valid err in axi read trans.
+ */
+#define SPI_MEM_C_AR_RESP_EN_MMU_VLD    (BIT(7))
+#define SPI_MEM_C_AR_RESP_EN_MMU_VLD_M  (SPI_MEM_C_AR_RESP_EN_MMU_VLD_V << SPI_MEM_C_AR_RESP_EN_MMU_VLD_S)
+#define SPI_MEM_C_AR_RESP_EN_MMU_VLD_V  0x00000001U
+#define SPI_MEM_C_AR_RESP_EN_MMU_VLD_S  7
+/** SPI_MEM_C_AR_RESP_EN_MMU_GID : R/W; bitpos: [8]; default: 0;
+ *  Set this bit  to enable AXI response function for mmu gid err in axi read trans.
+ */
+#define SPI_MEM_C_AR_RESP_EN_MMU_GID    (BIT(8))
+#define SPI_MEM_C_AR_RESP_EN_MMU_GID_M  (SPI_MEM_C_AR_RESP_EN_MMU_GID_V << SPI_MEM_C_AR_RESP_EN_MMU_GID_S)
+#define SPI_MEM_C_AR_RESP_EN_MMU_GID_V  0x00000001U
+#define SPI_MEM_C_AR_RESP_EN_MMU_GID_S  8
+/** SPI_MEM_C_AR_RESP_EN_MMU_ECC : R/W; bitpos: [9]; default: 0;
+ *  Set this bit  to enable AXI response function for mmu ecc err in axi read trans.
+ */
+#define SPI_MEM_C_AR_RESP_EN_MMU_ECC    (BIT(9))
+#define SPI_MEM_C_AR_RESP_EN_MMU_ECC_M  (SPI_MEM_C_AR_RESP_EN_MMU_ECC_V << SPI_MEM_C_AR_RESP_EN_MMU_ECC_S)
+#define SPI_MEM_C_AR_RESP_EN_MMU_ECC_V  0x00000001U
+#define SPI_MEM_C_AR_RESP_EN_MMU_ECC_S  9
+/** SPI_MEM_C_AR_RESP_EN_MMU_SENS : R/W; bitpos: [10]; default: 0;
+ *  Set this bit  to enable AXI response function for mmu sensitive err in axi read
+ *  trans.
+ */
+#define SPI_MEM_C_AR_RESP_EN_MMU_SENS    (BIT(10))
+#define SPI_MEM_C_AR_RESP_EN_MMU_SENS_M  (SPI_MEM_C_AR_RESP_EN_MMU_SENS_V << SPI_MEM_C_AR_RESP_EN_MMU_SENS_S)
+#define SPI_MEM_C_AR_RESP_EN_MMU_SENS_V  0x00000001U
+#define SPI_MEM_C_AR_RESP_EN_MMU_SENS_S  10
+/** SPI_MEM_C_AR_RESP_EN_AXI_SIZE : R/W; bitpos: [11]; default: 0;
+ *  Set this bit  to enable AXI response function for axi size err in axi read trans.
+ */
+#define SPI_MEM_C_AR_RESP_EN_AXI_SIZE    (BIT(11))
+#define SPI_MEM_C_AR_RESP_EN_AXI_SIZE_M  (SPI_MEM_C_AR_RESP_EN_AXI_SIZE_V << SPI_MEM_C_AR_RESP_EN_AXI_SIZE_S)
+#define SPI_MEM_C_AR_RESP_EN_AXI_SIZE_V  0x00000001U
+#define SPI_MEM_C_AR_RESP_EN_AXI_SIZE_S  11
+
+/** SPI_MEM_C_TIMING_CALI_REG register
+ *  SPI0 flash timing calibration register
+ */
+#define SPI_MEM_C_TIMING_CALI_REG (DR_REG_FLASH_SPI0_BASE + 0x180)
+/** SPI_MEM_C_TIMING_CLK_ENA : R/W; bitpos: [0]; default: 1;
+ *  The bit is used to enable timing adjust clock for all reading operations.
+ */
+#define SPI_MEM_C_TIMING_CLK_ENA    (BIT(0))
+#define SPI_MEM_C_TIMING_CLK_ENA_M  (SPI_MEM_C_TIMING_CLK_ENA_V << SPI_MEM_C_TIMING_CLK_ENA_S)
+#define SPI_MEM_C_TIMING_CLK_ENA_V  0x00000001U
+#define SPI_MEM_C_TIMING_CLK_ENA_S  0
+/** SPI_MEM_C_TIMING_CALI : R/W; bitpos: [1]; default: 0;
+ *  The bit is used to enable timing auto-calibration for all reading operations.
+ */
+#define SPI_MEM_C_TIMING_CALI    (BIT(1))
+#define SPI_MEM_C_TIMING_CALI_M  (SPI_MEM_C_TIMING_CALI_V << SPI_MEM_C_TIMING_CALI_S)
+#define SPI_MEM_C_TIMING_CALI_V  0x00000001U
+#define SPI_MEM_C_TIMING_CALI_S  1
+/** SPI_MEM_C_EXTRA_DUMMY_CYCLELEN : R/W; bitpos: [4:2]; default: 0;
+ *  add extra dummy spi clock cycle length for spi clock calibration.
+ */
+#define SPI_MEM_C_EXTRA_DUMMY_CYCLELEN    0x00000007U
+#define SPI_MEM_C_EXTRA_DUMMY_CYCLELEN_M  (SPI_MEM_C_EXTRA_DUMMY_CYCLELEN_V << SPI_MEM_C_EXTRA_DUMMY_CYCLELEN_S)
+#define SPI_MEM_C_EXTRA_DUMMY_CYCLELEN_V  0x00000007U
+#define SPI_MEM_C_EXTRA_DUMMY_CYCLELEN_S  2
+/** SPI_MEM_C_DLL_TIMING_CALI : HRO; bitpos: [5]; default: 0;
+ *  Set this bit to enable DLL for timing calibration in DDR mode when accessed to
+ *  flash.
+ */
+#define SPI_MEM_C_DLL_TIMING_CALI    (BIT(5))
+#define SPI_MEM_C_DLL_TIMING_CALI_M  (SPI_MEM_C_DLL_TIMING_CALI_V << SPI_MEM_C_DLL_TIMING_CALI_S)
+#define SPI_MEM_C_DLL_TIMING_CALI_V  0x00000001U
+#define SPI_MEM_C_DLL_TIMING_CALI_S  5
+/** SPI_MEM_C_TIMING_CALI_UPDATE : WT; bitpos: [6]; default: 0;
+ *  Set this bit to update delay mode, delay num and extra dummy in MSPI.
+ */
+#define SPI_MEM_C_TIMING_CALI_UPDATE    (BIT(6))
+#define SPI_MEM_C_TIMING_CALI_UPDATE_M  (SPI_MEM_C_TIMING_CALI_UPDATE_V << SPI_MEM_C_TIMING_CALI_UPDATE_S)
+#define SPI_MEM_C_TIMING_CALI_UPDATE_V  0x00000001U
+#define SPI_MEM_C_TIMING_CALI_UPDATE_S  6
+
+/** SPI_MEM_C_DIN_MODE_REG register
+ *  MSPI flash input timing delay mode control register
+ */
+#define SPI_MEM_C_DIN_MODE_REG (DR_REG_FLASH_SPI0_BASE + 0x184)
+/** SPI_MEM_C_DIN0_MODE : R/W; bitpos: [2:0]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb,  3: input
+ *  with the posedge of clk_160, 4 input with the negedge of clk_160, 5: input with the
+ *  spi_clk high edge,  6: input with the spi_clk low edge
+ */
+#define SPI_MEM_C_DIN0_MODE    0x00000007U
+#define SPI_MEM_C_DIN0_MODE_M  (SPI_MEM_C_DIN0_MODE_V << SPI_MEM_C_DIN0_MODE_S)
+#define SPI_MEM_C_DIN0_MODE_V  0x00000007U
+#define SPI_MEM_C_DIN0_MODE_S  0
+/** SPI_MEM_C_DIN1_MODE : R/W; bitpos: [5:3]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb,  3: input
+ *  with the posedge of clk_160, 4 input with the negedge of clk_160, 5: input with the
+ *  spi_clk high edge,  6: input with the spi_clk low edge
+ */
+#define SPI_MEM_C_DIN1_MODE    0x00000007U
+#define SPI_MEM_C_DIN1_MODE_M  (SPI_MEM_C_DIN1_MODE_V << SPI_MEM_C_DIN1_MODE_S)
+#define SPI_MEM_C_DIN1_MODE_V  0x00000007U
+#define SPI_MEM_C_DIN1_MODE_S  3
+/** SPI_MEM_C_DIN2_MODE : R/W; bitpos: [8:6]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb,  3: input
+ *  with the posedge of clk_160, 4 input with the negedge of clk_160, 5: input with the
+ *  spi_clk high edge,  6: input with the spi_clk low edge
+ */
+#define SPI_MEM_C_DIN2_MODE    0x00000007U
+#define SPI_MEM_C_DIN2_MODE_M  (SPI_MEM_C_DIN2_MODE_V << SPI_MEM_C_DIN2_MODE_S)
+#define SPI_MEM_C_DIN2_MODE_V  0x00000007U
+#define SPI_MEM_C_DIN2_MODE_S  6
+/** SPI_MEM_C_DIN3_MODE : R/W; bitpos: [11:9]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb,  3: input
+ *  with the posedge of clk_160, 4 input with the negedge of clk_160, 5: input with the
+ *  spi_clk high edge,  6: input with the spi_clk low edge
+ */
+#define SPI_MEM_C_DIN3_MODE    0x00000007U
+#define SPI_MEM_C_DIN3_MODE_M  (SPI_MEM_C_DIN3_MODE_V << SPI_MEM_C_DIN3_MODE_S)
+#define SPI_MEM_C_DIN3_MODE_V  0x00000007U
+#define SPI_MEM_C_DIN3_MODE_S  9
+/** SPI_MEM_C_DIN4_MODE : R/W; bitpos: [14:12]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3: input
+ *  with the spi_clk
+ */
+#define SPI_MEM_C_DIN4_MODE    0x00000007U
+#define SPI_MEM_C_DIN4_MODE_M  (SPI_MEM_C_DIN4_MODE_V << SPI_MEM_C_DIN4_MODE_S)
+#define SPI_MEM_C_DIN4_MODE_V  0x00000007U
+#define SPI_MEM_C_DIN4_MODE_S  12
+/** SPI_MEM_C_DIN5_MODE : R/W; bitpos: [17:15]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3: input
+ *  with the spi_clk
+ */
+#define SPI_MEM_C_DIN5_MODE    0x00000007U
+#define SPI_MEM_C_DIN5_MODE_M  (SPI_MEM_C_DIN5_MODE_V << SPI_MEM_C_DIN5_MODE_S)
+#define SPI_MEM_C_DIN5_MODE_V  0x00000007U
+#define SPI_MEM_C_DIN5_MODE_S  15
+/** SPI_MEM_C_DIN6_MODE : R/W; bitpos: [20:18]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3: input
+ *  with the spi_clk
+ */
+#define SPI_MEM_C_DIN6_MODE    0x00000007U
+#define SPI_MEM_C_DIN6_MODE_M  (SPI_MEM_C_DIN6_MODE_V << SPI_MEM_C_DIN6_MODE_S)
+#define SPI_MEM_C_DIN6_MODE_V  0x00000007U
+#define SPI_MEM_C_DIN6_MODE_S  18
+/** SPI_MEM_C_DIN7_MODE : R/W; bitpos: [23:21]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3: input
+ *  with the spi_clk
+ */
+#define SPI_MEM_C_DIN7_MODE    0x00000007U
+#define SPI_MEM_C_DIN7_MODE_M  (SPI_MEM_C_DIN7_MODE_V << SPI_MEM_C_DIN7_MODE_S)
+#define SPI_MEM_C_DIN7_MODE_V  0x00000007U
+#define SPI_MEM_C_DIN7_MODE_S  21
+/** SPI_MEM_C_DINS_MODE : R/W; bitpos: [26:24]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3: input
+ *  with the spi_clk
+ */
+#define SPI_MEM_C_DINS_MODE    0x00000007U
+#define SPI_MEM_C_DINS_MODE_M  (SPI_MEM_C_DINS_MODE_V << SPI_MEM_C_DINS_MODE_S)
+#define SPI_MEM_C_DINS_MODE_V  0x00000007U
+#define SPI_MEM_C_DINS_MODE_S  24
+
+/** SPI_MEM_C_DIN_NUM_REG register
+ *  MSPI flash input timing delay number control register
+ */
+#define SPI_MEM_C_DIN_NUM_REG (DR_REG_FLASH_SPI0_BASE + 0x188)
+/** SPI_MEM_C_DIN0_NUM : R/W; bitpos: [1:0]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_MEM_C_DIN0_NUM    0x00000003U
+#define SPI_MEM_C_DIN0_NUM_M  (SPI_MEM_C_DIN0_NUM_V << SPI_MEM_C_DIN0_NUM_S)
+#define SPI_MEM_C_DIN0_NUM_V  0x00000003U
+#define SPI_MEM_C_DIN0_NUM_S  0
+/** SPI_MEM_C_DIN1_NUM : R/W; bitpos: [3:2]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_MEM_C_DIN1_NUM    0x00000003U
+#define SPI_MEM_C_DIN1_NUM_M  (SPI_MEM_C_DIN1_NUM_V << SPI_MEM_C_DIN1_NUM_S)
+#define SPI_MEM_C_DIN1_NUM_V  0x00000003U
+#define SPI_MEM_C_DIN1_NUM_S  2
+/** SPI_MEM_C_DIN2_NUM : R/W; bitpos: [5:4]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_MEM_C_DIN2_NUM    0x00000003U
+#define SPI_MEM_C_DIN2_NUM_M  (SPI_MEM_C_DIN2_NUM_V << SPI_MEM_C_DIN2_NUM_S)
+#define SPI_MEM_C_DIN2_NUM_V  0x00000003U
+#define SPI_MEM_C_DIN2_NUM_S  4
+/** SPI_MEM_C_DIN3_NUM : R/W; bitpos: [7:6]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_MEM_C_DIN3_NUM    0x00000003U
+#define SPI_MEM_C_DIN3_NUM_M  (SPI_MEM_C_DIN3_NUM_V << SPI_MEM_C_DIN3_NUM_S)
+#define SPI_MEM_C_DIN3_NUM_V  0x00000003U
+#define SPI_MEM_C_DIN3_NUM_S  6
+/** SPI_MEM_C_DIN4_NUM : R/W; bitpos: [9:8]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_MEM_C_DIN4_NUM    0x00000003U
+#define SPI_MEM_C_DIN4_NUM_M  (SPI_MEM_C_DIN4_NUM_V << SPI_MEM_C_DIN4_NUM_S)
+#define SPI_MEM_C_DIN4_NUM_V  0x00000003U
+#define SPI_MEM_C_DIN4_NUM_S  8
+/** SPI_MEM_C_DIN5_NUM : R/W; bitpos: [11:10]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_MEM_C_DIN5_NUM    0x00000003U
+#define SPI_MEM_C_DIN5_NUM_M  (SPI_MEM_C_DIN5_NUM_V << SPI_MEM_C_DIN5_NUM_S)
+#define SPI_MEM_C_DIN5_NUM_V  0x00000003U
+#define SPI_MEM_C_DIN5_NUM_S  10
+/** SPI_MEM_C_DIN6_NUM : R/W; bitpos: [13:12]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_MEM_C_DIN6_NUM    0x00000003U
+#define SPI_MEM_C_DIN6_NUM_M  (SPI_MEM_C_DIN6_NUM_V << SPI_MEM_C_DIN6_NUM_S)
+#define SPI_MEM_C_DIN6_NUM_V  0x00000003U
+#define SPI_MEM_C_DIN6_NUM_S  12
+/** SPI_MEM_C_DIN7_NUM : R/W; bitpos: [15:14]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_MEM_C_DIN7_NUM    0x00000003U
+#define SPI_MEM_C_DIN7_NUM_M  (SPI_MEM_C_DIN7_NUM_V << SPI_MEM_C_DIN7_NUM_S)
+#define SPI_MEM_C_DIN7_NUM_V  0x00000003U
+#define SPI_MEM_C_DIN7_NUM_S  14
+/** SPI_MEM_C_DINS_NUM : R/W; bitpos: [17:16]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_MEM_C_DINS_NUM    0x00000003U
+#define SPI_MEM_C_DINS_NUM_M  (SPI_MEM_C_DINS_NUM_V << SPI_MEM_C_DINS_NUM_S)
+#define SPI_MEM_C_DINS_NUM_V  0x00000003U
+#define SPI_MEM_C_DINS_NUM_S  16
+
+/** SPI_MEM_C_DOUT_MODE_REG register
+ *  MSPI flash output timing adjustment control register
+ */
+#define SPI_MEM_C_DOUT_MODE_REG (DR_REG_FLASH_SPI0_BASE + 0x18c)
+/** SPI_MEM_C_DOUT0_MODE : R/W; bitpos: [0]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the posedge of clk_160,4 output with the negedge of clk_160,5: output
+ *  with the spi_clk high edge ,6: output with the spi_clk low edge
+ */
+#define SPI_MEM_C_DOUT0_MODE    (BIT(0))
+#define SPI_MEM_C_DOUT0_MODE_M  (SPI_MEM_C_DOUT0_MODE_V << SPI_MEM_C_DOUT0_MODE_S)
+#define SPI_MEM_C_DOUT0_MODE_V  0x00000001U
+#define SPI_MEM_C_DOUT0_MODE_S  0
+/** SPI_MEM_C_DOUT1_MODE : R/W; bitpos: [1]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the posedge of clk_160,4 output with the negedge of clk_160,5: output
+ *  with the spi_clk high edge ,6: output with the spi_clk low edge
+ */
+#define SPI_MEM_C_DOUT1_MODE    (BIT(1))
+#define SPI_MEM_C_DOUT1_MODE_M  (SPI_MEM_C_DOUT1_MODE_V << SPI_MEM_C_DOUT1_MODE_S)
+#define SPI_MEM_C_DOUT1_MODE_V  0x00000001U
+#define SPI_MEM_C_DOUT1_MODE_S  1
+/** SPI_MEM_C_DOUT2_MODE : R/W; bitpos: [2]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the posedge of clk_160,4 output with the negedge of clk_160,5: output
+ *  with the spi_clk high edge ,6: output with the spi_clk low edge
+ */
+#define SPI_MEM_C_DOUT2_MODE    (BIT(2))
+#define SPI_MEM_C_DOUT2_MODE_M  (SPI_MEM_C_DOUT2_MODE_V << SPI_MEM_C_DOUT2_MODE_S)
+#define SPI_MEM_C_DOUT2_MODE_V  0x00000001U
+#define SPI_MEM_C_DOUT2_MODE_S  2
+/** SPI_MEM_C_DOUT3_MODE : R/W; bitpos: [3]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the posedge of clk_160,4 output with the negedge of clk_160,5: output
+ *  with the spi_clk high edge ,6: output with the spi_clk low edge
+ */
+#define SPI_MEM_C_DOUT3_MODE    (BIT(3))
+#define SPI_MEM_C_DOUT3_MODE_M  (SPI_MEM_C_DOUT3_MODE_V << SPI_MEM_C_DOUT3_MODE_S)
+#define SPI_MEM_C_DOUT3_MODE_V  0x00000001U
+#define SPI_MEM_C_DOUT3_MODE_S  3
+/** SPI_MEM_C_DOUT4_MODE : R/W; bitpos: [4]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the spi_clk
+ */
+#define SPI_MEM_C_DOUT4_MODE    (BIT(4))
+#define SPI_MEM_C_DOUT4_MODE_M  (SPI_MEM_C_DOUT4_MODE_V << SPI_MEM_C_DOUT4_MODE_S)
+#define SPI_MEM_C_DOUT4_MODE_V  0x00000001U
+#define SPI_MEM_C_DOUT4_MODE_S  4
+/** SPI_MEM_C_DOUT5_MODE : R/W; bitpos: [5]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the spi_clk
+ */
+#define SPI_MEM_C_DOUT5_MODE    (BIT(5))
+#define SPI_MEM_C_DOUT5_MODE_M  (SPI_MEM_C_DOUT5_MODE_V << SPI_MEM_C_DOUT5_MODE_S)
+#define SPI_MEM_C_DOUT5_MODE_V  0x00000001U
+#define SPI_MEM_C_DOUT5_MODE_S  5
+/** SPI_MEM_C_DOUT6_MODE : R/W; bitpos: [6]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the spi_clk
+ */
+#define SPI_MEM_C_DOUT6_MODE    (BIT(6))
+#define SPI_MEM_C_DOUT6_MODE_M  (SPI_MEM_C_DOUT6_MODE_V << SPI_MEM_C_DOUT6_MODE_S)
+#define SPI_MEM_C_DOUT6_MODE_V  0x00000001U
+#define SPI_MEM_C_DOUT6_MODE_S  6
+/** SPI_MEM_C_DOUT7_MODE : R/W; bitpos: [7]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the spi_clk
+ */
+#define SPI_MEM_C_DOUT7_MODE    (BIT(7))
+#define SPI_MEM_C_DOUT7_MODE_M  (SPI_MEM_C_DOUT7_MODE_V << SPI_MEM_C_DOUT7_MODE_S)
+#define SPI_MEM_C_DOUT7_MODE_V  0x00000001U
+#define SPI_MEM_C_DOUT7_MODE_S  7
+/** SPI_MEM_C_DOUTS_MODE : R/W; bitpos: [8]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the spi_clk
+ */
+#define SPI_MEM_C_DOUTS_MODE    (BIT(8))
+#define SPI_MEM_C_DOUTS_MODE_M  (SPI_MEM_C_DOUTS_MODE_V << SPI_MEM_C_DOUTS_MODE_S)
+#define SPI_MEM_C_DOUTS_MODE_V  0x00000001U
+#define SPI_MEM_C_DOUTS_MODE_S  8
+
+/** SPI_SMEM_C_TIMING_CALI_REG register
+ *  MSPI external RAM timing calibration register
+ */
+#define SPI_SMEM_C_TIMING_CALI_REG (DR_REG_FLASH_SPI0_BASE + 0x190)
+/** SPI_SMEM_C_TIMING_CLK_ENA : HRO; bitpos: [0]; default: 1;
+ *  For sram, the bit is used to enable timing adjust clock for all reading operations.
+ */
+#define SPI_SMEM_C_TIMING_CLK_ENA    (BIT(0))
+#define SPI_SMEM_C_TIMING_CLK_ENA_M  (SPI_SMEM_C_TIMING_CLK_ENA_V << SPI_SMEM_C_TIMING_CLK_ENA_S)
+#define SPI_SMEM_C_TIMING_CLK_ENA_V  0x00000001U
+#define SPI_SMEM_C_TIMING_CLK_ENA_S  0
+/** SPI_SMEM_C_TIMING_CALI : HRO; bitpos: [1]; default: 0;
+ *  For sram, the bit is used to enable timing auto-calibration for all reading
+ *  operations.
+ */
+#define SPI_SMEM_C_TIMING_CALI    (BIT(1))
+#define SPI_SMEM_C_TIMING_CALI_M  (SPI_SMEM_C_TIMING_CALI_V << SPI_SMEM_C_TIMING_CALI_S)
+#define SPI_SMEM_C_TIMING_CALI_V  0x00000001U
+#define SPI_SMEM_C_TIMING_CALI_S  1
+/** SPI_SMEM_C_EXTRA_DUMMY_CYCLELEN : HRO; bitpos: [4:2]; default: 0;
+ *  For sram, add extra dummy spi clock cycle length for spi clock calibration.
+ */
+#define SPI_SMEM_C_EXTRA_DUMMY_CYCLELEN    0x00000007U
+#define SPI_SMEM_C_EXTRA_DUMMY_CYCLELEN_M  (SPI_SMEM_C_EXTRA_DUMMY_CYCLELEN_V << SPI_SMEM_C_EXTRA_DUMMY_CYCLELEN_S)
+#define SPI_SMEM_C_EXTRA_DUMMY_CYCLELEN_V  0x00000007U
+#define SPI_SMEM_C_EXTRA_DUMMY_CYCLELEN_S  2
+/** SPI_SMEM_C_DLL_TIMING_CALI : HRO; bitpos: [5]; default: 0;
+ *  Set this bit to enable DLL for timing calibration in DDR mode when accessed to
+ *  EXT_RAM.
+ */
+#define SPI_SMEM_C_DLL_TIMING_CALI    (BIT(5))
+#define SPI_SMEM_C_DLL_TIMING_CALI_M  (SPI_SMEM_C_DLL_TIMING_CALI_V << SPI_SMEM_C_DLL_TIMING_CALI_S)
+#define SPI_SMEM_C_DLL_TIMING_CALI_V  0x00000001U
+#define SPI_SMEM_C_DLL_TIMING_CALI_S  5
+/** SPI_SMEM_C_DQS0_270_SEL : HRO; bitpos: [8:7]; default: 1;
+ *  Set these bits to delay dqs signal & invert delayed signal for DLL timing adjust.
+ *  2'd0: 0.5ns, 2'd1: 1.0ns, 2'd2: 1.5ns 2'd3: 2.0ns.
+ */
+#define SPI_SMEM_C_DQS0_270_SEL    0x00000003U
+#define SPI_SMEM_C_DQS0_270_SEL_M  (SPI_SMEM_C_DQS0_270_SEL_V << SPI_SMEM_C_DQS0_270_SEL_S)
+#define SPI_SMEM_C_DQS0_270_SEL_V  0x00000003U
+#define SPI_SMEM_C_DQS0_270_SEL_S  7
+/** SPI_SMEM_C_DQS0_90_SEL : HRO; bitpos: [10:9]; default: 1;
+ *  Set these bits to delay dqs signal for DLL timing adjust. 2'd0: 0.5ns, 2'd1: 1.0ns,
+ *  2'd2: 1.5ns 2'd3: 2.0ns.
+ */
+#define SPI_SMEM_C_DQS0_90_SEL    0x00000003U
+#define SPI_SMEM_C_DQS0_90_SEL_M  (SPI_SMEM_C_DQS0_90_SEL_V << SPI_SMEM_C_DQS0_90_SEL_S)
+#define SPI_SMEM_C_DQS0_90_SEL_V  0x00000003U
+#define SPI_SMEM_C_DQS0_90_SEL_S  9
+/** SPI_SMEM_C_DQS1_270_SEL : HRO; bitpos: [12:11]; default: 1;
+ *  Set these bits to delay dqs signal & invert delayed signal for DLL timing adjust.
+ *  2'd0: 0.5ns, 2'd1: 1.0ns, 2'd2: 1.5ns 2'd3: 2.0ns.
+ */
+#define SPI_SMEM_C_DQS1_270_SEL    0x00000003U
+#define SPI_SMEM_C_DQS1_270_SEL_M  (SPI_SMEM_C_DQS1_270_SEL_V << SPI_SMEM_C_DQS1_270_SEL_S)
+#define SPI_SMEM_C_DQS1_270_SEL_V  0x00000003U
+#define SPI_SMEM_C_DQS1_270_SEL_S  11
+/** SPI_SMEM_C_DQS1_90_SEL : HRO; bitpos: [14:13]; default: 1;
+ *  Set these bits to delay dqs signal for DLL timing adjust. 2'd0: 0.5ns, 2'd1: 1.0ns,
+ *  2'd2: 1.5ns 2'd3: 2.0ns.
+ */
+#define SPI_SMEM_C_DQS1_90_SEL    0x00000003U
+#define SPI_SMEM_C_DQS1_90_SEL_M  (SPI_SMEM_C_DQS1_90_SEL_V << SPI_SMEM_C_DQS1_90_SEL_S)
+#define SPI_SMEM_C_DQS1_90_SEL_V  0x00000003U
+#define SPI_SMEM_C_DQS1_90_SEL_S  13
+
+/** SPI_SMEM_C_DIN_MODE_REG register
+ *  MSPI external RAM input timing delay mode control register
+ */
+#define SPI_SMEM_C_DIN_MODE_REG (DR_REG_FLASH_SPI0_BASE + 0x194)
+/** SPI_SMEM_C_DIN0_MODE : HRO; bitpos: [2:0]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb,  3: input
+ *  with the posedge of clk_160, 4 input with the negedge of clk_160, 5: input with the
+ *  spi_clk high edge,  6: input with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DIN0_MODE    0x00000007U
+#define SPI_SMEM_C_DIN0_MODE_M  (SPI_SMEM_C_DIN0_MODE_V << SPI_SMEM_C_DIN0_MODE_S)
+#define SPI_SMEM_C_DIN0_MODE_V  0x00000007U
+#define SPI_SMEM_C_DIN0_MODE_S  0
+/** SPI_SMEM_C_DIN1_MODE : HRO; bitpos: [5:3]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb,  3: input
+ *  with the posedge of clk_160, 4 input with the negedge of clk_160, 5: input with the
+ *  spi_clk high edge,  6: input with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DIN1_MODE    0x00000007U
+#define SPI_SMEM_C_DIN1_MODE_M  (SPI_SMEM_C_DIN1_MODE_V << SPI_SMEM_C_DIN1_MODE_S)
+#define SPI_SMEM_C_DIN1_MODE_V  0x00000007U
+#define SPI_SMEM_C_DIN1_MODE_S  3
+/** SPI_SMEM_C_DIN2_MODE : HRO; bitpos: [8:6]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb,  3: input
+ *  with the posedge of clk_160, 4 input with the negedge of clk_160, 5: input with the
+ *  spi_clk high edge,  6: input with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DIN2_MODE    0x00000007U
+#define SPI_SMEM_C_DIN2_MODE_M  (SPI_SMEM_C_DIN2_MODE_V << SPI_SMEM_C_DIN2_MODE_S)
+#define SPI_SMEM_C_DIN2_MODE_V  0x00000007U
+#define SPI_SMEM_C_DIN2_MODE_S  6
+/** SPI_SMEM_C_DIN3_MODE : HRO; bitpos: [11:9]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb,  3: input
+ *  with the posedge of clk_160, 4 input with the negedge of clk_160, 5: input with the
+ *  spi_clk high edge,  6: input with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DIN3_MODE    0x00000007U
+#define SPI_SMEM_C_DIN3_MODE_M  (SPI_SMEM_C_DIN3_MODE_V << SPI_SMEM_C_DIN3_MODE_S)
+#define SPI_SMEM_C_DIN3_MODE_V  0x00000007U
+#define SPI_SMEM_C_DIN3_MODE_S  9
+/** SPI_SMEM_C_DIN4_MODE : HRO; bitpos: [14:12]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb,  3: input
+ *  with the posedge of clk_160, 4 input with the negedge of clk_160, 5: input with the
+ *  spi_clk high edge,  6: input with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DIN4_MODE    0x00000007U
+#define SPI_SMEM_C_DIN4_MODE_M  (SPI_SMEM_C_DIN4_MODE_V << SPI_SMEM_C_DIN4_MODE_S)
+#define SPI_SMEM_C_DIN4_MODE_V  0x00000007U
+#define SPI_SMEM_C_DIN4_MODE_S  12
+/** SPI_SMEM_C_DIN5_MODE : HRO; bitpos: [17:15]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb,  3: input
+ *  with the posedge of clk_160, 4 input with the negedge of clk_160, 5: input with the
+ *  spi_clk high edge,  6: input with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DIN5_MODE    0x00000007U
+#define SPI_SMEM_C_DIN5_MODE_M  (SPI_SMEM_C_DIN5_MODE_V << SPI_SMEM_C_DIN5_MODE_S)
+#define SPI_SMEM_C_DIN5_MODE_V  0x00000007U
+#define SPI_SMEM_C_DIN5_MODE_S  15
+/** SPI_SMEM_C_DIN6_MODE : HRO; bitpos: [20:18]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb,  3: input
+ *  with the posedge of clk_160, 4 input with the negedge of clk_160, 5: input with the
+ *  spi_clk high edge,  6: input with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DIN6_MODE    0x00000007U
+#define SPI_SMEM_C_DIN6_MODE_M  (SPI_SMEM_C_DIN6_MODE_V << SPI_SMEM_C_DIN6_MODE_S)
+#define SPI_SMEM_C_DIN6_MODE_V  0x00000007U
+#define SPI_SMEM_C_DIN6_MODE_S  18
+/** SPI_SMEM_C_DIN7_MODE : HRO; bitpos: [23:21]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb,  3: input
+ *  with the posedge of clk_160, 4 input with the negedge of clk_160, 5: input with the
+ *  spi_clk high edge,  6: input with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DIN7_MODE    0x00000007U
+#define SPI_SMEM_C_DIN7_MODE_M  (SPI_SMEM_C_DIN7_MODE_V << SPI_SMEM_C_DIN7_MODE_S)
+#define SPI_SMEM_C_DIN7_MODE_V  0x00000007U
+#define SPI_SMEM_C_DIN7_MODE_S  21
+/** SPI_SMEM_C_DINS_MODE : HRO; bitpos: [26:24]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: input without delayed, 1:
+ *  input with the posedge of clk_apb,2 input with the negedge of clk_apb,  3: input
+ *  with the posedge of clk_160, 4 input with the negedge of clk_160, 5: input with the
+ *  spi_clk high edge,  6: input with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DINS_MODE    0x00000007U
+#define SPI_SMEM_C_DINS_MODE_M  (SPI_SMEM_C_DINS_MODE_V << SPI_SMEM_C_DINS_MODE_S)
+#define SPI_SMEM_C_DINS_MODE_V  0x00000007U
+#define SPI_SMEM_C_DINS_MODE_S  24
+
+/** SPI_SMEM_C_DIN_NUM_REG register
+ *  MSPI external RAM input timing delay number control register
+ */
+#define SPI_SMEM_C_DIN_NUM_REG (DR_REG_FLASH_SPI0_BASE + 0x198)
+/** SPI_SMEM_C_DIN0_NUM : HRO; bitpos: [1:0]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_SMEM_C_DIN0_NUM    0x00000003U
+#define SPI_SMEM_C_DIN0_NUM_M  (SPI_SMEM_C_DIN0_NUM_V << SPI_SMEM_C_DIN0_NUM_S)
+#define SPI_SMEM_C_DIN0_NUM_V  0x00000003U
+#define SPI_SMEM_C_DIN0_NUM_S  0
+/** SPI_SMEM_C_DIN1_NUM : HRO; bitpos: [3:2]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_SMEM_C_DIN1_NUM    0x00000003U
+#define SPI_SMEM_C_DIN1_NUM_M  (SPI_SMEM_C_DIN1_NUM_V << SPI_SMEM_C_DIN1_NUM_S)
+#define SPI_SMEM_C_DIN1_NUM_V  0x00000003U
+#define SPI_SMEM_C_DIN1_NUM_S  2
+/** SPI_SMEM_C_DIN2_NUM : HRO; bitpos: [5:4]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_SMEM_C_DIN2_NUM    0x00000003U
+#define SPI_SMEM_C_DIN2_NUM_M  (SPI_SMEM_C_DIN2_NUM_V << SPI_SMEM_C_DIN2_NUM_S)
+#define SPI_SMEM_C_DIN2_NUM_V  0x00000003U
+#define SPI_SMEM_C_DIN2_NUM_S  4
+/** SPI_SMEM_C_DIN3_NUM : HRO; bitpos: [7:6]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_SMEM_C_DIN3_NUM    0x00000003U
+#define SPI_SMEM_C_DIN3_NUM_M  (SPI_SMEM_C_DIN3_NUM_V << SPI_SMEM_C_DIN3_NUM_S)
+#define SPI_SMEM_C_DIN3_NUM_V  0x00000003U
+#define SPI_SMEM_C_DIN3_NUM_S  6
+/** SPI_SMEM_C_DIN4_NUM : HRO; bitpos: [9:8]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_SMEM_C_DIN4_NUM    0x00000003U
+#define SPI_SMEM_C_DIN4_NUM_M  (SPI_SMEM_C_DIN4_NUM_V << SPI_SMEM_C_DIN4_NUM_S)
+#define SPI_SMEM_C_DIN4_NUM_V  0x00000003U
+#define SPI_SMEM_C_DIN4_NUM_S  8
+/** SPI_SMEM_C_DIN5_NUM : HRO; bitpos: [11:10]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_SMEM_C_DIN5_NUM    0x00000003U
+#define SPI_SMEM_C_DIN5_NUM_M  (SPI_SMEM_C_DIN5_NUM_V << SPI_SMEM_C_DIN5_NUM_S)
+#define SPI_SMEM_C_DIN5_NUM_V  0x00000003U
+#define SPI_SMEM_C_DIN5_NUM_S  10
+/** SPI_SMEM_C_DIN6_NUM : HRO; bitpos: [13:12]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_SMEM_C_DIN6_NUM    0x00000003U
+#define SPI_SMEM_C_DIN6_NUM_M  (SPI_SMEM_C_DIN6_NUM_V << SPI_SMEM_C_DIN6_NUM_S)
+#define SPI_SMEM_C_DIN6_NUM_V  0x00000003U
+#define SPI_SMEM_C_DIN6_NUM_S  12
+/** SPI_SMEM_C_DIN7_NUM : HRO; bitpos: [15:14]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_SMEM_C_DIN7_NUM    0x00000003U
+#define SPI_SMEM_C_DIN7_NUM_M  (SPI_SMEM_C_DIN7_NUM_V << SPI_SMEM_C_DIN7_NUM_S)
+#define SPI_SMEM_C_DIN7_NUM_V  0x00000003U
+#define SPI_SMEM_C_DIN7_NUM_S  14
+/** SPI_SMEM_C_DINS_NUM : HRO; bitpos: [17:16]; default: 0;
+ *  the input signals are delayed by system clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...
+ */
+#define SPI_SMEM_C_DINS_NUM    0x00000003U
+#define SPI_SMEM_C_DINS_NUM_M  (SPI_SMEM_C_DINS_NUM_V << SPI_SMEM_C_DINS_NUM_S)
+#define SPI_SMEM_C_DINS_NUM_V  0x00000003U
+#define SPI_SMEM_C_DINS_NUM_S  16
+
+/** SPI_SMEM_C_DOUT_MODE_REG register
+ *  MSPI external RAM output timing adjustment control register
+ */
+#define SPI_SMEM_C_DOUT_MODE_REG (DR_REG_FLASH_SPI0_BASE + 0x19c)
+/** SPI_SMEM_C_DOUT0_MODE : HRO; bitpos: [0]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the posedge of clk_160,4 output with the negedge of clk_160,5: output
+ *  with the spi_clk high edge ,6: output with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DOUT0_MODE    (BIT(0))
+#define SPI_SMEM_C_DOUT0_MODE_M  (SPI_SMEM_C_DOUT0_MODE_V << SPI_SMEM_C_DOUT0_MODE_S)
+#define SPI_SMEM_C_DOUT0_MODE_V  0x00000001U
+#define SPI_SMEM_C_DOUT0_MODE_S  0
+/** SPI_SMEM_C_DOUT1_MODE : HRO; bitpos: [1]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the posedge of clk_160,4 output with the negedge of clk_160,5: output
+ *  with the spi_clk high edge ,6: output with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DOUT1_MODE    (BIT(1))
+#define SPI_SMEM_C_DOUT1_MODE_M  (SPI_SMEM_C_DOUT1_MODE_V << SPI_SMEM_C_DOUT1_MODE_S)
+#define SPI_SMEM_C_DOUT1_MODE_V  0x00000001U
+#define SPI_SMEM_C_DOUT1_MODE_S  1
+/** SPI_SMEM_C_DOUT2_MODE : HRO; bitpos: [2]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the posedge of clk_160,4 output with the negedge of clk_160,5: output
+ *  with the spi_clk high edge ,6: output with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DOUT2_MODE    (BIT(2))
+#define SPI_SMEM_C_DOUT2_MODE_M  (SPI_SMEM_C_DOUT2_MODE_V << SPI_SMEM_C_DOUT2_MODE_S)
+#define SPI_SMEM_C_DOUT2_MODE_V  0x00000001U
+#define SPI_SMEM_C_DOUT2_MODE_S  2
+/** SPI_SMEM_C_DOUT3_MODE : HRO; bitpos: [3]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the posedge of clk_160,4 output with the negedge of clk_160,5: output
+ *  with the spi_clk high edge ,6: output with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DOUT3_MODE    (BIT(3))
+#define SPI_SMEM_C_DOUT3_MODE_M  (SPI_SMEM_C_DOUT3_MODE_V << SPI_SMEM_C_DOUT3_MODE_S)
+#define SPI_SMEM_C_DOUT3_MODE_V  0x00000001U
+#define SPI_SMEM_C_DOUT3_MODE_S  3
+/** SPI_SMEM_C_DOUT4_MODE : HRO; bitpos: [4]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the posedge of clk_160,4 output with the negedge of clk_160,5: output
+ *  with the spi_clk high edge ,6: output with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DOUT4_MODE    (BIT(4))
+#define SPI_SMEM_C_DOUT4_MODE_M  (SPI_SMEM_C_DOUT4_MODE_V << SPI_SMEM_C_DOUT4_MODE_S)
+#define SPI_SMEM_C_DOUT4_MODE_V  0x00000001U
+#define SPI_SMEM_C_DOUT4_MODE_S  4
+/** SPI_SMEM_C_DOUT5_MODE : HRO; bitpos: [5]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the posedge of clk_160,4 output with the negedge of clk_160,5: output
+ *  with the spi_clk high edge ,6: output with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DOUT5_MODE    (BIT(5))
+#define SPI_SMEM_C_DOUT5_MODE_M  (SPI_SMEM_C_DOUT5_MODE_V << SPI_SMEM_C_DOUT5_MODE_S)
+#define SPI_SMEM_C_DOUT5_MODE_V  0x00000001U
+#define SPI_SMEM_C_DOUT5_MODE_S  5
+/** SPI_SMEM_C_DOUT6_MODE : HRO; bitpos: [6]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the posedge of clk_160,4 output with the negedge of clk_160,5: output
+ *  with the spi_clk high edge ,6: output with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DOUT6_MODE    (BIT(6))
+#define SPI_SMEM_C_DOUT6_MODE_M  (SPI_SMEM_C_DOUT6_MODE_V << SPI_SMEM_C_DOUT6_MODE_S)
+#define SPI_SMEM_C_DOUT6_MODE_V  0x00000001U
+#define SPI_SMEM_C_DOUT6_MODE_S  6
+/** SPI_SMEM_C_DOUT7_MODE : HRO; bitpos: [7]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the posedge of clk_160,4 output with the negedge of clk_160,5: output
+ *  with the spi_clk high edge ,6: output with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DOUT7_MODE    (BIT(7))
+#define SPI_SMEM_C_DOUT7_MODE_M  (SPI_SMEM_C_DOUT7_MODE_V << SPI_SMEM_C_DOUT7_MODE_S)
+#define SPI_SMEM_C_DOUT7_MODE_V  0x00000001U
+#define SPI_SMEM_C_DOUT7_MODE_S  7
+/** SPI_SMEM_C_DOUTS_MODE : HRO; bitpos: [8]; default: 0;
+ *  the output signals are delayed by system clock cycles, 0: output without delayed,
+ *  1: output with the posedge of clk_apb,2 output with the negedge of clk_apb, 3:
+ *  output with the posedge of clk_160,4 output with the negedge of clk_160,5: output
+ *  with the spi_clk high edge ,6: output with the spi_clk low edge
+ */
+#define SPI_SMEM_C_DOUTS_MODE    (BIT(8))
+#define SPI_SMEM_C_DOUTS_MODE_M  (SPI_SMEM_C_DOUTS_MODE_V << SPI_SMEM_C_DOUTS_MODE_S)
+#define SPI_SMEM_C_DOUTS_MODE_V  0x00000001U
+#define SPI_SMEM_C_DOUTS_MODE_S  8
+
+/** SPI_SMEM_C_AC_REG register
+ *  MSPI external RAM ECC and SPI CS timing control register
+ */
+#define SPI_SMEM_C_AC_REG (DR_REG_FLASH_SPI0_BASE + 0x1a0)
+/** SPI_SMEM_C_CS_SETUP : HRO; bitpos: [0]; default: 0;
+ *  For SPI0 and SPI1, spi cs is enable when spi is in prepare phase. 1: enable 0:
+ *  disable.
+ */
+#define SPI_SMEM_C_CS_SETUP    (BIT(0))
+#define SPI_SMEM_C_CS_SETUP_M  (SPI_SMEM_C_CS_SETUP_V << SPI_SMEM_C_CS_SETUP_S)
+#define SPI_SMEM_C_CS_SETUP_V  0x00000001U
+#define SPI_SMEM_C_CS_SETUP_S  0
+/** SPI_SMEM_C_CS_HOLD : HRO; bitpos: [1]; default: 0;
+ *  For SPI0 and SPI1, spi cs keep low when spi is in done phase. 1: enable 0: disable.
+ */
+#define SPI_SMEM_C_CS_HOLD    (BIT(1))
+#define SPI_SMEM_C_CS_HOLD_M  (SPI_SMEM_C_CS_HOLD_V << SPI_SMEM_C_CS_HOLD_S)
+#define SPI_SMEM_C_CS_HOLD_V  0x00000001U
+#define SPI_SMEM_C_CS_HOLD_S  1
+/** SPI_SMEM_C_CS_SETUP_TIME : HRO; bitpos: [6:2]; default: 1;
+ *  For spi0, (cycles-1) of prepare phase by spi clock this bits are combined with
+ *  spi_mem_cs_setup bit.
+ */
+#define SPI_SMEM_C_CS_SETUP_TIME    0x0000001FU
+#define SPI_SMEM_C_CS_SETUP_TIME_M  (SPI_SMEM_C_CS_SETUP_TIME_V << SPI_SMEM_C_CS_SETUP_TIME_S)
+#define SPI_SMEM_C_CS_SETUP_TIME_V  0x0000001FU
+#define SPI_SMEM_C_CS_SETUP_TIME_S  2
+/** SPI_SMEM_C_CS_HOLD_TIME : HRO; bitpos: [11:7]; default: 1;
+ *  For SPI0 and SPI1, spi cs signal is delayed to inactive by spi clock this bits are
+ *  combined with spi_mem_cs_hold bit.
+ */
+#define SPI_SMEM_C_CS_HOLD_TIME    0x0000001FU
+#define SPI_SMEM_C_CS_HOLD_TIME_M  (SPI_SMEM_C_CS_HOLD_TIME_V << SPI_SMEM_C_CS_HOLD_TIME_S)
+#define SPI_SMEM_C_CS_HOLD_TIME_V  0x0000001FU
+#define SPI_SMEM_C_CS_HOLD_TIME_S  7
+/** SPI_SMEM_C_ECC_CS_HOLD_TIME : HRO; bitpos: [14:12]; default: 3;
+ *  SPI_SMEM_C_CS_HOLD_TIME + SPI_SMEM_C_ECC_CS_HOLD_TIME is the SPI0 and SPI1 CS hold
+ *  cycles in ECC mode when accessed external RAM.
+ */
+#define SPI_SMEM_C_ECC_CS_HOLD_TIME    0x00000007U
+#define SPI_SMEM_C_ECC_CS_HOLD_TIME_M  (SPI_SMEM_C_ECC_CS_HOLD_TIME_V << SPI_SMEM_C_ECC_CS_HOLD_TIME_S)
+#define SPI_SMEM_C_ECC_CS_HOLD_TIME_V  0x00000007U
+#define SPI_SMEM_C_ECC_CS_HOLD_TIME_S  12
+/** SPI_SMEM_C_ECC_SKIP_PAGE_CORNER : HRO; bitpos: [15]; default: 1;
+ *  1: SPI0 skips page corner when accesses external RAM. 0: Not skip page corner when
+ *  accesses external RAM.
+ */
+#define SPI_SMEM_C_ECC_SKIP_PAGE_CORNER    (BIT(15))
+#define SPI_SMEM_C_ECC_SKIP_PAGE_CORNER_M  (SPI_SMEM_C_ECC_SKIP_PAGE_CORNER_V << SPI_SMEM_C_ECC_SKIP_PAGE_CORNER_S)
+#define SPI_SMEM_C_ECC_SKIP_PAGE_CORNER_V  0x00000001U
+#define SPI_SMEM_C_ECC_SKIP_PAGE_CORNER_S  15
+/** SPI_SMEM_C_ECC_16TO18_BYTE_EN : HRO; bitpos: [16]; default: 0;
+ *  Set this bit to enable SPI0 and SPI1 ECC 16 bytes data with 2 ECC bytes mode when
+ *  accesses external RAM.
+ */
+#define SPI_SMEM_C_ECC_16TO18_BYTE_EN    (BIT(16))
+#define SPI_SMEM_C_ECC_16TO18_BYTE_EN_M  (SPI_SMEM_C_ECC_16TO18_BYTE_EN_V << SPI_SMEM_C_ECC_16TO18_BYTE_EN_S)
+#define SPI_SMEM_C_ECC_16TO18_BYTE_EN_V  0x00000001U
+#define SPI_SMEM_C_ECC_16TO18_BYTE_EN_S  16
+/** SPI_SMEM_C_CS_HOLD_DELAY : HRO; bitpos: [30:25]; default: 0;
+ *  These bits are used to set the minimum CS high time tSHSL between SPI burst
+ *  transfer when accesses to external RAM. tSHSL is (SPI_SMEM_C_CS_HOLD_DELAY[5:0] + 1)
+ *  MSPI core clock cycles.
+ */
+#define SPI_SMEM_C_CS_HOLD_DELAY    0x0000003FU
+#define SPI_SMEM_C_CS_HOLD_DELAY_M  (SPI_SMEM_C_CS_HOLD_DELAY_V << SPI_SMEM_C_CS_HOLD_DELAY_S)
+#define SPI_SMEM_C_CS_HOLD_DELAY_V  0x0000003FU
+#define SPI_SMEM_C_CS_HOLD_DELAY_S  25
+/** SPI_SMEM_C_SPLIT_TRANS_EN : HRO; bitpos: [31]; default: 0;
+ *  Set this bit to enable SPI0 split one AXI accesses EXT_RAM transfer into two SPI
+ *  transfers when one transfer will cross flash/EXT_RAM page corner, valid no matter
+ *  whether there is an ECC region or not.
+ */
+#define SPI_SMEM_C_SPLIT_TRANS_EN    (BIT(31))
+#define SPI_SMEM_C_SPLIT_TRANS_EN_M  (SPI_SMEM_C_SPLIT_TRANS_EN_V << SPI_SMEM_C_SPLIT_TRANS_EN_S)
+#define SPI_SMEM_C_SPLIT_TRANS_EN_V  0x00000001U
+#define SPI_SMEM_C_SPLIT_TRANS_EN_S  31
+
+/** SPI_MEM_C_CLOCK_GATE_REG register
+ *  SPI0 clock gate register
+ */
+#define SPI_MEM_C_CLOCK_GATE_REG (DR_REG_FLASH_SPI0_BASE + 0x200)
+/** SPI_CLK_EN : R/W; bitpos: [0]; default: 1;
+ *  Register clock gate enable signal. 1: Enable. 0: Disable.
+ */
+#define SPI_CLK_EN    (BIT(0))
+#define SPI_CLK_EN_M  (SPI_CLK_EN_V << SPI_CLK_EN_S)
+#define SPI_CLK_EN_V  0x00000001U
+#define SPI_CLK_EN_S  0
+/** SPI_MSPI_CLK_FORCE_ON : R/W; bitpos: [1]; default: 0;
+ *  MSPI lowpower function clock gate force on signal. 1: Enable. 0: Disable.
+ */
+#define SPI_MSPI_CLK_FORCE_ON    (BIT(1))
+#define SPI_MSPI_CLK_FORCE_ON_M  (SPI_MSPI_CLK_FORCE_ON_V << SPI_MSPI_CLK_FORCE_ON_S)
+#define SPI_MSPI_CLK_FORCE_ON_V  0x00000001U
+#define SPI_MSPI_CLK_FORCE_ON_S  1
+
+/** SPI_MEM_C_NAND_FLASH_EN_REG register
+ *  NAND FLASH control register
+ */
+#define SPI_MEM_C_NAND_FLASH_EN_REG (DR_REG_FLASH_SPI0_BASE + 0x204)
+/** SPI_MEM_C_NAND_FLASH_EN : R/W; bitpos: [0]; default: 0;
+ *  NAND FLASH function enable signal. 1: Enable NAND FLASH, Disable NOR FLASH. 0:
+ *  Disable NAND FLASH, Enable NOR FLASH.
+ */
+#define SPI_MEM_C_NAND_FLASH_EN    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_EN_M  (SPI_MEM_C_NAND_FLASH_EN_V << SPI_MEM_C_NAND_FLASH_EN_S)
+#define SPI_MEM_C_NAND_FLASH_EN_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_EN_S  0
+/** SPI_MEM_C_NAND_FLASH_SEQ_HD_INDEX : R/W; bitpos: [15:1]; default: 32767;
+ *  NAND FLASH spi seq head index configure register. Every 5 bits represent  the 1st
+ *  index of a SPI CMD sequence.[14:10]:usr; [9:5]:axi_rd; [4:0]:axi_wr.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_HD_INDEX    0x00007FFFU
+#define SPI_MEM_C_NAND_FLASH_SEQ_HD_INDEX_M  (SPI_MEM_C_NAND_FLASH_SEQ_HD_INDEX_V << SPI_MEM_C_NAND_FLASH_SEQ_HD_INDEX_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_HD_INDEX_V  0x00007FFFU
+#define SPI_MEM_C_NAND_FLASH_SEQ_HD_INDEX_S  1
+/** SPI_MEM_C_NAND_FLASH_SEQ_USR_TRIG : R/W; bitpos: [16]; default: 0;
+ *  NAND FLASH spi seq user trigger configure register. SPI_MEM_C_NAND_FLASH_SEQ_USR_TRIG
+ *  is corresponds to SPI_MEM_C_NAND_FLASH_SEQ_HD_INDEX[14:10].1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_USR_TRIG    (BIT(16))
+#define SPI_MEM_C_NAND_FLASH_SEQ_USR_TRIG_M  (SPI_MEM_C_NAND_FLASH_SEQ_USR_TRIG_V << SPI_MEM_C_NAND_FLASH_SEQ_USR_TRIG_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_USR_TRIG_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_USR_TRIG_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_EN : HRO; bitpos: [17]; default: 1;
+ *  NAND FLASH spi seq & cmd lut cfg en. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_EN    (BIT(17))
+#define SPI_MEM_C_NAND_FLASH_LUT_EN_M  (SPI_MEM_C_NAND_FLASH_LUT_EN_V << SPI_MEM_C_NAND_FLASH_LUT_EN_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_EN_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_EN_S  17
+/** SPI_MEM_C_NAND_FLASH_SEQ_USR_WEND : R/W; bitpos: [18]; default: 0;
+ *  Used with SPI_MEM_C_NAND_FLASH_SEQ_USR_TRIG to indicate the last page program ,and to
+ *  execute page execute. 1: write end 0: write in a page size.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_USR_WEND    (BIT(18))
+#define SPI_MEM_C_NAND_FLASH_SEQ_USR_WEND_M  (SPI_MEM_C_NAND_FLASH_SEQ_USR_WEND_V << SPI_MEM_C_NAND_FLASH_SEQ_USR_WEND_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_USR_WEND_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_USR_WEND_S  18
+
+/** SPI_MEM_C_NAND_FLASH_SR_ADDR0_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR0_REG (DR_REG_FLASH_SPI0_BASE + 0x208)
+/** SPI_MEM_C_NAND_FLASH_SR_ADDR0 : R/W; bitpos: [7:0]; default: 0;
+ *  configure state register address for SPI SEQ need. If OIP is in address C0H , user
+ *  could configure C0H into this register
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR0    0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR0_M  (SPI_MEM_C_NAND_FLASH_SR_ADDR0_V << SPI_MEM_C_NAND_FLASH_SR_ADDR0_S)
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR0_V  0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR0_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_ADDR1 : R/W; bitpos: [15:8]; default: 0;
+ *  configure state register address for SPI SEQ need. If OIP is in address C0H , user
+ *  could configure C0H into this register
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR1    0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR1_M  (SPI_MEM_C_NAND_FLASH_SR_ADDR1_V << SPI_MEM_C_NAND_FLASH_SR_ADDR1_S)
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR1_V  0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR1_S  8
+/** SPI_MEM_C_NAND_FLASH_SR_ADDR2 : R/W; bitpos: [23:16]; default: 0;
+ *  configure state register address for SPI SEQ need. If OIP is in address C0H , user
+ *  could configure C0H into this register
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR2    0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR2_M  (SPI_MEM_C_NAND_FLASH_SR_ADDR2_V << SPI_MEM_C_NAND_FLASH_SR_ADDR2_S)
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR2_V  0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR2_S  16
+/** SPI_MEM_C_NAND_FLASH_SR_ADDR3 : R/W; bitpos: [31:24]; default: 0;
+ *  configure state register address for SPI SEQ need. If OIP is in address C0H , user
+ *  could configure C0H into this register
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR3    0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR3_M  (SPI_MEM_C_NAND_FLASH_SR_ADDR3_V << SPI_MEM_C_NAND_FLASH_SR_ADDR3_S)
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR3_V  0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_ADDR3_S  24
+
+/** SPI_MEM_C_NAND_FLASH_SR_DIN0_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_DIN0_REG (DR_REG_FLASH_SPI0_BASE + 0x20c)
+/** SPI_MEM_C_NAND_FLASH_SR_DIN0 : RO; bitpos: [7:0]; default: 0;
+ *  spi read state register data to this register for SPI SEQ need.
+ *  SPI_MEM_C_NAND_FLASH_SR_DIN0_REG corresponds to SPI_MEM_C_NAND_FLASH_SR_ADDR0_REG.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_DIN0    0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_DIN0_M  (SPI_MEM_C_NAND_FLASH_SR_DIN0_V << SPI_MEM_C_NAND_FLASH_SR_DIN0_S)
+#define SPI_MEM_C_NAND_FLASH_SR_DIN0_V  0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_DIN0_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_DIN1 : RO; bitpos: [15:8]; default: 0;
+ *  spi read state register data to this register for SPI SEQ need.
+ *  SPI_MEM_C_NAND_FLASH_SR_DIN0_REG corresponds to SPI_MEM_C_NAND_FLASH_SR_ADDR0_REG.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_DIN1    0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_DIN1_M  (SPI_MEM_C_NAND_FLASH_SR_DIN1_V << SPI_MEM_C_NAND_FLASH_SR_DIN1_S)
+#define SPI_MEM_C_NAND_FLASH_SR_DIN1_V  0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_DIN1_S  8
+/** SPI_MEM_C_NAND_FLASH_SR_DIN2 : RO; bitpos: [23:16]; default: 0;
+ *  spi read state register data to this register for SPI SEQ need.
+ *  SPI_MEM_C_NAND_FLASH_SR_DIN0_REG corresponds to SPI_MEM_C_NAND_FLASH_SR_ADDR0_REG.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_DIN2    0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_DIN2_M  (SPI_MEM_C_NAND_FLASH_SR_DIN2_V << SPI_MEM_C_NAND_FLASH_SR_DIN2_S)
+#define SPI_MEM_C_NAND_FLASH_SR_DIN2_V  0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_DIN2_S  16
+/** SPI_MEM_C_NAND_FLASH_SR_DIN3 : RO; bitpos: [31:24]; default: 0;
+ *  spi read state register data to this register for SPI SEQ need.
+ *  SPI_MEM_C_NAND_FLASH_SR_DIN0_REG corresponds to SPI_MEM_C_NAND_FLASH_SR_ADDR0_REG.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_DIN3    0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_DIN3_M  (SPI_MEM_C_NAND_FLASH_SR_DIN3_V << SPI_MEM_C_NAND_FLASH_SR_DIN3_S)
+#define SPI_MEM_C_NAND_FLASH_SR_DIN3_V  0x000000FFU
+#define SPI_MEM_C_NAND_FLASH_SR_DIN3_S  24
+
+/** SPI_MEM_C_NAND_FLASH_CFG_DATA0_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA0_REG (DR_REG_FLASH_SPI0_BASE + 0x210)
+/** SPI_MEM_C_NAND_FLASH_CFG_DATA0 : R/W; bitpos: [15:0]; default: 0;
+ *  configure data for SPI SEQ din/dout need. The data could be use to configure NAND
+ *  FLASH or compare read data
+ */
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA0    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA0_M  (SPI_MEM_C_NAND_FLASH_CFG_DATA0_V << SPI_MEM_C_NAND_FLASH_CFG_DATA0_S)
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA0_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA0_S  0
+/** SPI_MEM_C_NAND_FLASH_CFG_DATA1 : R/W; bitpos: [31:16]; default: 0;
+ *  configure data for SPI SEQ din/dout need. The data could be use to configure NAND
+ *  FLASH or compare read data
+ */
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA1    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA1_M  (SPI_MEM_C_NAND_FLASH_CFG_DATA1_V << SPI_MEM_C_NAND_FLASH_CFG_DATA1_S)
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA1_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA1_S  16
+
+/** SPI_MEM_C_NAND_FLASH_CFG_DATA1_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA1_REG (DR_REG_FLASH_SPI0_BASE + 0x214)
+/** SPI_MEM_C_NAND_FLASH_CFG_DATA2 : R/W; bitpos: [15:0]; default: 0;
+ *  configure data for SPI SEQ din/dout need. The data could be use to configure NAND
+ *  FLASH or compare read data
+ */
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA2    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA2_M  (SPI_MEM_C_NAND_FLASH_CFG_DATA2_V << SPI_MEM_C_NAND_FLASH_CFG_DATA2_S)
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA2_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA2_S  0
+/** SPI_MEM_C_NAND_FLASH_CFG_DATA3 : R/W; bitpos: [31:16]; default: 0;
+ *  configure data for SPI SEQ din/dout need. The data could be use to configure NAND
+ *  FLASH or compare read data
+ */
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA3    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA3_M  (SPI_MEM_C_NAND_FLASH_CFG_DATA3_V << SPI_MEM_C_NAND_FLASH_CFG_DATA3_S)
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA3_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA3_S  16
+
+/** SPI_MEM_C_NAND_FLASH_CFG_DATA2_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA2_REG (DR_REG_FLASH_SPI0_BASE + 0x218)
+/** SPI_MEM_C_NAND_FLASH_CFG_DATA4 : R/W; bitpos: [15:0]; default: 0;
+ *  configure data for SPI SEQ din/dout need. The data could be use to configure NAND
+ *  FLASH or compare read data
+ */
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA4    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA4_M  (SPI_MEM_C_NAND_FLASH_CFG_DATA4_V << SPI_MEM_C_NAND_FLASH_CFG_DATA4_S)
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA4_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA4_S  0
+/** SPI_MEM_C_NAND_FLASH_CFG_DATA5 : R/W; bitpos: [31:16]; default: 0;
+ *  configure data for SPI SEQ din/dout need. The data could be use to configure NAND
+ *  FLASH or compare read data
+ */
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA5    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA5_M  (SPI_MEM_C_NAND_FLASH_CFG_DATA5_V << SPI_MEM_C_NAND_FLASH_CFG_DATA5_S)
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA5_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_CFG_DATA5_S  16
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT0_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT0_REG (DR_REG_FLASH_SPI0_BASE + 0x240)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE0 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 0.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE0    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE0_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE0_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE0_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE0_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE0_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN0 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 0.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN0    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN0_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN0_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN0_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN0_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN0_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN0 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 0.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN0    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN0_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN0_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN0_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN0_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN0_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN0 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 0.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN0    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN0_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN0_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN0_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN0_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN0_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN0 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 0.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN0    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN0_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN0_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN0_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN0_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN0_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN0 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 0,SPI could use DUAL/QUAD mode
+ *  while enable, SPI could use SINGLE mode while disable.1:Enable. 0:Disable.(Note
+ *  these registers are described to indicate the SPI_MEM_C_NAND_FLASH_CMD_LUT0_REG's
+ *  field. The number of CMD LUT entries can be defined by the user, but cannot exceed
+ *  16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN0    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN0_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN0_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN0_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN0_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN0_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT1_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT1_REG (DR_REG_FLASH_SPI0_BASE + 0x244)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE1 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 1.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE1    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE1_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE1_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE1_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE1_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE1_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN1 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 1.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN1    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN1_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN1_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN1_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN1_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN1_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN1 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 1.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN1    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN1_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN1_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN1_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN1_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN1_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN1 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 1.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN1    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN1_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN1_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN1_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN1_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN1_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN1 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 1.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN1    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN1_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN1_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN1_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN1_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN1_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN1 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 1,SPI could use DUAL/QUAD mode
+ *  while enable, SPI could use SINGLE mode while disable.1:Enable. 0:Disable.(Note
+ *  these registers are described to indicate the SPI_MEM_C_NAND_FLASH_CMD_LUT1_REG's
+ *  field. The number of CMD LUT entries can be defined by the user, but cannot exceed
+ *  16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN1    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN1_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN1_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN1_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN1_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN1_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT2_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT2_REG (DR_REG_FLASH_SPI0_BASE + 0x248)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE2 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 2.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE2    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE2_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE2_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE2_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE2_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE2_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN2 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 2.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN2    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN2_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN2_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN2_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN2_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN2_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN2 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 2.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN2    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN2_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN2_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN2_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN2_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN2_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN2 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 2.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN2    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN2_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN2_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN2_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN2_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN2_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN2 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 2.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN2    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN2_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN2_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN2_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN2_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN2_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN2 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 2,SPI could use DUAL/QUAD mode
+ *  while enable, SPI could use SINGLE mode while disable.1:Enable. 0:Disable.(Note
+ *  these registers are described to indicate the SPI_MEM_C_NAND_FLASH_CMD_LUT2_REG's
+ *  field. The number of CMD LUT entries can be defined by the user, but cannot exceed
+ *  16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN2    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN2_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN2_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN2_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN2_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN2_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT3_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT3_REG (DR_REG_FLASH_SPI0_BASE + 0x24c)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE3 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 3.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE3    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE3_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE3_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE3_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE3_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE3_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN3 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 3.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN3    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN3_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN3_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN3_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN3_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN3_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN3 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 3.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN3    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN3_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN3_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN3_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN3_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN3_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN3 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 3.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN3    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN3_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN3_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN3_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN3_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN3_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN3 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 3.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN3    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN3_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN3_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN3_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN3_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN3_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN3 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 3,SPI could use DUAL/QUAD mode
+ *  while enable, SPI could use SINGLE mode while disable.1:Enable. 0:Disable.(Note
+ *  these registers are described to indicate the SPI_MEM_C_NAND_FLASH_CMD_LUT3_REG's
+ *  field. The number of CMD LUT entries can be defined by the user, but cannot exceed
+ *  16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN3    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN3_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN3_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN3_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN3_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN3_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT4_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT4_REG (DR_REG_FLASH_SPI0_BASE + 0x250)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE4 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 4.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE4    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE4_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE4_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE4_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE4_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE4_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN4 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 4.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN4    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN4_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN4_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN4_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN4_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN4_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN4 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 4.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN4    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN4_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN4_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN4_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN4_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN4_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN4 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 4.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN4    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN4_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN4_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN4_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN4_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN4_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN4 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 4.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN4    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN4_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN4_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN4_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN4_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN4_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN4 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 4,SPI could use DUAL/QUAD mode
+ *  while enable, SPI could use SINGLE mode while disable.1:Enable. 0:Disable.(Note
+ *  these registers are described to indicate the SPI_MEM_C_NAND_FLASH_CMD_LUT4_REG's
+ *  field. The number of CMD LUT entries can be defined by the user, but cannot exceed
+ *  16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN4    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN4_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN4_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN4_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN4_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN4_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT5_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT5_REG (DR_REG_FLASH_SPI0_BASE + 0x254)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE5 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 5.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE5    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE5_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE5_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE5_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE5_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE5_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN5 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 5.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN5    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN5_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN5_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN5_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN5_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN5_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN5 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 5.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN5    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN5_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN5_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN5_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN5_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN5_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN5 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 5.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN5    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN5_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN5_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN5_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN5_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN5_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN5 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 5.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN5    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN5_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN5_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN5_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN5_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN5_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN5 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 5,SPI could use DUAL/QUAD mode
+ *  while enable, SPI could use SINGLE mode while disable.1:Enable. 0:Disable.(Note
+ *  these registers are described to indicate the SPI_MEM_C_NAND_FLASH_CMD_LUT5_REG's
+ *  field. The number of CMD LUT entries can be defined by the user, but cannot exceed
+ *  16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN5    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN5_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN5_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN5_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN5_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN5_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT6_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT6_REG (DR_REG_FLASH_SPI0_BASE + 0x258)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE6 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 6.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE6    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE6_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE6_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE6_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE6_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE6_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN6 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 6.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN6    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN6_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN6_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN6_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN6_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN6_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN6 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 6.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN6    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN6_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN6_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN6_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN6_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN6_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN6 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 6.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN6    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN6_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN6_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN6_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN6_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN6_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN6 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 6.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN6    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN6_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN6_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN6_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN6_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN6_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN6 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 6,SPI could use DUAL/QUAD mode
+ *  while enable, SPI could use SINGLE mode while disable.1:Enable. 0:Disable.(Note
+ *  these registers are described to indicate the SPI_MEM_C_NAND_FLASH_CMD_LUT6_REG's
+ *  field. The number of CMD LUT entries can be defined by the user, but cannot exceed
+ *  16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN6    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN6_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN6_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN6_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN6_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN6_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT7_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT7_REG (DR_REG_FLASH_SPI0_BASE + 0x25c)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE7 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 7.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE7    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE7_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE7_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE7_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE7_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE7_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN7 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 7.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN7    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN7_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN7_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN7_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN7_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN7_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN7 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 7.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN7    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN7_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN7_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN7_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN7_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN7_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN7 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 7.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN7    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN7_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN7_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN7_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN7_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN7_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN7 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 7.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN7    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN7_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN7_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN7_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN7_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN7_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN7 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 7,SPI could use DUAL/QUAD mode
+ *  while enable, SPI could use SINGLE mode while disable.1:Enable. 0:Disable.(Note
+ *  these registers are described to indicate the SPI_MEM_C_NAND_FLASH_CMD_LUT7_REG's
+ *  field. The number of CMD LUT entries can be defined by the user, but cannot exceed
+ *  16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN7    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN7_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN7_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN7_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN7_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN7_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT8_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT8_REG (DR_REG_FLASH_SPI0_BASE + 0x260)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE8 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 8.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE8    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE8_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE8_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE8_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE8_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE8_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN8 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 8.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN8    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN8_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN8_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN8_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN8_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN8_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN8 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 8.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN8    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN8_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN8_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN8_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN8_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN8_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN8 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 8.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN8    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN8_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN8_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN8_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN8_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN8_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN8 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 8.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN8    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN8_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN8_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN8_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN8_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN8_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN8 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 8,SPI could use DUAL/QUAD mode
+ *  while enable, SPI could use SINGLE mode while disable.1:Enable. 0:Disable.(Note
+ *  these registers are described to indicate the SPI_MEM_C_NAND_FLASH_CMD_LUT8_REG's
+ *  field. The number of CMD LUT entries can be defined by the user, but cannot exceed
+ *  16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN8    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN8_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN8_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN8_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN8_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN8_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT9_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT9_REG (DR_REG_FLASH_SPI0_BASE + 0x264)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE9 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 9.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE9    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE9_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE9_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE9_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE9_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE9_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN9 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 9.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN9    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN9_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN9_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN9_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN9_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN9_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN9 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 9.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN9    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN9_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN9_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN9_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN9_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN9_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN9 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 9.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN9    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN9_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN9_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN9_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN9_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN9_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN9 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 9.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN9    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN9_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN9_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN9_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN9_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN9_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN9 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 9,SPI could use DUAL/QUAD mode
+ *  while enable, SPI could use SINGLE mode while disable.1:Enable. 0:Disable.(Note
+ *  these registers are described to indicate the SPI_MEM_C_NAND_FLASH_CMD_LUT9_REG's
+ *  field. The number of CMD LUT entries can be defined by the user, but cannot exceed
+ *  16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN9    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN9_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN9_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN9_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN9_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN9_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT10_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT10_REG (DR_REG_FLASH_SPI0_BASE + 0x268)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE10 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 10.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE10    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE10_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE10_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE10_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE10_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE10_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN10 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 10.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN10    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN10_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN10_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN10_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN10_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN10_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN10 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 10.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN10    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN10_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN10_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN10_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN10_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN10_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN10 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 10.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN10    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN10_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN10_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN10_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN10_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN10_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN10 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 10.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN10    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN10_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN10_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN10_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN10_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN10_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN10 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 10,SPI could use DUAL/QUAD
+ *  mode while enable, SPI could use SINGLE mode while disable.1:Enable.
+ *  0:Disable.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_CMD_LUT10_REG's field. The number of CMD LUT entries can be
+ *  defined by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN10    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN10_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN10_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN10_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN10_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN10_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT11_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT11_REG (DR_REG_FLASH_SPI0_BASE + 0x26c)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE11 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 11.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE11    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE11_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE11_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE11_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE11_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE11_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN11 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 11.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN11    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN11_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN11_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN11_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN11_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN11_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN11 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 11.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN11    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN11_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN11_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN11_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN11_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN11_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN11 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 11.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN11    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN11_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN11_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN11_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN11_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN11_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN11 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 11.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN11    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN11_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN11_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN11_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN11_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN11_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN11 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 11,SPI could use DUAL/QUAD
+ *  mode while enable, SPI could use SINGLE mode while disable.1:Enable.
+ *  0:Disable.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_CMD_LUT11_REG's field. The number of CMD LUT entries can be
+ *  defined by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN11    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN11_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN11_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN11_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN11_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN11_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT12_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT12_REG (DR_REG_FLASH_SPI0_BASE + 0x270)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE12 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 12.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE12    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE12_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE12_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE12_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE12_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE12_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN12 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 12.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN12    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN12_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN12_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN12_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN12_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN12_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN12 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 12.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN12    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN12_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN12_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN12_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN12_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN12_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN12 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 12.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN12    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN12_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN12_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN12_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN12_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN12_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN12 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 12.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN12    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN12_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN12_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN12_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN12_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN12_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN12 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 12,SPI could use DUAL/QUAD
+ *  mode while enable, SPI could use SINGLE mode while disable.1:Enable.
+ *  0:Disable.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_CMD_LUT12_REG's field. The number of CMD LUT entries can be
+ *  defined by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN12    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN12_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN12_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN12_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN12_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN12_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT13_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT13_REG (DR_REG_FLASH_SPI0_BASE + 0x274)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE13 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 13.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE13    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE13_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE13_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE13_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE13_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE13_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN13 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 13.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN13    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN13_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN13_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN13_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN13_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN13_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN13 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 13.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN13    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN13_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN13_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN13_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN13_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN13_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN13 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 13.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN13    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN13_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN13_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN13_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN13_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN13_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN13 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 13.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN13    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN13_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN13_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN13_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN13_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN13_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN13 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 13,SPI could use DUAL/QUAD
+ *  mode while enable, SPI could use SINGLE mode while disable.1:Enable.
+ *  0:Disable.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_CMD_LUT13_REG's field. The number of CMD LUT entries can be
+ *  defined by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN13    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN13_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN13_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN13_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN13_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN13_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT14_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT14_REG (DR_REG_FLASH_SPI0_BASE + 0x278)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE14 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 14.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE14    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE14_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE14_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE14_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE14_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE14_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN14 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 14.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN14    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN14_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN14_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN14_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN14_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN14_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN14 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 14.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN14    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN14_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN14_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN14_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN14_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN14_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN14 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 14.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN14    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN14_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN14_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN14_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN14_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN14_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN14 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 14.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN14    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN14_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN14_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN14_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN14_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN14_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN14 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 14,SPI could use DUAL/QUAD
+ *  mode while enable, SPI could use SINGLE mode while disable.1:Enable.
+ *  0:Disable.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_CMD_LUT14_REG's field. The number of CMD LUT entries can be
+ *  defined by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN14    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN14_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN14_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN14_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN14_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN14_S  30
+
+/** SPI_MEM_C_NAND_FLASH_CMD_LUT15_REG register
+ *  MSPI NAND FLASH CMD LUT control register
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_LUT15_REG (DR_REG_FLASH_SPI0_BASE + 0x27c)
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE15 : R/W; bitpos: [15:0]; default: 0;
+ *  MSPI NAND FLASH config cmd value at cmd lut address 15.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE15    0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE15_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE15_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE15_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE15_V  0x0000FFFFU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_VALUE15_S  0
+/** SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN15 : R/W; bitpos: [19:16]; default: 0;
+ *  MSPI NAND FLASH config sfsm_st_en at cmd lut address 15.[3]-ADDR period enable;
+ *  [2]-DUMMY period enable; [1]-DIN period; [0]-DOUT period.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN15    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN15_M  (SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN15_V << SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN15_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN15_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_SFSM_ST_EN15_S  16
+/** SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN15 : R/W; bitpos: [23:20]; default: 0;
+ *  MSPI NAND FLASH config cmd length at cmd lut address 15.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN15    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN15_M  (SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN15_V << SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN15_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN15_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_CMD_LEN15_S  20
+/** SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN15 : R/W; bitpos: [27:24]; default: 0;
+ *  MSPI NAND FLASH config address length at cmd lut address 15.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN15    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN15_M  (SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN15_V << SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN15_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN15_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_LUT_ADDR_LEN15_S  24
+/** SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN15 : R/W; bitpos: [29:28]; default: 0;
+ *  MSPI NAND FLASH config data length at cmd lut address 15.
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN15    0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN15_M  (SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN15_V << SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN15_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN15_V  0x00000003U
+#define SPI_MEM_C_NAND_FLASH_LUT_DATA_LEN15_S  28
+/** SPI_MEM_C_NAND_FLASH_LUT_BUS_EN15 : R/W; bitpos: [30]; default: 0;
+ *  MSPI NAND FLASH config spi_bus_en at cmd lut address 15,SPI could use DUAL/QUAD
+ *  mode while enable, SPI could use SINGLE mode while disable.1:Enable.
+ *  0:Disable.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_CMD_LUT15_REG's field. The number of CMD LUT entries can be
+ *  defined by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN15    (BIT(30))
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN15_M  (SPI_MEM_C_NAND_FLASH_LUT_BUS_EN15_V << SPI_MEM_C_NAND_FLASH_LUT_BUS_EN15_S)
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN15_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_LUT_BUS_EN15_S  30
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ0_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ0_REG (DR_REG_FLASH_SPI0_BASE + 0x280)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG0 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 0.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG0    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG0_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG0_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG0_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG0_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG0_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN0 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 0. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN0    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN0_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN0_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN0_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN0_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN0_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX0 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 0.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX0    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX0_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX0_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX0_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX0_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX0_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX0 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 0.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX0    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX0_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX0_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX0_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX0_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX0_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG0 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 0. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG0    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG0_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG0_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG0_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG0_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG0_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX0 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 0. Use to find SPI command in
+ *  CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX0    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX0_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX0_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX0_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX0_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX0_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ1_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ1_REG (DR_REG_FLASH_SPI0_BASE + 0x284)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG1 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 1.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG1    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG1_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG1_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG1_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG1_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG1_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN1 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 1. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN1    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN1_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN1_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN1_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN1_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN1_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX1 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 1.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX1    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX1_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX1_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX1_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX1_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX1_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX1 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 1.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX1    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX1_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX1_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX1_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX1_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX1_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG1 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 1. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG1    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG1_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG1_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG1_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG1_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG1_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX1 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 1. Use to find SPI command in
+ *  CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX1    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX1_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX1_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX1_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX1_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX1_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ2_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ2_REG (DR_REG_FLASH_SPI0_BASE + 0x288)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG2 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 2.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG2    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG2_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG2_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG2_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG2_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG2_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN2 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 2. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN2    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN2_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN2_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN2_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN2_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN2_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX2 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 2.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX2    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX2_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX2_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX2_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX2_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX2_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX2 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 2.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX2    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX2_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX2_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX2_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX2_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX2_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG2 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 2. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG2    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG2_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG2_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG2_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG2_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG2_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX2 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 2. Use to find SPI command in
+ *  CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX2    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX2_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX2_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX2_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX2_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX2_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ3_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ3_REG (DR_REG_FLASH_SPI0_BASE + 0x28c)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG3 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 3.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG3    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG3_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG3_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG3_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG3_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG3_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN3 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 3. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN3    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN3_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN3_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN3_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN3_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN3_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX3 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 3.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX3    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX3_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX3_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX3_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX3_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX3_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX3 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 3.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX3    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX3_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX3_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX3_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX3_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX3_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG3 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 3. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG3    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG3_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG3_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG3_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG3_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG3_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX3 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 3. Use to find SPI command in
+ *  CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX3    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX3_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX3_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX3_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX3_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX3_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ4_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ4_REG (DR_REG_FLASH_SPI0_BASE + 0x290)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG4 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 4.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG4    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG4_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG4_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG4_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG4_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG4_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN4 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 4. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN4    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN4_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN4_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN4_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN4_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN4_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX4 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 4.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX4    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX4_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX4_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX4_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX4_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX4_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX4 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 4.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX4    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX4_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX4_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX4_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX4_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX4_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG4 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 4. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG4    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG4_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG4_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG4_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG4_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG4_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX4 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 4. Use to find SPI command in
+ *  CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX4    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX4_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX4_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX4_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX4_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX4_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ5_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ5_REG (DR_REG_FLASH_SPI0_BASE + 0x294)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG5 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 5.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG5    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG5_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG5_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG5_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG5_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG5_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN5 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 5. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN5    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN5_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN5_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN5_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN5_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN5_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX5 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 5.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX5    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX5_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX5_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX5_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX5_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX5_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX5 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 5.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX5    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX5_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX5_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX5_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX5_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX5_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG5 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 5. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG5    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG5_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG5_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG5_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG5_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG5_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX5 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 5. Use to find SPI command in
+ *  CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX5    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX5_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX5_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX5_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX5_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX5_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ6_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ6_REG (DR_REG_FLASH_SPI0_BASE + 0x298)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG6 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 6.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG6    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG6_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG6_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG6_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG6_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG6_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN6 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 6. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN6    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN6_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN6_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN6_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN6_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN6_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX6 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 6.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX6    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX6_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX6_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX6_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX6_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX6_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX6 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 6.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX6    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX6_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX6_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX6_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX6_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX6_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG6 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 6. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG6    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG6_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG6_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG6_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG6_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG6_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX6 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 6. Use to find SPI command in
+ *  CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX6    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX6_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX6_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX6_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX6_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX6_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ7_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ7_REG (DR_REG_FLASH_SPI0_BASE + 0x29c)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG7 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 7.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG7    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG7_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG7_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG7_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG7_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG7_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN7 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 7. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN7    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN7_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN7_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN7_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN7_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN7_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX7 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 7.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX7    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX7_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX7_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX7_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX7_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX7_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX7 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 7.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX7    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX7_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX7_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX7_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX7_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX7_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG7 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 7. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG7    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG7_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG7_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG7_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG7_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG7_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX7 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 7. Use to find SPI command in
+ *  CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX7    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX7_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX7_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX7_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX7_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX7_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ8_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ8_REG (DR_REG_FLASH_SPI0_BASE + 0x2a0)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG8 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 8.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG8    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG8_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG8_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG8_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG8_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG8_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN8 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 8. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN8    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN8_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN8_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN8_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN8_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN8_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX8 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 8.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX8    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX8_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX8_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX8_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX8_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX8_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX8 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 8.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX8    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX8_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX8_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX8_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX8_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX8_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG8 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 8. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG8    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG8_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG8_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG8_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG8_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG8_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX8 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 8. Use to find SPI command in
+ *  CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX8    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX8_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX8_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX8_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX8_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX8_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ9_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ9_REG (DR_REG_FLASH_SPI0_BASE + 0x2a4)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG9 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 9.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG9    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG9_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG9_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG9_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG9_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG9_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN9 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 9. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN9    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN9_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN9_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN9_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN9_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN9_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX9 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 9.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX9    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX9_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX9_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX9_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX9_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX9_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX9 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 9.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX9    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX9_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX9_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX9_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX9_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX9_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG9 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 9. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG9    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG9_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG9_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG9_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG9_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG9_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX9 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 9. Use to find SPI command in
+ *  CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX9    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX9_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX9_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX9_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX9_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX9_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ10_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ10_REG (DR_REG_FLASH_SPI0_BASE + 0x2a8)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG10 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 10.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG10    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG10_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG10_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG10_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG10_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG10_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN10 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 10. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN10    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN10_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN10_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN10_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN10_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN10_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX10 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 10.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX10    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX10_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX10_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX10_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX10_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX10_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX10 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 10.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX10    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX10_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX10_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX10_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX10_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX10_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG10 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 10. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG10    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG10_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG10_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG10_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG10_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG10_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX10 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 10. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX10    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX10_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX10_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX10_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX10_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX10_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ11_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ11_REG (DR_REG_FLASH_SPI0_BASE + 0x2ac)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG11 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 11.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG11    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG11_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG11_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG11_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG11_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG11_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN11 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 11. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN11    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN11_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN11_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN11_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN11_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN11_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX11 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 11.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX11    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX11_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX11_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX11_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX11_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX11_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX11 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 11.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX11    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX11_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX11_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX11_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX11_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX11_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG11 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 11. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG11    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG11_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG11_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG11_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG11_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG11_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX11 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 11. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX11    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX11_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX11_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX11_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX11_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX11_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ12_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ12_REG (DR_REG_FLASH_SPI0_BASE + 0x2b0)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG12 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 12.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG12    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG12_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG12_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG12_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG12_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG12_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN12 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 12. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN12    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN12_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN12_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN12_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN12_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN12_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX12 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 12.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX12    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX12_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX12_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX12_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX12_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX12_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX12 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 12.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX12    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX12_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX12_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX12_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX12_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX12_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG12 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 12. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG12    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG12_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG12_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG12_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG12_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG12_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX12 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 12. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX12    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX12_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX12_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX12_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX12_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX12_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ13_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ13_REG (DR_REG_FLASH_SPI0_BASE + 0x2b4)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG13 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 13.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG13    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG13_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG13_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG13_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG13_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG13_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN13 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 13. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN13    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN13_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN13_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN13_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN13_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN13_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX13 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 13.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX13    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX13_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX13_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX13_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX13_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX13_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX13 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 13.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX13    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX13_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX13_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX13_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX13_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX13_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG13 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 13. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG13    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG13_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG13_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG13_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG13_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG13_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX13 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 13. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX13    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX13_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX13_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX13_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX13_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX13_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ14_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ14_REG (DR_REG_FLASH_SPI0_BASE + 0x2b8)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG14 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 14.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG14    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG14_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG14_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG14_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG14_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG14_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN14 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 14. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN14    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN14_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN14_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN14_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN14_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN14_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX14 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 14.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX14    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX14_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX14_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX14_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX14_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX14_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX14 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 14.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX14    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX14_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX14_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX14_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX14_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX14_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG14 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 14. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG14    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG14_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG14_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG14_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG14_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG14_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX14 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 14. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX14    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX14_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX14_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX14_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX14_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX14_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ15_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ15_REG (DR_REG_FLASH_SPI0_BASE + 0x2bc)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG15 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 15.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG15    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG15_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG15_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG15_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG15_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG15_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN15 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 15. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN15    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN15_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN15_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN15_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN15_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN15_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX15 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 15.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX15    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX15_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX15_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX15_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX15_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX15_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX15 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 15.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX15    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX15_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX15_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX15_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX15_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX15_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG15 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 15. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG15    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG15_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG15_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG15_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG15_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG15_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX15 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 15. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX15    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX15_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX15_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX15_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX15_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX15_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ16_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ16_REG (DR_REG_FLASH_SPI0_BASE + 0x2c0)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG16 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 16.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG16    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG16_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG16_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG16_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG16_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG16_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN16 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 16. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN16    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN16_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN16_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN16_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN16_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN16_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX16 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 16.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX16    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX16_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX16_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX16_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX16_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX16_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX16 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 16.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX16    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX16_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX16_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX16_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX16_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX16_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG16 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 16. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG16    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG16_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG16_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG16_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG16_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG16_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX16 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 16. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX16    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX16_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX16_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX16_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX16_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX16_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ17_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ17_REG (DR_REG_FLASH_SPI0_BASE + 0x2c4)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG17 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 17.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG17    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG17_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG17_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG17_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG17_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG17_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN17 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 17. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN17    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN17_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN17_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN17_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN17_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN17_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX17 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 17.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX17    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX17_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX17_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX17_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX17_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX17_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX17 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 17.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX17    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX17_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX17_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX17_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX17_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX17_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG17 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 17. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG17    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG17_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG17_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG17_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG17_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG17_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX17 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 17. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX17    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX17_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX17_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX17_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX17_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX17_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ18_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ18_REG (DR_REG_FLASH_SPI0_BASE + 0x2c8)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG18 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 18.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG18    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG18_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG18_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG18_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG18_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG18_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN18 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 18. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN18    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN18_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN18_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN18_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN18_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN18_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX18 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 18.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX18    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX18_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX18_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX18_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX18_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX18_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX18 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 18.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX18    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX18_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX18_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX18_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX18_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX18_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG18 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 18. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG18    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG18_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG18_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG18_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG18_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG18_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX18 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 18. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX18    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX18_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX18_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX18_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX18_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX18_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ19_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ19_REG (DR_REG_FLASH_SPI0_BASE + 0x2cc)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG19 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 19.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG19    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG19_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG19_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG19_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG19_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG19_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN19 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 19. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN19    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN19_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN19_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN19_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN19_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN19_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX19 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 19.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX19    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX19_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX19_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX19_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX19_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX19_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX19 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 19.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX19    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX19_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX19_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX19_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX19_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX19_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG19 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 19. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG19    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG19_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG19_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG19_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG19_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG19_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX19 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 19. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX19    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX19_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX19_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX19_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX19_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX19_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ20_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ20_REG (DR_REG_FLASH_SPI0_BASE + 0x2d0)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG20 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 20.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG20    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG20_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG20_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG20_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG20_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG20_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN20 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 20. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN20    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN20_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN20_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN20_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN20_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN20_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX20 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 20.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX20    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX20_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX20_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX20_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX20_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX20_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX20 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 20.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX20    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX20_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX20_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX20_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX20_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX20_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG20 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 20. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG20    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG20_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG20_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG20_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG20_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG20_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX20 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 20. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX20    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX20_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX20_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX20_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX20_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX20_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ21_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ21_REG (DR_REG_FLASH_SPI0_BASE + 0x2d4)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG21 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 21.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG21    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG21_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG21_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG21_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG21_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG21_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN21 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 21. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN21    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN21_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN21_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN21_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN21_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN21_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX21 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 21.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX21    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX21_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX21_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX21_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX21_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX21_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX21 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 21.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX21    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX21_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX21_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX21_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX21_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX21_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG21 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 21. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG21    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG21_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG21_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG21_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG21_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG21_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX21 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 21. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX21    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX21_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX21_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX21_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX21_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX21_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ22_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ22_REG (DR_REG_FLASH_SPI0_BASE + 0x2d8)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG22 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 22.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG22    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG22_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG22_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG22_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG22_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG22_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN22 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 22. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN22    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN22_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN22_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN22_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN22_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN22_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX22 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 22.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX22    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX22_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX22_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX22_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX22_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX22_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX22 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 22.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX22    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX22_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX22_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX22_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX22_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX22_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG22 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 22. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG22    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG22_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG22_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG22_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG22_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG22_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX22 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 22. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX22    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX22_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX22_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX22_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX22_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX22_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ23_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ23_REG (DR_REG_FLASH_SPI0_BASE + 0x2dc)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG23 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 23.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG23    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG23_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG23_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG23_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG23_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG23_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN23 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 23. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN23    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN23_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN23_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN23_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN23_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN23_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX23 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 23.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX23    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX23_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX23_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX23_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX23_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX23_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX23 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 23.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX23    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX23_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX23_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX23_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX23_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX23_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG23 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 23. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG23    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG23_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG23_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG23_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG23_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG23_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX23 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 23. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX23    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX23_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX23_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX23_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX23_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX23_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ24_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ24_REG (DR_REG_FLASH_SPI0_BASE + 0x2e0)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG24 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 24.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG24    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG24_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG24_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG24_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG24_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG24_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN24 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 24. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN24    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN24_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN24_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN24_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN24_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN24_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX24 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 24.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX24    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX24_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX24_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX24_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX24_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX24_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX24 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 24.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX24    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX24_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX24_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX24_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX24_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX24_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG24 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 24. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG24    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG24_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG24_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG24_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG24_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG24_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX24 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 24. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX24    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX24_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX24_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX24_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX24_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX24_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ25_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ25_REG (DR_REG_FLASH_SPI0_BASE + 0x2e4)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG25 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 25.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG25    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG25_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG25_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG25_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG25_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG25_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN25 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 25. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN25    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN25_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN25_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN25_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN25_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN25_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX25 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 25.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX25    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX25_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX25_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX25_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX25_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX25_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX25 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 25.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX25    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX25_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX25_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX25_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX25_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX25_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG25 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 25. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG25    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG25_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG25_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG25_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG25_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG25_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX25 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 25. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX25    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX25_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX25_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX25_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX25_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX25_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ26_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ26_REG (DR_REG_FLASH_SPI0_BASE + 0x2e8)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG26 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 26.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG26    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG26_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG26_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG26_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG26_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG26_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN26 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 26. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN26    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN26_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN26_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN26_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN26_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN26_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX26 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 26.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX26    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX26_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX26_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX26_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX26_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX26_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX26 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 26.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX26    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX26_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX26_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX26_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX26_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX26_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG26 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 26. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG26    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG26_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG26_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG26_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG26_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG26_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX26 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 26. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX26    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX26_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX26_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX26_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX26_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX26_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ27_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ27_REG (DR_REG_FLASH_SPI0_BASE + 0x2ec)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG27 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 27.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG27    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG27_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG27_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG27_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG27_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG27_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN27 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 27. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN27    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN27_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN27_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN27_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN27_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN27_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX27 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 27.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX27    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX27_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX27_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX27_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX27_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX27_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX27 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 27.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX27    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX27_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX27_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX27_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX27_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX27_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG27 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 27. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG27    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG27_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG27_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG27_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG27_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG27_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX27 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 27. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX27    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX27_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX27_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX27_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX27_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX27_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ28_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ28_REG (DR_REG_FLASH_SPI0_BASE + 0x2f0)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG28 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 28.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG28    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG28_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG28_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG28_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG28_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG28_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN28 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 28. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN28    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN28_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN28_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN28_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN28_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN28_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX28 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 28.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX28    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX28_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX28_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX28_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX28_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX28_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX28 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 28.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX28    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX28_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX28_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX28_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX28_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX28_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG28 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 28. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG28    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG28_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG28_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG28_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG28_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG28_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX28 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 28. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX28    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX28_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX28_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX28_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX28_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX28_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ29_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ29_REG (DR_REG_FLASH_SPI0_BASE + 0x2f4)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG29 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 29.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG29    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG29_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG29_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG29_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG29_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG29_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN29 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 29. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN29    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN29_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN29_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN29_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN29_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN29_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX29 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 29.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX29    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX29_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX29_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX29_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX29_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX29_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX29 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 29.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX29    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX29_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX29_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX29_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX29_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX29_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG29 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 29. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG29    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG29_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG29_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG29_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG29_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG29_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX29 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 29. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX29    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX29_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX29_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX29_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX29_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX29_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ30_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ30_REG (DR_REG_FLASH_SPI0_BASE + 0x2f8)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG30 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 30.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG30    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG30_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG30_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG30_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG30_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG30_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN30 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 30. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN30    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN30_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN30_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN30_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN30_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN30_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX30 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 30.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX30    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX30_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX30_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX30_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX30_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX30_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX30 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 30.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX30    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX30_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX30_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX30_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX30_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX30_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG30 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 30. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG30    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG30_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG30_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG30_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG30_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG30_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX30 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 30. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX30    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX30_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX30_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX30_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX30_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX30_S  11
+
+/** SPI_MEM_C_NAND_FLASH_SPI_SEQ31_REG register
+ *  NAND FLASH SPI SEQ control register
+ */
+#define SPI_MEM_C_NAND_FLASH_SPI_SEQ31_REG (DR_REG_FLASH_SPI0_BASE + 0x2fc)
+/** SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG31 : R/W; bitpos: [0]; default: 0;
+ *  MSPI NAND FLASH config seq_tail_flg at spi seq index 31.1: The last index for
+ *  sequence. 0: Not the last index.
+ */
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG31    (BIT(0))
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG31_M  (SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG31_V << SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG31_S)
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG31_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SEQ_TAIL_FLG31_S  0
+/** SPI_MEM_C_NAND_FLASH_SR_CHK_EN31 : R/W; bitpos: [1]; default: 0;
+ *  MSPI NAND FLASH config sr_chk_en at spi seq index 31. 1: enable 0: disable.
+ */
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN31    (BIT(1))
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN31_M  (SPI_MEM_C_NAND_FLASH_SR_CHK_EN31_V << SPI_MEM_C_NAND_FLASH_SR_CHK_EN31_S)
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN31_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_SR_CHK_EN31_S  1
+/** SPI_MEM_C_NAND_FLASH_DIN_INDEX31 : R/W; bitpos: [5:2]; default: 0;
+ *  MSPI NAND FLASH config din_index at spi seq index 31.  Use with
+ *  SPI_MEM_C_NAND_FLASH_CFG_DATA
+ */
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX31    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX31_M  (SPI_MEM_C_NAND_FLASH_DIN_INDEX31_V << SPI_MEM_C_NAND_FLASH_DIN_INDEX31_S)
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX31_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_DIN_INDEX31_S  2
+/** SPI_MEM_C_NAND_FLASH_ADDR_INDEX31 : R/W; bitpos: [9:6]; default: 0;
+ *  MSPI NAND FLASH config addr_index at spi seq index 31.  Use with
+ *  SPI_MEM_C_NAND_FLASH_SR_ADDR
+ */
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX31    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX31_M  (SPI_MEM_C_NAND_FLASH_ADDR_INDEX31_V << SPI_MEM_C_NAND_FLASH_ADDR_INDEX31_S)
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX31_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_ADDR_INDEX31_S  6
+/** SPI_MEM_C_NAND_FLASH_REQ_OR_CFG31 : R/W; bitpos: [10]; default: 0;
+ *  MSPI NAND FLASH config reg_or_cfg at spi seq index 31. 1: AXI/APB request  0: SPI
+ *  SEQ configuration.
+ */
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG31    (BIT(10))
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG31_M  (SPI_MEM_C_NAND_FLASH_REQ_OR_CFG31_V << SPI_MEM_C_NAND_FLASH_REQ_OR_CFG31_S)
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG31_V  0x00000001U
+#define SPI_MEM_C_NAND_FLASH_REQ_OR_CFG31_S  10
+/** SPI_MEM_C_NAND_FLASH_CMD_INDEX31 : R/W; bitpos: [14:11]; default: 0;
+ *  MSPI NAND FLASH config spi_cmd_index at spi seq index 31. Use to find SPI command
+ *  in CMD LUT.(Note these registers are described to indicate the
+ *  SPI_MEM_C_NAND_FLASH_SPI_SEQ_REG' fieldd The number of CMD LUT entries can be defined
+ *  by the user, but cannot exceed 16 )
+ */
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX31    0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX31_M  (SPI_MEM_C_NAND_FLASH_CMD_INDEX31_V << SPI_MEM_C_NAND_FLASH_CMD_INDEX31_S)
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX31_V  0x0000000FU
+#define SPI_MEM_C_NAND_FLASH_CMD_INDEX31_S  11
+
+/** SPI_MEM_C_XTS_PLAIN_BASE_REG register
+ *  The base address of the memory that stores plaintext in Manual Encryption
+ */
+#define SPI_MEM_C_XTS_PLAIN_BASE_REG (DR_REG_FLASH_SPI0_BASE + 0x300)
+/** SPI_XTS_PLAIN : R/W; bitpos: [31:0]; default: 0;
+ *  This field is only used to generate include file in c case. This field is useless.
+ *  Please do not use this field.
+ */
+#define SPI_XTS_PLAIN    0xFFFFFFFFU
+#define SPI_XTS_PLAIN_M  (SPI_XTS_PLAIN_V << SPI_XTS_PLAIN_S)
+#define SPI_XTS_PLAIN_V  0xFFFFFFFFU
+#define SPI_XTS_PLAIN_S  0
+
+/** SPI_MEM_C_XTS_LINESIZE_REG register
+ *  Manual Encryption Line-Size register
+ */
+#define SPI_MEM_C_XTS_LINESIZE_REG (DR_REG_FLASH_SPI0_BASE + 0x340)
+/** SPI_XTS_LINESIZE : R/W; bitpos: [1:0]; default: 0;
+ *  This bits stores the line-size parameter which will be used in manual encryption
+ *  calculation. It decides how many bytes will be encrypted one time. 0: 16-bytes, 1:
+ *  32-bytes, 2: 64-bytes, 3:reserved.
+ */
+#define SPI_XTS_LINESIZE    0x00000003U
+#define SPI_XTS_LINESIZE_M  (SPI_XTS_LINESIZE_V << SPI_XTS_LINESIZE_S)
+#define SPI_XTS_LINESIZE_V  0x00000003U
+#define SPI_XTS_LINESIZE_S  0
+
+/** SPI_MEM_C_XTS_DESTINATION_REG register
+ *  Manual Encryption destination register
+ */
+#define SPI_MEM_C_XTS_DESTINATION_REG (DR_REG_FLASH_SPI0_BASE + 0x344)
+/** SPI_XTS_DESTINATION : R/W; bitpos: [0]; default: 0;
+ *  This bit stores the destination parameter which will be used in manual encryption
+ *  calculation. 0: flash(default), 1: psram(reserved). Only default value can be used.
+ */
+#define SPI_XTS_DESTINATION    (BIT(0))
+#define SPI_XTS_DESTINATION_M  (SPI_XTS_DESTINATION_V << SPI_XTS_DESTINATION_S)
+#define SPI_XTS_DESTINATION_V  0x00000001U
+#define SPI_XTS_DESTINATION_S  0
+
+/** SPI_MEM_C_XTS_PHYSICAL_ADDRESS_REG register
+ *  Manual Encryption physical address register
+ */
+#define SPI_MEM_C_XTS_PHYSICAL_ADDRESS_REG (DR_REG_FLASH_SPI0_BASE + 0x348)
+/** SPI_XTS_PHYSICAL_ADDRESS : R/W; bitpos: [29:0]; default: 0;
+ *  This bits stores the physical-address parameter which will be used in manual
+ *  encryption calculation. This value should aligned with byte number decided by
+ *  line-size parameter.
+ */
+#define SPI_XTS_PHYSICAL_ADDRESS    0x3FFFFFFFU
+#define SPI_XTS_PHYSICAL_ADDRESS_M  (SPI_XTS_PHYSICAL_ADDRESS_V << SPI_XTS_PHYSICAL_ADDRESS_S)
+#define SPI_XTS_PHYSICAL_ADDRESS_V  0x3FFFFFFFU
+#define SPI_XTS_PHYSICAL_ADDRESS_S  0
+
+/** SPI_MEM_C_XTS_TRIGGER_REG register
+ *  Manual Encryption physical address register
+ */
+#define SPI_MEM_C_XTS_TRIGGER_REG (DR_REG_FLASH_SPI0_BASE + 0x34c)
+/** SPI_XTS_TRIGGER : WT; bitpos: [0]; default: 0;
+ *  Set this bit to trigger the process of manual encryption calculation. This action
+ *  should only be asserted when manual encryption status is 0. After this action,
+ *  manual encryption status becomes 1. After calculation is done, manual encryption
+ *  status becomes 2.
+ */
+#define SPI_XTS_TRIGGER    (BIT(0))
+#define SPI_XTS_TRIGGER_M  (SPI_XTS_TRIGGER_V << SPI_XTS_TRIGGER_S)
+#define SPI_XTS_TRIGGER_V  0x00000001U
+#define SPI_XTS_TRIGGER_S  0
+
+/** SPI_MEM_C_XTS_RELEASE_REG register
+ *  Manual Encryption physical address register
+ */
+#define SPI_MEM_C_XTS_RELEASE_REG (DR_REG_FLASH_SPI0_BASE + 0x350)
+/** SPI_XTS_RELEASE : WT; bitpos: [0]; default: 0;
+ *  Set this bit to release encrypted result to mspi. This action should only be
+ *  asserted when manual encryption status is 2. After this action, manual encryption
+ *  status will become 3.
+ */
+#define SPI_XTS_RELEASE    (BIT(0))
+#define SPI_XTS_RELEASE_M  (SPI_XTS_RELEASE_V << SPI_XTS_RELEASE_S)
+#define SPI_XTS_RELEASE_V  0x00000001U
+#define SPI_XTS_RELEASE_S  0
+
+/** SPI_MEM_C_XTS_DESTROY_REG register
+ *  Manual Encryption physical address register
+ */
+#define SPI_MEM_C_XTS_DESTROY_REG (DR_REG_FLASH_SPI0_BASE + 0x354)
+/** SPI_XTS_DESTROY : WT; bitpos: [0]; default: 0;
+ *  Set this bit to destroy encrypted result. This action should be asserted only when
+ *  manual encryption status is 3. After this action, manual encryption status will
+ *  become 0.
+ */
+#define SPI_XTS_DESTROY    (BIT(0))
+#define SPI_XTS_DESTROY_M  (SPI_XTS_DESTROY_V << SPI_XTS_DESTROY_S)
+#define SPI_XTS_DESTROY_V  0x00000001U
+#define SPI_XTS_DESTROY_S  0
+
+/** SPI_MEM_C_XTS_STATE_REG register
+ *  Manual Encryption physical address register
+ */
+#define SPI_MEM_C_XTS_STATE_REG (DR_REG_FLASH_SPI0_BASE + 0x358)
+/** SPI_XTS_STATE : RO; bitpos: [1:0]; default: 0;
+ *  This bits stores the status of manual encryption. 0: idle, 1: busy of encryption
+ *  calculation, 2: encryption calculation is done but the encrypted result is
+ *  invisible to mspi, 3: the encrypted result is visible to mspi.
+ */
+#define SPI_XTS_STATE    0x00000003U
+#define SPI_XTS_STATE_M  (SPI_XTS_STATE_V << SPI_XTS_STATE_S)
+#define SPI_XTS_STATE_V  0x00000003U
+#define SPI_XTS_STATE_S  0
+
+/** SPI_MEM_C_XTS_DATE_REG register
+ *  Manual Encryption version register
+ */
+#define SPI_MEM_C_XTS_DATE_REG (DR_REG_FLASH_SPI0_BASE + 0x35c)
+/** SPI_XTS_DATE : R/W; bitpos: [29:0]; default: 539035911;
+ *  This bits stores the last modified-time of manual encryption feature.
+ */
+#define SPI_XTS_DATE    0x3FFFFFFFU
+#define SPI_XTS_DATE_M  (SPI_XTS_DATE_V << SPI_XTS_DATE_S)
+#define SPI_XTS_DATE_V  0x3FFFFFFFU
+#define SPI_XTS_DATE_S  0
+
+/** SPI_MEM_C_MMU_ITEM_CONTENT_REG register
+ *  MSPI-MMU item content register
+ */
+#define SPI_MEM_C_MMU_ITEM_CONTENT_REG (DR_REG_FLASH_SPI0_BASE + 0x37c)
+/** SPI_MMU_ITEM_CONTENT : R/W; bitpos: [31:0]; default: 892;
+ *  MSPI-MMU item content
+ */
+#define SPI_MMU_ITEM_CONTENT    0xFFFFFFFFU
+#define SPI_MMU_ITEM_CONTENT_M  (SPI_MMU_ITEM_CONTENT_V << SPI_MMU_ITEM_CONTENT_S)
+#define SPI_MMU_ITEM_CONTENT_V  0xFFFFFFFFU
+#define SPI_MMU_ITEM_CONTENT_S  0
+
+/** SPI_MEM_C_MMU_ITEM_INDEX_REG register
+ *  MSPI-MMU item index register
+ */
+#define SPI_MEM_C_MMU_ITEM_INDEX_REG (DR_REG_FLASH_SPI0_BASE + 0x380)
+/** SPI_MMU_ITEM_INDEX : R/W; bitpos: [31:0]; default: 0;
+ *  MSPI-MMU item index
+ */
+#define SPI_MMU_ITEM_INDEX    0xFFFFFFFFU
+#define SPI_MMU_ITEM_INDEX_M  (SPI_MMU_ITEM_INDEX_V << SPI_MMU_ITEM_INDEX_S)
+#define SPI_MMU_ITEM_INDEX_V  0xFFFFFFFFU
+#define SPI_MMU_ITEM_INDEX_S  0
+
+/** SPI_MEM_C_MMU_POWER_CTRL_REG register
+ *  MSPI MMU power control register
+ */
+#define SPI_MEM_C_MMU_POWER_CTRL_REG (DR_REG_FLASH_SPI0_BASE + 0x384)
+/** SPI_MMU_MEM_FORCE_ON : R/W; bitpos: [0]; default: 0;
+ *  Set this bit to enable mmu-memory clock force on
+ */
+#define SPI_MMU_MEM_FORCE_ON    (BIT(0))
+#define SPI_MMU_MEM_FORCE_ON_M  (SPI_MMU_MEM_FORCE_ON_V << SPI_MMU_MEM_FORCE_ON_S)
+#define SPI_MMU_MEM_FORCE_ON_V  0x00000001U
+#define SPI_MMU_MEM_FORCE_ON_S  0
+/** SPI_MMU_PAGE_SIZE : R/W; bitpos: [4:3]; default: 0;
+ *  0: Max page size , 1: Max page size/2 , 2: Max page size/4, 3: Max page size/8
+ */
+#define SPI_MMU_PAGE_SIZE    0x00000003U
+#define SPI_MMU_PAGE_SIZE_M  (SPI_MMU_PAGE_SIZE_V << SPI_MMU_PAGE_SIZE_S)
+#define SPI_MMU_PAGE_SIZE_V  0x00000003U
+#define SPI_MMU_PAGE_SIZE_S  3
+/** SPI_MEM_C_AUX_CTRL : HRO; bitpos: [29:16]; default: 4896;
+ *  MMU PSRAM aux control register
+ */
+#define SPI_MEM_C_AUX_CTRL    0x00003FFFU
+#define SPI_MEM_C_AUX_CTRL_M  (SPI_MEM_C_AUX_CTRL_V << SPI_MEM_C_AUX_CTRL_S)
+#define SPI_MEM_C_AUX_CTRL_V  0x00003FFFU
+#define SPI_MEM_C_AUX_CTRL_S  16
+/** SPI_MEM_C_RDN_ENA : R/W; bitpos: [30]; default: 0;
+ *  ECO register enable bit
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_RDN_ENA    (BIT(30))
+#define SPI_MEM_C_RDN_ENA_M  (SPI_MEM_C_RDN_ENA_V << SPI_MEM_C_RDN_ENA_S)
+#define SPI_MEM_C_RDN_ENA_V  0x00000001U
+#define SPI_MEM_C_RDN_ENA_S  30
+/** SPI_MEM_C_RDN_RESULT : RO; bitpos: [31]; default: 0;
+ *  MSPI module clock domain and AXI clock domain ECO register result register
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_RDN_RESULT    (BIT(31))
+#define SPI_MEM_C_RDN_RESULT_M  (SPI_MEM_C_RDN_RESULT_V << SPI_MEM_C_RDN_RESULT_S)
+#define SPI_MEM_C_RDN_RESULT_V  0x00000001U
+#define SPI_MEM_C_RDN_RESULT_S  31
+
+/** SPI_MEM_C_DPA_CTRL_REG register
+ *  SPI memory cryption DPA register
+ */
+#define SPI_MEM_C_DPA_CTRL_REG (DR_REG_FLASH_SPI0_BASE + 0x388)
+/** SPI_CRYPT_SECURITY_LEVEL : R/W; bitpos: [2:0]; default: 7;
+ *  Set the security level of spi mem cryption. 0: Shut off cryption DPA function. 1-7:
+ *  The bigger the number is, the more secure the cryption is. (Note that the
+ *  performance of cryption will decrease together with this number increasing)
+ */
+#define SPI_CRYPT_SECURITY_LEVEL    0x00000007U
+#define SPI_CRYPT_SECURITY_LEVEL_M  (SPI_CRYPT_SECURITY_LEVEL_V << SPI_CRYPT_SECURITY_LEVEL_S)
+#define SPI_CRYPT_SECURITY_LEVEL_V  0x00000007U
+#define SPI_CRYPT_SECURITY_LEVEL_S  0
+/** SPI_CRYPT_CALC_D_DPA_EN : R/W; bitpos: [3]; default: 1;
+ *  Only available when SPI_CRYPT_SECURITY_LEVEL is not 0. 1: Enable DPA in the
+ *  calculation that using key 1 or key 2. 0: Enable DPA only in the calculation that
+ *  using key 1.
+ */
+#define SPI_CRYPT_CALC_D_DPA_EN    (BIT(3))
+#define SPI_CRYPT_CALC_D_DPA_EN_M  (SPI_CRYPT_CALC_D_DPA_EN_V << SPI_CRYPT_CALC_D_DPA_EN_S)
+#define SPI_CRYPT_CALC_D_DPA_EN_V  0x00000001U
+#define SPI_CRYPT_CALC_D_DPA_EN_S  3
+/** SPI_CRYPT_DPA_SELECT_REGISTER : R/W; bitpos: [4]; default: 0;
+ *  1: MSPI XTS DPA clock gate is controlled by SPI_CRYPT_CALC_D_DPA_EN and
+ *  SPI_CRYPT_SECURITY_LEVEL. 0: Controlled by efuse bits.
+ */
+#define SPI_CRYPT_DPA_SELECT_REGISTER    (BIT(4))
+#define SPI_CRYPT_DPA_SELECT_REGISTER_M  (SPI_CRYPT_DPA_SELECT_REGISTER_V << SPI_CRYPT_DPA_SELECT_REGISTER_S)
+#define SPI_CRYPT_DPA_SELECT_REGISTER_V  0x00000001U
+#define SPI_CRYPT_DPA_SELECT_REGISTER_S  4
+/** SPI_XTS_SHADOW_FOR_SEC : HRO; bitpos: [5]; default: 1;
+ *  1: shadow core mode for security (against fault injection attack). 0: shadow core
+ *  mode for performance.
+ */
+#define SPI_XTS_SHADOW_FOR_SEC    (BIT(5))
+#define SPI_XTS_SHADOW_FOR_SEC_M  (SPI_XTS_SHADOW_FOR_SEC_V << SPI_XTS_SHADOW_FOR_SEC_S)
+#define SPI_XTS_SHADOW_FOR_SEC_V  0x00000001U
+#define SPI_XTS_SHADOW_FOR_SEC_S  5
+
+/** SPI_MEM_C_XTS_PSEUDO_ROUND_CONF_REG register
+ *  SPI memory cryption PSEUDO register
+ */
+#define SPI_MEM_C_XTS_PSEUDO_ROUND_CONF_REG (DR_REG_FLASH_SPI0_BASE + 0x38c)
+/** SPI_MEM_C_MODE_PSEUDO : R/W; bitpos: [1:0]; default: 0;
+ *  Set the mode of pseudo. 2'b00: crypto without pseudo. 2'b01: state T with pseudo
+ *  and state D without pseudo. 2'b10: state T with pseudo and state D with few pseudo.
+ *  2'b11: crypto with pseudo.
+ */
+#define SPI_MEM_C_MODE_PSEUDO    0x00000003U
+#define SPI_MEM_C_MODE_PSEUDO_M  (SPI_MEM_C_MODE_PSEUDO_V << SPI_MEM_C_MODE_PSEUDO_S)
+#define SPI_MEM_C_MODE_PSEUDO_V  0x00000003U
+#define SPI_MEM_C_MODE_PSEUDO_S  0
+/** SPI_MEM_C_PSEUDO_RNG_CNT : R/W; bitpos: [4:2]; default: 7;
+ *  xts aes peseudo function base round that must be performed.
+ */
+#define SPI_MEM_C_PSEUDO_RNG_CNT    0x00000007U
+#define SPI_MEM_C_PSEUDO_RNG_CNT_M  (SPI_MEM_C_PSEUDO_RNG_CNT_V << SPI_MEM_C_PSEUDO_RNG_CNT_S)
+#define SPI_MEM_C_PSEUDO_RNG_CNT_V  0x00000007U
+#define SPI_MEM_C_PSEUDO_RNG_CNT_S  2
+/** SPI_MEM_C_PSEUDO_BASE : R/W; bitpos: [8:5]; default: 2;
+ *  xts aes peseudo function base round that must be performed.
+ */
+#define SPI_MEM_C_PSEUDO_BASE    0x0000000FU
+#define SPI_MEM_C_PSEUDO_BASE_M  (SPI_MEM_C_PSEUDO_BASE_V << SPI_MEM_C_PSEUDO_BASE_S)
+#define SPI_MEM_C_PSEUDO_BASE_V  0x0000000FU
+#define SPI_MEM_C_PSEUDO_BASE_S  5
+/** SPI_MEM_C_PSEUDO_INC : R/W; bitpos: [10:9]; default: 2;
+ *  xts aes peseudo function increment round that will be performed randomly between 0 &
+ *  2**(inc+1).
+ */
+#define SPI_MEM_C_PSEUDO_INC    0x00000003U
+#define SPI_MEM_C_PSEUDO_INC_M  (SPI_MEM_C_PSEUDO_INC_V << SPI_MEM_C_PSEUDO_INC_S)
+#define SPI_MEM_C_PSEUDO_INC_V  0x00000003U
+#define SPI_MEM_C_PSEUDO_INC_S  9
+
+/** SPI_MEM_C_REGISTERRND_ECO_HIGH_REG register
+ *  MSPI ECO high register
+ *  This register is only for internal debugging purposes. Do not use it in
+ *  applications.
+ */
+#define SPI_MEM_C_REGISTERRND_ECO_HIGH_REG (DR_REG_FLASH_SPI0_BASE + 0x3f0)
+/** SPI_MEM_C_REGISTERRND_ECO_HIGH : R/W; bitpos: [31:0]; default: 892;
+ *  ECO high register
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_REGISTERRND_ECO_HIGH    0xFFFFFFFFU
+#define SPI_MEM_C_REGISTERRND_ECO_HIGH_M  (SPI_MEM_C_REGISTERRND_ECO_HIGH_V << SPI_MEM_C_REGISTERRND_ECO_HIGH_S)
+#define SPI_MEM_C_REGISTERRND_ECO_HIGH_V  0xFFFFFFFFU
+#define SPI_MEM_C_REGISTERRND_ECO_HIGH_S  0
+
+/** SPI_MEM_C_REGISTERRND_ECO_LOW_REG register
+ *  MSPI ECO low register
+ *  This register is only for internal debugging purposes. Do not use it in
+ *  applications.
+ */
+#define SPI_MEM_C_REGISTERRND_ECO_LOW_REG (DR_REG_FLASH_SPI0_BASE + 0x3f4)
+/** SPI_MEM_C_REGISTERRND_ECO_LOW : R/W; bitpos: [31:0]; default: 892;
+ *  ECO low register
+ *  This field is only for internal debugging purposes. Do not use it in applications.
+ */
+#define SPI_MEM_C_REGISTERRND_ECO_LOW    0xFFFFFFFFU
+#define SPI_MEM_C_REGISTERRND_ECO_LOW_M  (SPI_MEM_C_REGISTERRND_ECO_LOW_V << SPI_MEM_C_REGISTERRND_ECO_LOW_S)
+#define SPI_MEM_C_REGISTERRND_ECO_LOW_V  0xFFFFFFFFU
+#define SPI_MEM_C_REGISTERRND_ECO_LOW_S  0
+
+/** SPI_MEM_C_DATE_REG register
+ *  SPI0 version control register
+ */
+#define SPI_MEM_C_DATE_REG (DR_REG_FLASH_SPI0_BASE + 0x3fc)
+/** SPI_MEM_C_DATE : R/W; bitpos: [27:0]; default: 38834224;
+ *  SPI0 register version.
+ */
+#define SPI_MEM_C_DATE    0x0FFFFFFFU
+#define SPI_MEM_C_DATE_M  (SPI_MEM_C_DATE_V << SPI_MEM_C_DATE_S)
+#define SPI_MEM_C_DATE_V  0x0FFFFFFFU
+#define SPI_MEM_C_DATE_S  0
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/target/esp32s31/include/soc/spi_mem_compat.h
+++ b/src/target/esp32s31/include/soc/spi_mem_compat.h
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include "spi_mem_c_reg.h"
+#include "spi1_mem_c_reg.h"
+
+#define SPI_MEM_RD_STATUS_REG(FLASH_SPI_NUM) SPI1_MEM_C_RD_STATUS_REG
+#define SPI_MEM_CMD_REG(FLASH_SPI_NUM)      SPI1_MEM_C_CMD_REG
+#define SPI_MEM_ADDR_REG(FLASH_SPI_NUM)     SPI1_MEM_C_ADDR_REG
+#define SPI_MEM_FLASH_SE                    SPI1_MEM_C_FLASH_SE
+#define SPI_MEM_FLASH_BE                    SPI1_MEM_C_FLASH_BE
+#define SPI_MEM_FLASH_RDSR                  SPI1_MEM_C_FLASH_RDSR
+
+#define SPI_MEM_MST_ST                      SPI1_MEM_C_MST_ST
+#define SPI_MEM_MST_ST_S                    SPI1_MEM_C_MST_ST_S
+#define SPI_MEM_MST_ST_V                    SPI1_MEM_C_MST_ST_V
+
+#define SPI_MEM_SLV_ST                      SPI1_MEM_C_SLV_ST
+#define SPI_MEM_SLV_ST_S                    SPI1_MEM_C_SLV_ST_S
+#define SPI_MEM_SLV_ST_V                    SPI1_MEM_C_SLV_ST_V

--- a/src/target/esp32s31/include/soc/uart_reg.h
+++ b/src/target/esp32s31/include/soc/uart_reg.h
@@ -1,0 +1,1664 @@
+/**
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ *  SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include <esp-stub-lib/bit_utils.h>
+
+#include "soc/soc.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** UART_FIFO_REG register
+ *  FIFO data register
+ */
+#define UART_FIFO_REG(i) (REG_UART_BASE(i) + 0x0)
+/** UART_RXFIFO_RD_BYTE : RO; bitpos: [7:0]; default: 0;
+ *  Represents the data UART $n read from FIFO.
+ *  Measurement unit: byte.
+ */
+#define UART_RXFIFO_RD_BYTE    0x000000FFU
+#define UART_RXFIFO_RD_BYTE_M  (UART_RXFIFO_RD_BYTE_V << UART_RXFIFO_RD_BYTE_S)
+#define UART_RXFIFO_RD_BYTE_V  0x000000FFU
+#define UART_RXFIFO_RD_BYTE_S  0
+
+/** UART_INT_RAW_REG register
+ *  Raw interrupt status
+ */
+#define UART_INT_RAW_REG(i) (REG_UART_BASE(i) + 0x4)
+/** UART_RXFIFO_FULL_INT_RAW : R/WTC/SS; bitpos: [0]; default: 0;
+ *  The raw interrupt status of UART_RXFIFO_FULL_INT.
+ */
+#define UART_RXFIFO_FULL_INT_RAW    (BIT(0))
+#define UART_RXFIFO_FULL_INT_RAW_M  (UART_RXFIFO_FULL_INT_RAW_V << UART_RXFIFO_FULL_INT_RAW_S)
+#define UART_RXFIFO_FULL_INT_RAW_V  0x00000001U
+#define UART_RXFIFO_FULL_INT_RAW_S  0
+/** UART_TXFIFO_EMPTY_INT_RAW : R/WTC/SS; bitpos: [1]; default: 1;
+ *  The raw interrupt status of UART_TXFIFO_EMPTY_INT.
+ */
+#define UART_TXFIFO_EMPTY_INT_RAW    (BIT(1))
+#define UART_TXFIFO_EMPTY_INT_RAW_M  (UART_TXFIFO_EMPTY_INT_RAW_V << UART_TXFIFO_EMPTY_INT_RAW_S)
+#define UART_TXFIFO_EMPTY_INT_RAW_V  0x00000001U
+#define UART_TXFIFO_EMPTY_INT_RAW_S  1
+/** UART_PARITY_ERR_INT_RAW : R/WTC/SS; bitpos: [2]; default: 0;
+ *  The raw interrupt status of UART_PARITY_ERR_INT.
+ */
+#define UART_PARITY_ERR_INT_RAW    (BIT(2))
+#define UART_PARITY_ERR_INT_RAW_M  (UART_PARITY_ERR_INT_RAW_V << UART_PARITY_ERR_INT_RAW_S)
+#define UART_PARITY_ERR_INT_RAW_V  0x00000001U
+#define UART_PARITY_ERR_INT_RAW_S  2
+/** UART_FRM_ERR_INT_RAW : R/WTC/SS; bitpos: [3]; default: 0;
+ *  The raw interrupt status of UART_FRM_ERR_INT.
+ */
+#define UART_FRM_ERR_INT_RAW    (BIT(3))
+#define UART_FRM_ERR_INT_RAW_M  (UART_FRM_ERR_INT_RAW_V << UART_FRM_ERR_INT_RAW_S)
+#define UART_FRM_ERR_INT_RAW_V  0x00000001U
+#define UART_FRM_ERR_INT_RAW_S  3
+/** UART_RXFIFO_OVF_INT_RAW : R/WTC/SS; bitpos: [4]; default: 0;
+ *  The raw interrupt status of UART_RXFIFO_OVF_INT.
+ */
+#define UART_RXFIFO_OVF_INT_RAW    (BIT(4))
+#define UART_RXFIFO_OVF_INT_RAW_M  (UART_RXFIFO_OVF_INT_RAW_V << UART_RXFIFO_OVF_INT_RAW_S)
+#define UART_RXFIFO_OVF_INT_RAW_V  0x00000001U
+#define UART_RXFIFO_OVF_INT_RAW_S  4
+/** UART_DSR_CHG_INT_RAW : R/WTC/SS; bitpos: [5]; default: 0;
+ *  The raw interrupt status of UART_DSR_CHG_INT.
+ */
+#define UART_DSR_CHG_INT_RAW    (BIT(5))
+#define UART_DSR_CHG_INT_RAW_M  (UART_DSR_CHG_INT_RAW_V << UART_DSR_CHG_INT_RAW_S)
+#define UART_DSR_CHG_INT_RAW_V  0x00000001U
+#define UART_DSR_CHG_INT_RAW_S  5
+/** UART_CTS_CHG_INT_RAW : R/WTC/SS; bitpos: [6]; default: 0;
+ *  The raw interrupt status of UART_CTS_CHG_INT.
+ */
+#define UART_CTS_CHG_INT_RAW    (BIT(6))
+#define UART_CTS_CHG_INT_RAW_M  (UART_CTS_CHG_INT_RAW_V << UART_CTS_CHG_INT_RAW_S)
+#define UART_CTS_CHG_INT_RAW_V  0x00000001U
+#define UART_CTS_CHG_INT_RAW_S  6
+/** UART_BRK_DET_INT_RAW : R/WTC/SS; bitpos: [7]; default: 0;
+ *  The raw interrupt status of UART_BRK_DET_INT.
+ */
+#define UART_BRK_DET_INT_RAW    (BIT(7))
+#define UART_BRK_DET_INT_RAW_M  (UART_BRK_DET_INT_RAW_V << UART_BRK_DET_INT_RAW_S)
+#define UART_BRK_DET_INT_RAW_V  0x00000001U
+#define UART_BRK_DET_INT_RAW_S  7
+/** UART_RXFIFO_TOUT_INT_RAW : R/WTC/SS; bitpos: [8]; default: 0;
+ *  The raw interrupt status of UART_RXFIFO_TOUT_INT.
+ */
+#define UART_RXFIFO_TOUT_INT_RAW    (BIT(8))
+#define UART_RXFIFO_TOUT_INT_RAW_M  (UART_RXFIFO_TOUT_INT_RAW_V << UART_RXFIFO_TOUT_INT_RAW_S)
+#define UART_RXFIFO_TOUT_INT_RAW_V  0x00000001U
+#define UART_RXFIFO_TOUT_INT_RAW_S  8
+/** UART_SW_XON_INT_RAW : R/WTC/SS; bitpos: [9]; default: 0;
+ *  The raw interrupt status of UART_SW_XON_INT.
+ */
+#define UART_SW_XON_INT_RAW    (BIT(9))
+#define UART_SW_XON_INT_RAW_M  (UART_SW_XON_INT_RAW_V << UART_SW_XON_INT_RAW_S)
+#define UART_SW_XON_INT_RAW_V  0x00000001U
+#define UART_SW_XON_INT_RAW_S  9
+/** UART_SW_XOFF_INT_RAW : R/WTC/SS; bitpos: [10]; default: 0;
+ *  UART_SW_XOFF_INT.
+ */
+#define UART_SW_XOFF_INT_RAW    (BIT(10))
+#define UART_SW_XOFF_INT_RAW_M  (UART_SW_XOFF_INT_RAW_V << UART_SW_XOFF_INT_RAW_S)
+#define UART_SW_XOFF_INT_RAW_V  0x00000001U
+#define UART_SW_XOFF_INT_RAW_S  10
+/** UART_GLITCH_DET_INT_RAW : R/WTC/SS; bitpos: [11]; default: 0;
+ *  The raw interrupt status of UART_GLITCH_DET_INT.
+ */
+#define UART_GLITCH_DET_INT_RAW    (BIT(11))
+#define UART_GLITCH_DET_INT_RAW_M  (UART_GLITCH_DET_INT_RAW_V << UART_GLITCH_DET_INT_RAW_S)
+#define UART_GLITCH_DET_INT_RAW_V  0x00000001U
+#define UART_GLITCH_DET_INT_RAW_S  11
+/** UART_TX_BRK_DONE_INT_RAW : R/WTC/SS; bitpos: [12]; default: 0;
+ *  The raw interrupt status of UART_TX_BRK_DONE_INT.
+ */
+#define UART_TX_BRK_DONE_INT_RAW    (BIT(12))
+#define UART_TX_BRK_DONE_INT_RAW_M  (UART_TX_BRK_DONE_INT_RAW_V << UART_TX_BRK_DONE_INT_RAW_S)
+#define UART_TX_BRK_DONE_INT_RAW_V  0x00000001U
+#define UART_TX_BRK_DONE_INT_RAW_S  12
+/** UART_TX_BRK_IDLE_DONE_INT_RAW : R/WTC/SS; bitpos: [13]; default: 0;
+ *  The raw interrupt status of UART_TX_BRK_IDLE_DONE_INT.
+ */
+#define UART_TX_BRK_IDLE_DONE_INT_RAW    (BIT(13))
+#define UART_TX_BRK_IDLE_DONE_INT_RAW_M  (UART_TX_BRK_IDLE_DONE_INT_RAW_V << UART_TX_BRK_IDLE_DONE_INT_RAW_S)
+#define UART_TX_BRK_IDLE_DONE_INT_RAW_V  0x00000001U
+#define UART_TX_BRK_IDLE_DONE_INT_RAW_S  13
+/** UART_TX_DONE_INT_RAW : R/WTC/SS; bitpos: [14]; default: 0;
+ *  The raw interrupt status of UART_TX_DONE_INT.
+ */
+#define UART_TX_DONE_INT_RAW    (BIT(14))
+#define UART_TX_DONE_INT_RAW_M  (UART_TX_DONE_INT_RAW_V << UART_TX_DONE_INT_RAW_S)
+#define UART_TX_DONE_INT_RAW_V  0x00000001U
+#define UART_TX_DONE_INT_RAW_S  14
+/** UART_RS485_PARITY_ERR_INT_RAW : R/WTC/SS; bitpos: [15]; default: 0;
+ *  The raw interrupt status of UART_RS485_PARITY_ERR_INT.
+ */
+#define UART_RS485_PARITY_ERR_INT_RAW    (BIT(15))
+#define UART_RS485_PARITY_ERR_INT_RAW_M  (UART_RS485_PARITY_ERR_INT_RAW_V << UART_RS485_PARITY_ERR_INT_RAW_S)
+#define UART_RS485_PARITY_ERR_INT_RAW_V  0x00000001U
+#define UART_RS485_PARITY_ERR_INT_RAW_S  15
+/** UART_RS485_FRM_ERR_INT_RAW : R/WTC/SS; bitpos: [16]; default: 0;
+ *  The raw interrupt status of UART_RS485_FRM_ERR_INT.
+ */
+#define UART_RS485_FRM_ERR_INT_RAW    (BIT(16))
+#define UART_RS485_FRM_ERR_INT_RAW_M  (UART_RS485_FRM_ERR_INT_RAW_V << UART_RS485_FRM_ERR_INT_RAW_S)
+#define UART_RS485_FRM_ERR_INT_RAW_V  0x00000001U
+#define UART_RS485_FRM_ERR_INT_RAW_S  16
+/** UART_RS485_CLASH_INT_RAW : R/WTC/SS; bitpos: [17]; default: 0;
+ *  The raw interrupt status of UART_RS485_CLASH_INT.
+ */
+#define UART_RS485_CLASH_INT_RAW    (BIT(17))
+#define UART_RS485_CLASH_INT_RAW_M  (UART_RS485_CLASH_INT_RAW_V << UART_RS485_CLASH_INT_RAW_S)
+#define UART_RS485_CLASH_INT_RAW_V  0x00000001U
+#define UART_RS485_CLASH_INT_RAW_S  17
+/** UART_AT_CMD_CHAR_DET_INT_RAW : R/WTC/SS; bitpos: [18]; default: 0;
+ *  The raw interrupt status of UART_AT_CMD_CHAR_DET_INT.
+ */
+#define UART_AT_CMD_CHAR_DET_INT_RAW    (BIT(18))
+#define UART_AT_CMD_CHAR_DET_INT_RAW_M  (UART_AT_CMD_CHAR_DET_INT_RAW_V << UART_AT_CMD_CHAR_DET_INT_RAW_S)
+#define UART_AT_CMD_CHAR_DET_INT_RAW_V  0x00000001U
+#define UART_AT_CMD_CHAR_DET_INT_RAW_S  18
+/** UART_WAKEUP_INT_RAW : R/WTC/SS; bitpos: [19]; default: 0;
+ *  The raw interrupt status of UART_WAKEUP_INT.
+ */
+#define UART_WAKEUP_INT_RAW    (BIT(19))
+#define UART_WAKEUP_INT_RAW_M  (UART_WAKEUP_INT_RAW_V << UART_WAKEUP_INT_RAW_S)
+#define UART_WAKEUP_INT_RAW_V  0x00000001U
+#define UART_WAKEUP_INT_RAW_S  19
+
+/** UART_INT_ST_REG register
+ *  Masked interrupt status
+ */
+#define UART_INT_ST_REG(i) (REG_UART_BASE(i) + 0x8)
+/** UART_RXFIFO_FULL_INT_ST : RO; bitpos: [0]; default: 0;
+ *  The masked interrupt status of UART_RXFIFO_FULL_INT.
+ */
+#define UART_RXFIFO_FULL_INT_ST    (BIT(0))
+#define UART_RXFIFO_FULL_INT_ST_M  (UART_RXFIFO_FULL_INT_ST_V << UART_RXFIFO_FULL_INT_ST_S)
+#define UART_RXFIFO_FULL_INT_ST_V  0x00000001U
+#define UART_RXFIFO_FULL_INT_ST_S  0
+/** UART_TXFIFO_EMPTY_INT_ST : RO; bitpos: [1]; default: 0;
+ *  The masked interrupt status of UART_TXFIFO_EMPTY_INT.
+ */
+#define UART_TXFIFO_EMPTY_INT_ST    (BIT(1))
+#define UART_TXFIFO_EMPTY_INT_ST_M  (UART_TXFIFO_EMPTY_INT_ST_V << UART_TXFIFO_EMPTY_INT_ST_S)
+#define UART_TXFIFO_EMPTY_INT_ST_V  0x00000001U
+#define UART_TXFIFO_EMPTY_INT_ST_S  1
+/** UART_PARITY_ERR_INT_ST : RO; bitpos: [2]; default: 0;
+ *  The masked interrupt status of UART_PARITY_ERR_INT.
+ */
+#define UART_PARITY_ERR_INT_ST    (BIT(2))
+#define UART_PARITY_ERR_INT_ST_M  (UART_PARITY_ERR_INT_ST_V << UART_PARITY_ERR_INT_ST_S)
+#define UART_PARITY_ERR_INT_ST_V  0x00000001U
+#define UART_PARITY_ERR_INT_ST_S  2
+/** UART_FRM_ERR_INT_ST : RO; bitpos: [3]; default: 0;
+ *  The masked interrupt status of UART_FRM_ERR_INT.
+ */
+#define UART_FRM_ERR_INT_ST    (BIT(3))
+#define UART_FRM_ERR_INT_ST_M  (UART_FRM_ERR_INT_ST_V << UART_FRM_ERR_INT_ST_S)
+#define UART_FRM_ERR_INT_ST_V  0x00000001U
+#define UART_FRM_ERR_INT_ST_S  3
+/** UART_RXFIFO_OVF_INT_ST : RO; bitpos: [4]; default: 0;
+ *  The masked interrupt status of UART_RXFIFO_OVF_INT.
+ */
+#define UART_RXFIFO_OVF_INT_ST    (BIT(4))
+#define UART_RXFIFO_OVF_INT_ST_M  (UART_RXFIFO_OVF_INT_ST_V << UART_RXFIFO_OVF_INT_ST_S)
+#define UART_RXFIFO_OVF_INT_ST_V  0x00000001U
+#define UART_RXFIFO_OVF_INT_ST_S  4
+/** UART_DSR_CHG_INT_ST : RO; bitpos: [5]; default: 0;
+ *  The masked interrupt status of UART_DSR_CHG_INT.
+ */
+#define UART_DSR_CHG_INT_ST    (BIT(5))
+#define UART_DSR_CHG_INT_ST_M  (UART_DSR_CHG_INT_ST_V << UART_DSR_CHG_INT_ST_S)
+#define UART_DSR_CHG_INT_ST_V  0x00000001U
+#define UART_DSR_CHG_INT_ST_S  5
+/** UART_CTS_CHG_INT_ST : RO; bitpos: [6]; default: 0;
+ *  The masked interrupt status of UART_CTS_CHG_INT.
+ */
+#define UART_CTS_CHG_INT_ST    (BIT(6))
+#define UART_CTS_CHG_INT_ST_M  (UART_CTS_CHG_INT_ST_V << UART_CTS_CHG_INT_ST_S)
+#define UART_CTS_CHG_INT_ST_V  0x00000001U
+#define UART_CTS_CHG_INT_ST_S  6
+/** UART_BRK_DET_INT_ST : RO; bitpos: [7]; default: 0;
+ *  The masked interrupt status of UART_BRK_DET_INT.
+ */
+#define UART_BRK_DET_INT_ST    (BIT(7))
+#define UART_BRK_DET_INT_ST_M  (UART_BRK_DET_INT_ST_V << UART_BRK_DET_INT_ST_S)
+#define UART_BRK_DET_INT_ST_V  0x00000001U
+#define UART_BRK_DET_INT_ST_S  7
+/** UART_RXFIFO_TOUT_INT_ST : RO; bitpos: [8]; default: 0;
+ *  The masked interrupt status of UART_RXFIFO_TOUT_INT.
+ */
+#define UART_RXFIFO_TOUT_INT_ST    (BIT(8))
+#define UART_RXFIFO_TOUT_INT_ST_M  (UART_RXFIFO_TOUT_INT_ST_V << UART_RXFIFO_TOUT_INT_ST_S)
+#define UART_RXFIFO_TOUT_INT_ST_V  0x00000001U
+#define UART_RXFIFO_TOUT_INT_ST_S  8
+/** UART_SW_XON_INT_ST : RO; bitpos: [9]; default: 0;
+ *  The masked interrupt status of UART_SW_XON_INT.
+ */
+#define UART_SW_XON_INT_ST    (BIT(9))
+#define UART_SW_XON_INT_ST_M  (UART_SW_XON_INT_ST_V << UART_SW_XON_INT_ST_S)
+#define UART_SW_XON_INT_ST_V  0x00000001U
+#define UART_SW_XON_INT_ST_S  9
+/** UART_SW_XOFF_INT_ST : RO; bitpos: [10]; default: 0;
+ *  The masked interrupt status of UART_SW_XOFF_INT.
+ */
+#define UART_SW_XOFF_INT_ST    (BIT(10))
+#define UART_SW_XOFF_INT_ST_M  (UART_SW_XOFF_INT_ST_V << UART_SW_XOFF_INT_ST_S)
+#define UART_SW_XOFF_INT_ST_V  0x00000001U
+#define UART_SW_XOFF_INT_ST_S  10
+/** UART_GLITCH_DET_INT_ST : RO; bitpos: [11]; default: 0;
+ *  The masked interrupt status of UART_GLITCH_DET_INT.
+ */
+#define UART_GLITCH_DET_INT_ST    (BIT(11))
+#define UART_GLITCH_DET_INT_ST_M  (UART_GLITCH_DET_INT_ST_V << UART_GLITCH_DET_INT_ST_S)
+#define UART_GLITCH_DET_INT_ST_V  0x00000001U
+#define UART_GLITCH_DET_INT_ST_S  11
+/** UART_TX_BRK_DONE_INT_ST : RO; bitpos: [12]; default: 0;
+ *  The masked interrupt status of UART_TX_BRK_DONE_INT.
+ */
+#define UART_TX_BRK_DONE_INT_ST    (BIT(12))
+#define UART_TX_BRK_DONE_INT_ST_M  (UART_TX_BRK_DONE_INT_ST_V << UART_TX_BRK_DONE_INT_ST_S)
+#define UART_TX_BRK_DONE_INT_ST_V  0x00000001U
+#define UART_TX_BRK_DONE_INT_ST_S  12
+/** UART_TX_BRK_IDLE_DONE_INT_ST : RO; bitpos: [13]; default: 0;
+ *  The masked interrupt status of UART_TX_BRK_IDLE_DONE_INT.
+ */
+#define UART_TX_BRK_IDLE_DONE_INT_ST    (BIT(13))
+#define UART_TX_BRK_IDLE_DONE_INT_ST_M  (UART_TX_BRK_IDLE_DONE_INT_ST_V << UART_TX_BRK_IDLE_DONE_INT_ST_S)
+#define UART_TX_BRK_IDLE_DONE_INT_ST_V  0x00000001U
+#define UART_TX_BRK_IDLE_DONE_INT_ST_S  13
+/** UART_TX_DONE_INT_ST : RO; bitpos: [14]; default: 0;
+ *  The masked interrupt status of UART_TX_DONE_INT.
+ */
+#define UART_TX_DONE_INT_ST    (BIT(14))
+#define UART_TX_DONE_INT_ST_M  (UART_TX_DONE_INT_ST_V << UART_TX_DONE_INT_ST_S)
+#define UART_TX_DONE_INT_ST_V  0x00000001U
+#define UART_TX_DONE_INT_ST_S  14
+/** UART_RS485_PARITY_ERR_INT_ST : RO; bitpos: [15]; default: 0;
+ *  The masked interrupt status of UART_RS485_PARITY_ERR_INT.
+ */
+#define UART_RS485_PARITY_ERR_INT_ST    (BIT(15))
+#define UART_RS485_PARITY_ERR_INT_ST_M  (UART_RS485_PARITY_ERR_INT_ST_V << UART_RS485_PARITY_ERR_INT_ST_S)
+#define UART_RS485_PARITY_ERR_INT_ST_V  0x00000001U
+#define UART_RS485_PARITY_ERR_INT_ST_S  15
+/** UART_RS485_FRM_ERR_INT_ST : RO; bitpos: [16]; default: 0;
+ *  The masked interrupt status of UART_RS485_FRM_ERR_INT.
+ */
+#define UART_RS485_FRM_ERR_INT_ST    (BIT(16))
+#define UART_RS485_FRM_ERR_INT_ST_M  (UART_RS485_FRM_ERR_INT_ST_V << UART_RS485_FRM_ERR_INT_ST_S)
+#define UART_RS485_FRM_ERR_INT_ST_V  0x00000001U
+#define UART_RS485_FRM_ERR_INT_ST_S  16
+/** UART_RS485_CLASH_INT_ST : RO; bitpos: [17]; default: 0;
+ *  The masked interrupt status of UART_RS485_CLASH_INT.
+ */
+#define UART_RS485_CLASH_INT_ST    (BIT(17))
+#define UART_RS485_CLASH_INT_ST_M  (UART_RS485_CLASH_INT_ST_V << UART_RS485_CLASH_INT_ST_S)
+#define UART_RS485_CLASH_INT_ST_V  0x00000001U
+#define UART_RS485_CLASH_INT_ST_S  17
+/** UART_AT_CMD_CHAR_DET_INT_ST : RO; bitpos: [18]; default: 0;
+ *  The masked interrupt status of UART_AT_CMD_CHAR_DET_INT.
+ */
+#define UART_AT_CMD_CHAR_DET_INT_ST    (BIT(18))
+#define UART_AT_CMD_CHAR_DET_INT_ST_M  (UART_AT_CMD_CHAR_DET_INT_ST_V << UART_AT_CMD_CHAR_DET_INT_ST_S)
+#define UART_AT_CMD_CHAR_DET_INT_ST_V  0x00000001U
+#define UART_AT_CMD_CHAR_DET_INT_ST_S  18
+/** UART_WAKEUP_INT_ST : RO; bitpos: [19]; default: 0;
+ *  The masked interrupt status of UART_WAKEUP_INT.
+ */
+#define UART_WAKEUP_INT_ST    (BIT(19))
+#define UART_WAKEUP_INT_ST_M  (UART_WAKEUP_INT_ST_V << UART_WAKEUP_INT_ST_S)
+#define UART_WAKEUP_INT_ST_V  0x00000001U
+#define UART_WAKEUP_INT_ST_S  19
+
+/** UART_INT_ENA_REG register
+ *  Interrupt enable bits
+ */
+#define UART_INT_ENA_REG(i) (REG_UART_BASE(i) + 0xc)
+/** UART_RXFIFO_FULL_INT_ENA : R/W; bitpos: [0]; default: 0;
+ *  Write 1 to enable UART_RXFIFO_FULL_INT.
+ */
+#define UART_RXFIFO_FULL_INT_ENA    (BIT(0))
+#define UART_RXFIFO_FULL_INT_ENA_M  (UART_RXFIFO_FULL_INT_ENA_V << UART_RXFIFO_FULL_INT_ENA_S)
+#define UART_RXFIFO_FULL_INT_ENA_V  0x00000001U
+#define UART_RXFIFO_FULL_INT_ENA_S  0
+/** UART_TXFIFO_EMPTY_INT_ENA : R/W; bitpos: [1]; default: 0;
+ *  Write 1 to enable UART_TXFIFO_EMPTY_INT.
+ */
+#define UART_TXFIFO_EMPTY_INT_ENA    (BIT(1))
+#define UART_TXFIFO_EMPTY_INT_ENA_M  (UART_TXFIFO_EMPTY_INT_ENA_V << UART_TXFIFO_EMPTY_INT_ENA_S)
+#define UART_TXFIFO_EMPTY_INT_ENA_V  0x00000001U
+#define UART_TXFIFO_EMPTY_INT_ENA_S  1
+/** UART_PARITY_ERR_INT_ENA : R/W; bitpos: [2]; default: 0;
+ *  Write 1 to enable UART_PARITY_ERR_INT.
+ */
+#define UART_PARITY_ERR_INT_ENA    (BIT(2))
+#define UART_PARITY_ERR_INT_ENA_M  (UART_PARITY_ERR_INT_ENA_V << UART_PARITY_ERR_INT_ENA_S)
+#define UART_PARITY_ERR_INT_ENA_V  0x00000001U
+#define UART_PARITY_ERR_INT_ENA_S  2
+/** UART_FRM_ERR_INT_ENA : R/W; bitpos: [3]; default: 0;
+ *  Write 1 to enable UART_FRM_ERR_INT.
+ */
+#define UART_FRM_ERR_INT_ENA    (BIT(3))
+#define UART_FRM_ERR_INT_ENA_M  (UART_FRM_ERR_INT_ENA_V << UART_FRM_ERR_INT_ENA_S)
+#define UART_FRM_ERR_INT_ENA_V  0x00000001U
+#define UART_FRM_ERR_INT_ENA_S  3
+/** UART_RXFIFO_OVF_INT_ENA : R/W; bitpos: [4]; default: 0;
+ *  Write 1 to enable UART_RXFIFO_OVF_INT.
+ */
+#define UART_RXFIFO_OVF_INT_ENA    (BIT(4))
+#define UART_RXFIFO_OVF_INT_ENA_M  (UART_RXFIFO_OVF_INT_ENA_V << UART_RXFIFO_OVF_INT_ENA_S)
+#define UART_RXFIFO_OVF_INT_ENA_V  0x00000001U
+#define UART_RXFIFO_OVF_INT_ENA_S  4
+/** UART_DSR_CHG_INT_ENA : R/W; bitpos: [5]; default: 0;
+ *  Write 1 to enable UART_DSR_CHG_INT.
+ */
+#define UART_DSR_CHG_INT_ENA    (BIT(5))
+#define UART_DSR_CHG_INT_ENA_M  (UART_DSR_CHG_INT_ENA_V << UART_DSR_CHG_INT_ENA_S)
+#define UART_DSR_CHG_INT_ENA_V  0x00000001U
+#define UART_DSR_CHG_INT_ENA_S  5
+/** UART_CTS_CHG_INT_ENA : R/W; bitpos: [6]; default: 0;
+ *  Write 1 to enable UART_CTS_CHG_INT.
+ */
+#define UART_CTS_CHG_INT_ENA    (BIT(6))
+#define UART_CTS_CHG_INT_ENA_M  (UART_CTS_CHG_INT_ENA_V << UART_CTS_CHG_INT_ENA_S)
+#define UART_CTS_CHG_INT_ENA_V  0x00000001U
+#define UART_CTS_CHG_INT_ENA_S  6
+/** UART_BRK_DET_INT_ENA : R/W; bitpos: [7]; default: 0;
+ *  Write 1 to enable UART_BRK_DET_INT.
+ */
+#define UART_BRK_DET_INT_ENA    (BIT(7))
+#define UART_BRK_DET_INT_ENA_M  (UART_BRK_DET_INT_ENA_V << UART_BRK_DET_INT_ENA_S)
+#define UART_BRK_DET_INT_ENA_V  0x00000001U
+#define UART_BRK_DET_INT_ENA_S  7
+/** UART_RXFIFO_TOUT_INT_ENA : R/W; bitpos: [8]; default: 0;
+ *  Write 1 to enable UART_RXFIFO_TOUT_INT.
+ */
+#define UART_RXFIFO_TOUT_INT_ENA    (BIT(8))
+#define UART_RXFIFO_TOUT_INT_ENA_M  (UART_RXFIFO_TOUT_INT_ENA_V << UART_RXFIFO_TOUT_INT_ENA_S)
+#define UART_RXFIFO_TOUT_INT_ENA_V  0x00000001U
+#define UART_RXFIFO_TOUT_INT_ENA_S  8
+/** UART_SW_XON_INT_ENA : R/W; bitpos: [9]; default: 0;
+ *  Write 1 to enable UART_SW_XON_INT.
+ */
+#define UART_SW_XON_INT_ENA    (BIT(9))
+#define UART_SW_XON_INT_ENA_M  (UART_SW_XON_INT_ENA_V << UART_SW_XON_INT_ENA_S)
+#define UART_SW_XON_INT_ENA_V  0x00000001U
+#define UART_SW_XON_INT_ENA_S  9
+/** UART_SW_XOFF_INT_ENA : R/W; bitpos: [10]; default: 0;
+ *  Write 1 to enable UART_SW_XOFF_INT.
+ */
+#define UART_SW_XOFF_INT_ENA    (BIT(10))
+#define UART_SW_XOFF_INT_ENA_M  (UART_SW_XOFF_INT_ENA_V << UART_SW_XOFF_INT_ENA_S)
+#define UART_SW_XOFF_INT_ENA_V  0x00000001U
+#define UART_SW_XOFF_INT_ENA_S  10
+/** UART_GLITCH_DET_INT_ENA : R/W; bitpos: [11]; default: 0;
+ *  Write 1 to enable UART_GLITCH_DET_INT.
+ */
+#define UART_GLITCH_DET_INT_ENA    (BIT(11))
+#define UART_GLITCH_DET_INT_ENA_M  (UART_GLITCH_DET_INT_ENA_V << UART_GLITCH_DET_INT_ENA_S)
+#define UART_GLITCH_DET_INT_ENA_V  0x00000001U
+#define UART_GLITCH_DET_INT_ENA_S  11
+/** UART_TX_BRK_DONE_INT_ENA : R/W; bitpos: [12]; default: 0;
+ *  Write 1 to enable UART_TX_BRK_DONE_INT.
+ */
+#define UART_TX_BRK_DONE_INT_ENA    (BIT(12))
+#define UART_TX_BRK_DONE_INT_ENA_M  (UART_TX_BRK_DONE_INT_ENA_V << UART_TX_BRK_DONE_INT_ENA_S)
+#define UART_TX_BRK_DONE_INT_ENA_V  0x00000001U
+#define UART_TX_BRK_DONE_INT_ENA_S  12
+/** UART_TX_BRK_IDLE_DONE_INT_ENA : R/W; bitpos: [13]; default: 0;
+ *  Write 1 to enable UART_TX_BRK_IDLE_DONE_INT.
+ */
+#define UART_TX_BRK_IDLE_DONE_INT_ENA    (BIT(13))
+#define UART_TX_BRK_IDLE_DONE_INT_ENA_M  (UART_TX_BRK_IDLE_DONE_INT_ENA_V << UART_TX_BRK_IDLE_DONE_INT_ENA_S)
+#define UART_TX_BRK_IDLE_DONE_INT_ENA_V  0x00000001U
+#define UART_TX_BRK_IDLE_DONE_INT_ENA_S  13
+/** UART_TX_DONE_INT_ENA : R/W; bitpos: [14]; default: 0;
+ *  Write 1 to enable UART_TX_DONE_INT.
+ */
+#define UART_TX_DONE_INT_ENA    (BIT(14))
+#define UART_TX_DONE_INT_ENA_M  (UART_TX_DONE_INT_ENA_V << UART_TX_DONE_INT_ENA_S)
+#define UART_TX_DONE_INT_ENA_V  0x00000001U
+#define UART_TX_DONE_INT_ENA_S  14
+/** UART_RS485_PARITY_ERR_INT_ENA : R/W; bitpos: [15]; default: 0;
+ *  Write 1 to enable UART_RS485_PARITY_ERR_INT.
+ */
+#define UART_RS485_PARITY_ERR_INT_ENA    (BIT(15))
+#define UART_RS485_PARITY_ERR_INT_ENA_M  (UART_RS485_PARITY_ERR_INT_ENA_V << UART_RS485_PARITY_ERR_INT_ENA_S)
+#define UART_RS485_PARITY_ERR_INT_ENA_V  0x00000001U
+#define UART_RS485_PARITY_ERR_INT_ENA_S  15
+/** UART_RS485_FRM_ERR_INT_ENA : R/W; bitpos: [16]; default: 0;
+ *  Write 1 to enable UART_RS485_FRM_ERR_INT.
+ */
+#define UART_RS485_FRM_ERR_INT_ENA    (BIT(16))
+#define UART_RS485_FRM_ERR_INT_ENA_M  (UART_RS485_FRM_ERR_INT_ENA_V << UART_RS485_FRM_ERR_INT_ENA_S)
+#define UART_RS485_FRM_ERR_INT_ENA_V  0x00000001U
+#define UART_RS485_FRM_ERR_INT_ENA_S  16
+/** UART_RS485_CLASH_INT_ENA : R/W; bitpos: [17]; default: 0;
+ *  Write 1 to enable UART_RS485_CLASH_INT.
+ */
+#define UART_RS485_CLASH_INT_ENA    (BIT(17))
+#define UART_RS485_CLASH_INT_ENA_M  (UART_RS485_CLASH_INT_ENA_V << UART_RS485_CLASH_INT_ENA_S)
+#define UART_RS485_CLASH_INT_ENA_V  0x00000001U
+#define UART_RS485_CLASH_INT_ENA_S  17
+/** UART_AT_CMD_CHAR_DET_INT_ENA : R/W; bitpos: [18]; default: 0;
+ *  Write 1 to enable UART_AT_CMD_CHAR_DET_INT.
+ */
+#define UART_AT_CMD_CHAR_DET_INT_ENA    (BIT(18))
+#define UART_AT_CMD_CHAR_DET_INT_ENA_M  (UART_AT_CMD_CHAR_DET_INT_ENA_V << UART_AT_CMD_CHAR_DET_INT_ENA_S)
+#define UART_AT_CMD_CHAR_DET_INT_ENA_V  0x00000001U
+#define UART_AT_CMD_CHAR_DET_INT_ENA_S  18
+/** UART_WAKEUP_INT_ENA : R/W; bitpos: [19]; default: 0;
+ *  Write 1 to enable UART_WAKEUP_INT.
+ */
+#define UART_WAKEUP_INT_ENA    (BIT(19))
+#define UART_WAKEUP_INT_ENA_M  (UART_WAKEUP_INT_ENA_V << UART_WAKEUP_INT_ENA_S)
+#define UART_WAKEUP_INT_ENA_V  0x00000001U
+#define UART_WAKEUP_INT_ENA_S  19
+
+/** UART_INT_CLR_REG register
+ *  Interrupt clear bits
+ */
+#define UART_INT_CLR_REG(i) (REG_UART_BASE(i) + 0x10)
+/** UART_RXFIFO_FULL_INT_CLR : WT; bitpos: [0]; default: 0;
+ *  Write 1 to clear UART_RXFIFO_FULL_INT.
+ */
+#define UART_RXFIFO_FULL_INT_CLR    (BIT(0))
+#define UART_RXFIFO_FULL_INT_CLR_M  (UART_RXFIFO_FULL_INT_CLR_V << UART_RXFIFO_FULL_INT_CLR_S)
+#define UART_RXFIFO_FULL_INT_CLR_V  0x00000001U
+#define UART_RXFIFO_FULL_INT_CLR_S  0
+/** UART_TXFIFO_EMPTY_INT_CLR : WT; bitpos: [1]; default: 0;
+ *  Write 1 to clear UART_TXFIFO_EMPTY_INT.
+ */
+#define UART_TXFIFO_EMPTY_INT_CLR    (BIT(1))
+#define UART_TXFIFO_EMPTY_INT_CLR_M  (UART_TXFIFO_EMPTY_INT_CLR_V << UART_TXFIFO_EMPTY_INT_CLR_S)
+#define UART_TXFIFO_EMPTY_INT_CLR_V  0x00000001U
+#define UART_TXFIFO_EMPTY_INT_CLR_S  1
+/** UART_PARITY_ERR_INT_CLR : WT; bitpos: [2]; default: 0;
+ *  Write 1 to clear UART_PARITY_ERR_INT.
+ */
+#define UART_PARITY_ERR_INT_CLR    (BIT(2))
+#define UART_PARITY_ERR_INT_CLR_M  (UART_PARITY_ERR_INT_CLR_V << UART_PARITY_ERR_INT_CLR_S)
+#define UART_PARITY_ERR_INT_CLR_V  0x00000001U
+#define UART_PARITY_ERR_INT_CLR_S  2
+/** UART_FRM_ERR_INT_CLR : WT; bitpos: [3]; default: 0;
+ *  Write 1 to clear UART_FRM_ERR_INT.
+ */
+#define UART_FRM_ERR_INT_CLR    (BIT(3))
+#define UART_FRM_ERR_INT_CLR_M  (UART_FRM_ERR_INT_CLR_V << UART_FRM_ERR_INT_CLR_S)
+#define UART_FRM_ERR_INT_CLR_V  0x00000001U
+#define UART_FRM_ERR_INT_CLR_S  3
+/** UART_RXFIFO_OVF_INT_CLR : WT; bitpos: [4]; default: 0;
+ *  Write 1 to clear UART_RXFIFO_OVF_INT.
+ */
+#define UART_RXFIFO_OVF_INT_CLR    (BIT(4))
+#define UART_RXFIFO_OVF_INT_CLR_M  (UART_RXFIFO_OVF_INT_CLR_V << UART_RXFIFO_OVF_INT_CLR_S)
+#define UART_RXFIFO_OVF_INT_CLR_V  0x00000001U
+#define UART_RXFIFO_OVF_INT_CLR_S  4
+/** UART_DSR_CHG_INT_CLR : WT; bitpos: [5]; default: 0;
+ *  Write 1 to clear UART_DSR_CHG_INT.
+ */
+#define UART_DSR_CHG_INT_CLR    (BIT(5))
+#define UART_DSR_CHG_INT_CLR_M  (UART_DSR_CHG_INT_CLR_V << UART_DSR_CHG_INT_CLR_S)
+#define UART_DSR_CHG_INT_CLR_V  0x00000001U
+#define UART_DSR_CHG_INT_CLR_S  5
+/** UART_CTS_CHG_INT_CLR : WT; bitpos: [6]; default: 0;
+ *  Write 1 to clear UART_CTS_CHG_INT.
+ */
+#define UART_CTS_CHG_INT_CLR    (BIT(6))
+#define UART_CTS_CHG_INT_CLR_M  (UART_CTS_CHG_INT_CLR_V << UART_CTS_CHG_INT_CLR_S)
+#define UART_CTS_CHG_INT_CLR_V  0x00000001U
+#define UART_CTS_CHG_INT_CLR_S  6
+/** UART_BRK_DET_INT_CLR : WT; bitpos: [7]; default: 0;
+ *  Write 1 to clear UART_BRK_DET_INT.
+ */
+#define UART_BRK_DET_INT_CLR    (BIT(7))
+#define UART_BRK_DET_INT_CLR_M  (UART_BRK_DET_INT_CLR_V << UART_BRK_DET_INT_CLR_S)
+#define UART_BRK_DET_INT_CLR_V  0x00000001U
+#define UART_BRK_DET_INT_CLR_S  7
+/** UART_RXFIFO_TOUT_INT_CLR : WT; bitpos: [8]; default: 0;
+ *  Write 1 to clear UART_RXFIFO_TOUT_INT.
+ */
+#define UART_RXFIFO_TOUT_INT_CLR    (BIT(8))
+#define UART_RXFIFO_TOUT_INT_CLR_M  (UART_RXFIFO_TOUT_INT_CLR_V << UART_RXFIFO_TOUT_INT_CLR_S)
+#define UART_RXFIFO_TOUT_INT_CLR_V  0x00000001U
+#define UART_RXFIFO_TOUT_INT_CLR_S  8
+/** UART_SW_XON_INT_CLR : WT; bitpos: [9]; default: 0;
+ *  Write 1 to clear UART_SW_XON_INT.
+ */
+#define UART_SW_XON_INT_CLR    (BIT(9))
+#define UART_SW_XON_INT_CLR_M  (UART_SW_XON_INT_CLR_V << UART_SW_XON_INT_CLR_S)
+#define UART_SW_XON_INT_CLR_V  0x00000001U
+#define UART_SW_XON_INT_CLR_S  9
+/** UART_SW_XOFF_INT_CLR : WT; bitpos: [10]; default: 0;
+ *  Write 1 to clear UART_SW_XOFF_INT.
+ */
+#define UART_SW_XOFF_INT_CLR    (BIT(10))
+#define UART_SW_XOFF_INT_CLR_M  (UART_SW_XOFF_INT_CLR_V << UART_SW_XOFF_INT_CLR_S)
+#define UART_SW_XOFF_INT_CLR_V  0x00000001U
+#define UART_SW_XOFF_INT_CLR_S  10
+/** UART_GLITCH_DET_INT_CLR : WT; bitpos: [11]; default: 0;
+ *  Write 1 to clear UART_GLITCH_DET_INT.
+ */
+#define UART_GLITCH_DET_INT_CLR    (BIT(11))
+#define UART_GLITCH_DET_INT_CLR_M  (UART_GLITCH_DET_INT_CLR_V << UART_GLITCH_DET_INT_CLR_S)
+#define UART_GLITCH_DET_INT_CLR_V  0x00000001U
+#define UART_GLITCH_DET_INT_CLR_S  11
+/** UART_TX_BRK_DONE_INT_CLR : WT; bitpos: [12]; default: 0;
+ *  Write 1 to clear UART_TX_BRK_DONE_INT.
+ */
+#define UART_TX_BRK_DONE_INT_CLR    (BIT(12))
+#define UART_TX_BRK_DONE_INT_CLR_M  (UART_TX_BRK_DONE_INT_CLR_V << UART_TX_BRK_DONE_INT_CLR_S)
+#define UART_TX_BRK_DONE_INT_CLR_V  0x00000001U
+#define UART_TX_BRK_DONE_INT_CLR_S  12
+/** UART_TX_BRK_IDLE_DONE_INT_CLR : WT; bitpos: [13]; default: 0;
+ *  Write 1 to clear UART_TX_BRK_IDLE_DONE_INT.
+ */
+#define UART_TX_BRK_IDLE_DONE_INT_CLR    (BIT(13))
+#define UART_TX_BRK_IDLE_DONE_INT_CLR_M  (UART_TX_BRK_IDLE_DONE_INT_CLR_V << UART_TX_BRK_IDLE_DONE_INT_CLR_S)
+#define UART_TX_BRK_IDLE_DONE_INT_CLR_V  0x00000001U
+#define UART_TX_BRK_IDLE_DONE_INT_CLR_S  13
+/** UART_TX_DONE_INT_CLR : WT; bitpos: [14]; default: 0;
+ *  Write 1 to clear UART_TX_DONE_INT.
+ */
+#define UART_TX_DONE_INT_CLR    (BIT(14))
+#define UART_TX_DONE_INT_CLR_M  (UART_TX_DONE_INT_CLR_V << UART_TX_DONE_INT_CLR_S)
+#define UART_TX_DONE_INT_CLR_V  0x00000001U
+#define UART_TX_DONE_INT_CLR_S  14
+/** UART_RS485_PARITY_ERR_INT_CLR : WT; bitpos: [15]; default: 0;
+ *  Write 1 to clear UART_RS485_PARITY_ERR_INT.
+ */
+#define UART_RS485_PARITY_ERR_INT_CLR    (BIT(15))
+#define UART_RS485_PARITY_ERR_INT_CLR_M  (UART_RS485_PARITY_ERR_INT_CLR_V << UART_RS485_PARITY_ERR_INT_CLR_S)
+#define UART_RS485_PARITY_ERR_INT_CLR_V  0x00000001U
+#define UART_RS485_PARITY_ERR_INT_CLR_S  15
+/** UART_RS485_FRM_ERR_INT_CLR : WT; bitpos: [16]; default: 0;
+ *  Write 1 to clear UART_RS485_FRM_ERR_INT.
+ */
+#define UART_RS485_FRM_ERR_INT_CLR    (BIT(16))
+#define UART_RS485_FRM_ERR_INT_CLR_M  (UART_RS485_FRM_ERR_INT_CLR_V << UART_RS485_FRM_ERR_INT_CLR_S)
+#define UART_RS485_FRM_ERR_INT_CLR_V  0x00000001U
+#define UART_RS485_FRM_ERR_INT_CLR_S  16
+/** UART_RS485_CLASH_INT_CLR : WT; bitpos: [17]; default: 0;
+ *  Write 1 to clear UART_RS485_CLASH_INT.
+ */
+#define UART_RS485_CLASH_INT_CLR    (BIT(17))
+#define UART_RS485_CLASH_INT_CLR_M  (UART_RS485_CLASH_INT_CLR_V << UART_RS485_CLASH_INT_CLR_S)
+#define UART_RS485_CLASH_INT_CLR_V  0x00000001U
+#define UART_RS485_CLASH_INT_CLR_S  17
+/** UART_AT_CMD_CHAR_DET_INT_CLR : WT; bitpos: [18]; default: 0;
+ *  Write 1 to clear UART_AT_CMD_CHAR_DET_INT.
+ */
+#define UART_AT_CMD_CHAR_DET_INT_CLR    (BIT(18))
+#define UART_AT_CMD_CHAR_DET_INT_CLR_M  (UART_AT_CMD_CHAR_DET_INT_CLR_V << UART_AT_CMD_CHAR_DET_INT_CLR_S)
+#define UART_AT_CMD_CHAR_DET_INT_CLR_V  0x00000001U
+#define UART_AT_CMD_CHAR_DET_INT_CLR_S  18
+/** UART_WAKEUP_INT_CLR : WT; bitpos: [19]; default: 0;
+ *  Write 1 to clear UART_WAKEUP_INT.
+ */
+#define UART_WAKEUP_INT_CLR    (BIT(19))
+#define UART_WAKEUP_INT_CLR_M  (UART_WAKEUP_INT_CLR_V << UART_WAKEUP_INT_CLR_S)
+#define UART_WAKEUP_INT_CLR_V  0x00000001U
+#define UART_WAKEUP_INT_CLR_S  19
+
+/** UART_CLKDIV_SYNC_REG register
+ *  Clock divider configuration
+ */
+#define UART_CLKDIV_SYNC_REG(i) (REG_UART_BASE(i) + 0x14)
+/** UART_CLKDIV : R/W; bitpos: [11:0]; default: 694;
+ *  Configures the integral part of the divisor for baud rate generation.
+ */
+#define UART_CLKDIV    0x00000FFFU
+#define UART_CLKDIV_M  (UART_CLKDIV_V << UART_CLKDIV_S)
+#define UART_CLKDIV_V  0x00000FFFU
+#define UART_CLKDIV_S  0
+/** UART_CLKDIV_FRAG : R/W; bitpos: [23:20]; default: 0;
+ *  Configures the fractional part of the divisor for baud rate generation.
+ */
+#define UART_CLKDIV_FRAG    0x0000000FU
+#define UART_CLKDIV_FRAG_M  (UART_CLKDIV_FRAG_V << UART_CLKDIV_FRAG_S)
+#define UART_CLKDIV_FRAG_V  0x0000000FU
+#define UART_CLKDIV_FRAG_S  20
+
+/** UART_RX_FILT_REG register
+ *  RX filter configuration
+ */
+#define UART_RX_FILT_REG(i) (REG_UART_BASE(i) + 0x18)
+/** UART_GLITCH_FILT : R/W; bitpos: [7:0]; default: 8;
+ *  Configures the width of a pulse to be filtered.
+ *  Measurement unit: UART Core's clock cycle.
+ *  Pulses whose width is lower than this value will be ignored.
+ */
+#define UART_GLITCH_FILT    0x000000FFU
+#define UART_GLITCH_FILT_M  (UART_GLITCH_FILT_V << UART_GLITCH_FILT_S)
+#define UART_GLITCH_FILT_V  0x000000FFU
+#define UART_GLITCH_FILT_S  0
+/** UART_GLITCH_FILT_EN : R/W; bitpos: [8]; default: 0;
+ *  Configures whether or not to enable RX signal filter.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_GLITCH_FILT_EN    (BIT(8))
+#define UART_GLITCH_FILT_EN_M  (UART_GLITCH_FILT_EN_V << UART_GLITCH_FILT_EN_S)
+#define UART_GLITCH_FILT_EN_V  0x00000001U
+#define UART_GLITCH_FILT_EN_S  8
+
+/** UART_STATUS_REG register
+ *  UART status register
+ */
+#define UART_STATUS_REG(i) (REG_UART_BASE(i) + 0x1c)
+/** UART_RXFIFO_CNT : RO; bitpos: [7:0]; default: 0;
+ *  Represents the number of valid data bytes in RX FIFO.
+ */
+#define UART_RXFIFO_CNT    0x000000FFU
+#define UART_RXFIFO_CNT_M  (UART_RXFIFO_CNT_V << UART_RXFIFO_CNT_S)
+#define UART_RXFIFO_CNT_V  0x000000FFU
+#define UART_RXFIFO_CNT_S  0
+/** UART_DSRN : RO; bitpos: [13]; default: 0;
+ *  Represents the level of the internal UART DSR signal.
+ */
+#define UART_DSRN    (BIT(13))
+#define UART_DSRN_M  (UART_DSRN_V << UART_DSRN_S)
+#define UART_DSRN_V  0x00000001U
+#define UART_DSRN_S  13
+/** UART_CTSN : RO; bitpos: [14]; default: 1;
+ *  Represents the level of the internal UART CTS signal.
+ */
+#define UART_CTSN    (BIT(14))
+#define UART_CTSN_M  (UART_CTSN_V << UART_CTSN_S)
+#define UART_CTSN_V  0x00000001U
+#define UART_CTSN_S  14
+/** UART_RXD : RO; bitpos: [15]; default: 1;
+ *  Represents the  level of the internal UART RXD signal.
+ */
+#define UART_RXD    (BIT(15))
+#define UART_RXD_M  (UART_RXD_V << UART_RXD_S)
+#define UART_RXD_V  0x00000001U
+#define UART_RXD_S  15
+/** UART_TXFIFO_CNT : RO; bitpos: [23:16]; default: 0;
+ *  Represents the number of valid data bytes in RX FIFO.
+ */
+#define UART_TXFIFO_CNT    0x000000FFU
+#define UART_TXFIFO_CNT_M  (UART_TXFIFO_CNT_V << UART_TXFIFO_CNT_S)
+#define UART_TXFIFO_CNT_V  0x000000FFU
+#define UART_TXFIFO_CNT_S  16
+/** UART_DTRN : RO; bitpos: [29]; default: 1;
+ *  Represents the level of the internal UART DTR signal.
+ */
+#define UART_DTRN    (BIT(29))
+#define UART_DTRN_M  (UART_DTRN_V << UART_DTRN_S)
+#define UART_DTRN_V  0x00000001U
+#define UART_DTRN_S  29
+/** UART_RTSN : RO; bitpos: [30]; default: 1;
+ *  Represents the level of the internal UART RTS signal.
+ */
+#define UART_RTSN    (BIT(30))
+#define UART_RTSN_M  (UART_RTSN_V << UART_RTSN_S)
+#define UART_RTSN_V  0x00000001U
+#define UART_RTSN_S  30
+/** UART_TXD : RO; bitpos: [31]; default: 1;
+ *  Represents the  level of the internal UART TXD signal.
+ */
+#define UART_TXD    (BIT(31))
+#define UART_TXD_M  (UART_TXD_V << UART_TXD_S)
+#define UART_TXD_V  0x00000001U
+#define UART_TXD_S  31
+
+/** UART_CONF0_SYNC_REG register
+ *  Configuration register 0
+ */
+#define UART_CONF0_SYNC_REG(i) (REG_UART_BASE(i) + 0x20)
+/** UART_PARITY : R/W; bitpos: [0]; default: 0;
+ *  Configures the parity check mode.
+ *  0: Even parity
+ *  1: Odd parity
+ */
+#define UART_PARITY    (BIT(0))
+#define UART_PARITY_M  (UART_PARITY_V << UART_PARITY_S)
+#define UART_PARITY_V  0x00000001U
+#define UART_PARITY_S  0
+/** UART_PARITY_EN : R/W; bitpos: [1]; default: 0;
+ *  Configures whether or not to enable UART parity check.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_PARITY_EN    (BIT(1))
+#define UART_PARITY_EN_M  (UART_PARITY_EN_V << UART_PARITY_EN_S)
+#define UART_PARITY_EN_V  0x00000001U
+#define UART_PARITY_EN_S  1
+/** UART_BIT_NUM : R/W; bitpos: [3:2]; default: 3;
+ *  Configures the number of data bits.
+ *  0: 5 bits
+ *  1: 6 bits
+ *  2: 7 bits
+ *  3: 8 bits
+ */
+#define UART_BIT_NUM    0x00000003U
+#define UART_BIT_NUM_M  (UART_BIT_NUM_V << UART_BIT_NUM_S)
+#define UART_BIT_NUM_V  0x00000003U
+#define UART_BIT_NUM_S  2
+/** UART_STOP_BIT_NUM : R/W; bitpos: [5:4]; default: 1;
+ *  Configures the number of stop bits.
+ *  0: Invalid. No effect
+ *  1: 1 bits
+ *  2: 1.5 bits
+ *  3: 2 bits
+ */
+#define UART_STOP_BIT_NUM    0x00000003U
+#define UART_STOP_BIT_NUM_M  (UART_STOP_BIT_NUM_V << UART_STOP_BIT_NUM_S)
+#define UART_STOP_BIT_NUM_V  0x00000003U
+#define UART_STOP_BIT_NUM_S  4
+/** UART_TXD_BRK : R/W; bitpos: [6]; default: 0;
+ *  Configures whether or not to send NULL characters when finishing data transmission.
+ *  0: Not send
+ *  1: Send
+ */
+#define UART_TXD_BRK    (BIT(6))
+#define UART_TXD_BRK_M  (UART_TXD_BRK_V << UART_TXD_BRK_S)
+#define UART_TXD_BRK_V  0x00000001U
+#define UART_TXD_BRK_S  6
+/** UART_IRDA_DPLX : R/W; bitpos: [7]; default: 0;
+ *  Configures whether or not to enable IrDA loopback test.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_IRDA_DPLX    (BIT(7))
+#define UART_IRDA_DPLX_M  (UART_IRDA_DPLX_V << UART_IRDA_DPLX_S)
+#define UART_IRDA_DPLX_V  0x00000001U
+#define UART_IRDA_DPLX_S  7
+/** UART_IRDA_TX_EN : R/W; bitpos: [8]; default: 0;
+ *  Configures whether or not to enable the IrDA transmitter.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_IRDA_TX_EN    (BIT(8))
+#define UART_IRDA_TX_EN_M  (UART_IRDA_TX_EN_V << UART_IRDA_TX_EN_S)
+#define UART_IRDA_TX_EN_V  0x00000001U
+#define UART_IRDA_TX_EN_S  8
+/** UART_IRDA_WCTL : R/W; bitpos: [9]; default: 0;
+ *  Configures the 11th bit of the IrDA transmitter.
+ *  0: This bit is 0.
+ *  1: This bit is the same as the 10th bit.
+ */
+#define UART_IRDA_WCTL    (BIT(9))
+#define UART_IRDA_WCTL_M  (UART_IRDA_WCTL_V << UART_IRDA_WCTL_S)
+#define UART_IRDA_WCTL_V  0x00000001U
+#define UART_IRDA_WCTL_S  9
+/** UART_IRDA_TX_INV : R/W; bitpos: [10]; default: 0;
+ *  Configures whether or not to invert the level of the IrDA transmitter.
+ *  0: Not invert
+ *  1: Invert
+ */
+#define UART_IRDA_TX_INV    (BIT(10))
+#define UART_IRDA_TX_INV_M  (UART_IRDA_TX_INV_V << UART_IRDA_TX_INV_S)
+#define UART_IRDA_TX_INV_V  0x00000001U
+#define UART_IRDA_TX_INV_S  10
+/** UART_IRDA_RX_INV : R/W; bitpos: [11]; default: 0;
+ *  Configures whether or not to invert the level of the IrDA receiver.
+ *  0: Not invert
+ *  1: Invert
+ */
+#define UART_IRDA_RX_INV    (BIT(11))
+#define UART_IRDA_RX_INV_M  (UART_IRDA_RX_INV_V << UART_IRDA_RX_INV_S)
+#define UART_IRDA_RX_INV_V  0x00000001U
+#define UART_IRDA_RX_INV_S  11
+/** UART_LOOPBACK : R/W; bitpos: [12]; default: 0;
+ *  Configures whether or not to enable UART loopback test.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_LOOPBACK    (BIT(12))
+#define UART_LOOPBACK_M  (UART_LOOPBACK_V << UART_LOOPBACK_S)
+#define UART_LOOPBACK_V  0x00000001U
+#define UART_LOOPBACK_S  12
+/** UART_TX_FLOW_EN : R/W; bitpos: [13]; default: 0;
+ *  Configures whether or not to enable flow control for the transmitter.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_TX_FLOW_EN    (BIT(13))
+#define UART_TX_FLOW_EN_M  (UART_TX_FLOW_EN_V << UART_TX_FLOW_EN_S)
+#define UART_TX_FLOW_EN_V  0x00000001U
+#define UART_TX_FLOW_EN_S  13
+/** UART_IRDA_EN : R/W; bitpos: [14]; default: 0;
+ *  Configures whether or not to enable IrDA protocol.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_IRDA_EN    (BIT(14))
+#define UART_IRDA_EN_M  (UART_IRDA_EN_V << UART_IRDA_EN_S)
+#define UART_IRDA_EN_V  0x00000001U
+#define UART_IRDA_EN_S  14
+/** UART_RXD_INV : R/W; bitpos: [15]; default: 0;
+ *  Configures whether or not to invert the level of UART RXD signal.
+ *  0: Not invert
+ *  1: Invert
+ */
+#define UART_RXD_INV    (BIT(15))
+#define UART_RXD_INV_M  (UART_RXD_INV_V << UART_RXD_INV_S)
+#define UART_RXD_INV_V  0x00000001U
+#define UART_RXD_INV_S  15
+/** UART_TXD_INV : R/W; bitpos: [16]; default: 0;
+ *  Configures whether or not to invert the level of UART TXD signal.
+ *  0: Not invert
+ *  1: Invert
+ */
+#define UART_TXD_INV    (BIT(16))
+#define UART_TXD_INV_M  (UART_TXD_INV_V << UART_TXD_INV_S)
+#define UART_TXD_INV_V  0x00000001U
+#define UART_TXD_INV_S  16
+/** UART_DIS_RX_DAT_OVF : R/W; bitpos: [17]; default: 0;
+ *  Configures whether or not to disable data overflow detection for the UART receiver.
+ *  0: Enable
+ *  1: Disable
+ */
+#define UART_DIS_RX_DAT_OVF    (BIT(17))
+#define UART_DIS_RX_DAT_OVF_M  (UART_DIS_RX_DAT_OVF_V << UART_DIS_RX_DAT_OVF_S)
+#define UART_DIS_RX_DAT_OVF_V  0x00000001U
+#define UART_DIS_RX_DAT_OVF_S  17
+/** UART_ERR_WR_MASK : R/W; bitpos: [18]; default: 0;
+ *  Configures whether or not to store the received data with errors into FIFO.
+ *  0: Store
+ *  1: Not store
+ */
+#define UART_ERR_WR_MASK    (BIT(18))
+#define UART_ERR_WR_MASK_M  (UART_ERR_WR_MASK_V << UART_ERR_WR_MASK_S)
+#define UART_ERR_WR_MASK_V  0x00000001U
+#define UART_ERR_WR_MASK_S  18
+/** UART_AUTOBAUD_EN : R/W; bitpos: [19]; default: 0;
+ *  Configures whether or not to enable baud rate detection.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_AUTOBAUD_EN    (BIT(19))
+#define UART_AUTOBAUD_EN_M  (UART_AUTOBAUD_EN_V << UART_AUTOBAUD_EN_S)
+#define UART_AUTOBAUD_EN_V  0x00000001U
+#define UART_AUTOBAUD_EN_S  19
+/** UART_MEM_CLK_EN : R/W; bitpos: [20]; default: 0;
+ *  Configures whether or not to enable clock gating for UART memory.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_MEM_CLK_EN    (BIT(20))
+#define UART_MEM_CLK_EN_M  (UART_MEM_CLK_EN_V << UART_MEM_CLK_EN_S)
+#define UART_MEM_CLK_EN_V  0x00000001U
+#define UART_MEM_CLK_EN_S  20
+/** UART_SW_RTS : R/W; bitpos: [21]; default: 0;
+ *  Configures the RTS signal used in software flow control.
+ *  0: The UART transmitter is allowed to send data.
+ *  1: The UART transmitted is not allowed to send data.
+ */
+#define UART_SW_RTS    (BIT(21))
+#define UART_SW_RTS_M  (UART_SW_RTS_V << UART_SW_RTS_S)
+#define UART_SW_RTS_V  0x00000001U
+#define UART_SW_RTS_S  21
+/** UART_RXFIFO_RST : R/W; bitpos: [22]; default: 0;
+ *  Configures whether or not to reset the UART RX FIFO.
+ *  0: Not reset
+ *  1: Reset
+ */
+#define UART_RXFIFO_RST    (BIT(22))
+#define UART_RXFIFO_RST_M  (UART_RXFIFO_RST_V << UART_RXFIFO_RST_S)
+#define UART_RXFIFO_RST_V  0x00000001U
+#define UART_RXFIFO_RST_S  22
+/** UART_TXFIFO_RST : R/W; bitpos: [23]; default: 0;
+ *  Configures whether or not to reset the UART TX FIFO.
+ *  0: Not reset
+ *  1: Reset
+ */
+#define UART_TXFIFO_RST    (BIT(23))
+#define UART_TXFIFO_RST_M  (UART_TXFIFO_RST_V << UART_TXFIFO_RST_S)
+#define UART_TXFIFO_RST_V  0x00000001U
+#define UART_TXFIFO_RST_S  23
+
+/** UART_CONF1_REG register
+ *  Configuration register 1
+ */
+#define UART_CONF1_REG(i) (REG_UART_BASE(i) + 0x24)
+/** UART_RXFIFO_FULL_THRHD : R/W; bitpos: [7:0]; default: 96;
+ *  Configures the threshold for RX FIFO being full.
+ *  Measurement unit: byte.
+ */
+#define UART_RXFIFO_FULL_THRHD    0x000000FFU
+#define UART_RXFIFO_FULL_THRHD_M  (UART_RXFIFO_FULL_THRHD_V << UART_RXFIFO_FULL_THRHD_S)
+#define UART_RXFIFO_FULL_THRHD_V  0x000000FFU
+#define UART_RXFIFO_FULL_THRHD_S  0
+/** UART_TXFIFO_EMPTY_THRHD : R/W; bitpos: [15:8]; default: 96;
+ *  Configures the threshold for TX FIFO being empty.
+ *  Measurement unit: byte.
+ */
+#define UART_TXFIFO_EMPTY_THRHD    0x000000FFU
+#define UART_TXFIFO_EMPTY_THRHD_M  (UART_TXFIFO_EMPTY_THRHD_V << UART_TXFIFO_EMPTY_THRHD_S)
+#define UART_TXFIFO_EMPTY_THRHD_V  0x000000FFU
+#define UART_TXFIFO_EMPTY_THRHD_S  8
+/** UART_CTS_INV : R/W; bitpos: [16]; default: 0;
+ *  Configures whether or not to invert the level of UART CTS signal.
+ *  0: Not invert
+ *  1: Invert
+ */
+#define UART_CTS_INV    (BIT(16))
+#define UART_CTS_INV_M  (UART_CTS_INV_V << UART_CTS_INV_S)
+#define UART_CTS_INV_V  0x00000001U
+#define UART_CTS_INV_S  16
+/** UART_DSR_INV : R/W; bitpos: [17]; default: 0;
+ *  Configures whether or not to invert the level of UART DSR signal.
+ *  0: Not invert
+ *  1: Invert
+ */
+#define UART_DSR_INV    (BIT(17))
+#define UART_DSR_INV_M  (UART_DSR_INV_V << UART_DSR_INV_S)
+#define UART_DSR_INV_V  0x00000001U
+#define UART_DSR_INV_S  17
+/** UART_RTS_INV : R/W; bitpos: [18]; default: 0;
+ *  Configures whether or not to invert the level of UART RTS signal.
+ *  0: Not invert
+ *  1: Invert
+ */
+#define UART_RTS_INV    (BIT(18))
+#define UART_RTS_INV_M  (UART_RTS_INV_V << UART_RTS_INV_S)
+#define UART_RTS_INV_V  0x00000001U
+#define UART_RTS_INV_S  18
+/** UART_DTR_INV : R/W; bitpos: [19]; default: 0;
+ *  Configures whether or not to invert the level of UART DTR signal.
+ *  0: Not invert
+ *  1: Invert
+ */
+#define UART_DTR_INV    (BIT(19))
+#define UART_DTR_INV_M  (UART_DTR_INV_V << UART_DTR_INV_S)
+#define UART_DTR_INV_V  0x00000001U
+#define UART_DTR_INV_S  19
+/** UART_SW_DTR : R/W; bitpos: [20]; default: 0;
+ *  Configures the DTR signal used in software flow control.
+ *  0: Data to be transmitted is not ready.
+ *  1: Data to be transmitted is ready.
+ */
+#define UART_SW_DTR    (BIT(20))
+#define UART_SW_DTR_M  (UART_SW_DTR_V << UART_SW_DTR_S)
+#define UART_SW_DTR_V  0x00000001U
+#define UART_SW_DTR_S  20
+/** UART_CLK_EN : R/W; bitpos: [21]; default: 0;
+ *  Configures clock gating.
+ *  0: Support clock only when the application writes registers.
+ *  1: Always force the clock on for registers.
+ */
+#define UART_CLK_EN    (BIT(21))
+#define UART_CLK_EN_M  (UART_CLK_EN_V << UART_CLK_EN_S)
+#define UART_CLK_EN_V  0x00000001U
+#define UART_CLK_EN_S  21
+
+/** UART_HWFC_CONF_SYNC_REG register
+ *  Hardware flow control configuration
+ */
+#define UART_HWFC_CONF_SYNC_REG(i) (REG_UART_BASE(i) + 0x2c)
+/** UART_RX_FLOW_THRHD : R/W; bitpos: [7:0]; default: 0;
+ *  Configures the maximum number of data bytes that can be received  during hardware
+ *  flow control.
+ *  Measurement unit: byte.
+ */
+#define UART_RX_FLOW_THRHD    0x000000FFU
+#define UART_RX_FLOW_THRHD_M  (UART_RX_FLOW_THRHD_V << UART_RX_FLOW_THRHD_S)
+#define UART_RX_FLOW_THRHD_V  0x000000FFU
+#define UART_RX_FLOW_THRHD_S  0
+/** UART_RX_FLOW_EN : R/W; bitpos: [8]; default: 0;
+ *  Configures whether or not to enable the UART receiver.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_RX_FLOW_EN    (BIT(8))
+#define UART_RX_FLOW_EN_M  (UART_RX_FLOW_EN_V << UART_RX_FLOW_EN_S)
+#define UART_RX_FLOW_EN_V  0x00000001U
+#define UART_RX_FLOW_EN_S  8
+
+/** UART_SLEEP_CONF0_REG register
+ *  UART sleep configuration register 0
+ */
+#define UART_SLEEP_CONF0_REG(i) (REG_UART_BASE(i) + 0x30)
+/** UART_WK_CHAR1 : R/W; bitpos: [7:0]; default: 0;
+ *  Configures wakeup character 1.
+ */
+#define UART_WK_CHAR1    0x000000FFU
+#define UART_WK_CHAR1_M  (UART_WK_CHAR1_V << UART_WK_CHAR1_S)
+#define UART_WK_CHAR1_V  0x000000FFU
+#define UART_WK_CHAR1_S  0
+/** UART_WK_CHAR2 : R/W; bitpos: [15:8]; default: 0;
+ *  Configures wakeup character 2.
+ */
+#define UART_WK_CHAR2    0x000000FFU
+#define UART_WK_CHAR2_M  (UART_WK_CHAR2_V << UART_WK_CHAR2_S)
+#define UART_WK_CHAR2_V  0x000000FFU
+#define UART_WK_CHAR2_S  8
+/** UART_WK_CHAR3 : R/W; bitpos: [23:16]; default: 0;
+ *  Configures wakeup character 3.
+ */
+#define UART_WK_CHAR3    0x000000FFU
+#define UART_WK_CHAR3_M  (UART_WK_CHAR3_V << UART_WK_CHAR3_S)
+#define UART_WK_CHAR3_V  0x000000FFU
+#define UART_WK_CHAR3_S  16
+/** UART_WK_CHAR4 : R/W; bitpos: [31:24]; default: 0;
+ *  Configures wakeup character 4.
+ */
+#define UART_WK_CHAR4    0x000000FFU
+#define UART_WK_CHAR4_M  (UART_WK_CHAR4_V << UART_WK_CHAR4_S)
+#define UART_WK_CHAR4_V  0x000000FFU
+#define UART_WK_CHAR4_S  24
+
+/** UART_SLEEP_CONF1_REG register
+ *  UART sleep configuration register 1
+ */
+#define UART_SLEEP_CONF1_REG(i) (REG_UART_BASE(i) + 0x34)
+/** UART_WK_CHAR0 : R/W; bitpos: [7:0]; default: 0;
+ *  Configures wakeup character 0.
+ */
+#define UART_WK_CHAR0    0x000000FFU
+#define UART_WK_CHAR0_M  (UART_WK_CHAR0_V << UART_WK_CHAR0_S)
+#define UART_WK_CHAR0_V  0x000000FFU
+#define UART_WK_CHAR0_S  0
+
+/** UART_SLEEP_CONF2_REG register
+ *  UART sleep configuration register 2
+ */
+#define UART_SLEEP_CONF2_REG(i) (REG_UART_BASE(i) + 0x38)
+/** UART_ACTIVE_THRESHOLD : R/W; bitpos: [9:0]; default: 240;
+ *  Configures the number of RXD edge changes to wake up the chip in wakeup mode 0.
+ */
+#define UART_ACTIVE_THRESHOLD    0x000003FFU
+#define UART_ACTIVE_THRESHOLD_M  (UART_ACTIVE_THRESHOLD_V << UART_ACTIVE_THRESHOLD_S)
+#define UART_ACTIVE_THRESHOLD_V  0x000003FFU
+#define UART_ACTIVE_THRESHOLD_S  0
+/** UART_RX_WAKE_UP_THRHD : R/W; bitpos: [17:10]; default: 1;
+ *  Configures the number of received data bytes to wake up the chip in wakeup mode 1.
+ */
+#define UART_RX_WAKE_UP_THRHD    0x000000FFU
+#define UART_RX_WAKE_UP_THRHD_M  (UART_RX_WAKE_UP_THRHD_V << UART_RX_WAKE_UP_THRHD_S)
+#define UART_RX_WAKE_UP_THRHD_V  0x000000FFU
+#define UART_RX_WAKE_UP_THRHD_S  10
+/** UART_WK_CHAR_NUM : R/W; bitpos: [20:18]; default: 5;
+ *  Configures the number of wakeup characters.
+ */
+#define UART_WK_CHAR_NUM    0x00000007U
+#define UART_WK_CHAR_NUM_M  (UART_WK_CHAR_NUM_V << UART_WK_CHAR_NUM_S)
+#define UART_WK_CHAR_NUM_V  0x00000007U
+#define UART_WK_CHAR_NUM_S  18
+/** UART_WK_CHAR_MASK : R/W; bitpos: [25:21]; default: 0;
+ *  Configures whether or not to mask wakeup characters.
+ *  0: Not mask
+ *  1: Mask
+ */
+#define UART_WK_CHAR_MASK    0x0000001FU
+#define UART_WK_CHAR_MASK_M  (UART_WK_CHAR_MASK_V << UART_WK_CHAR_MASK_S)
+#define UART_WK_CHAR_MASK_V  0x0000001FU
+#define UART_WK_CHAR_MASK_S  21
+/** UART_WK_MODE_SEL : R/W; bitpos: [27:26]; default: 0;
+ *  Configures which wakeup mode to select.
+ *  0: Mode 0
+ *  1: Mode 1
+ *  2: Mode 2
+ *  3: Mode 3
+ */
+#define UART_WK_MODE_SEL    0x00000003U
+#define UART_WK_MODE_SEL_M  (UART_WK_MODE_SEL_V << UART_WK_MODE_SEL_S)
+#define UART_WK_MODE_SEL_V  0x00000003U
+#define UART_WK_MODE_SEL_S  26
+
+/** UART_SWFC_CONF0_SYNC_REG register
+ *  Software flow control character configuration
+ */
+#define UART_SWFC_CONF0_SYNC_REG(i) (REG_UART_BASE(i) + 0x3c)
+/** UART_XON_CHAR : R/W; bitpos: [7:0]; default: 17;
+ *  Configures the XON character for flow control.
+ */
+#define UART_XON_CHAR    0x000000FFU
+#define UART_XON_CHAR_M  (UART_XON_CHAR_V << UART_XON_CHAR_S)
+#define UART_XON_CHAR_V  0x000000FFU
+#define UART_XON_CHAR_S  0
+/** UART_XOFF_CHAR : R/W; bitpos: [15:8]; default: 19;
+ *  Configures the XOFF character for flow control.
+ */
+#define UART_XOFF_CHAR    0x000000FFU
+#define UART_XOFF_CHAR_M  (UART_XOFF_CHAR_V << UART_XOFF_CHAR_S)
+#define UART_XOFF_CHAR_V  0x000000FFU
+#define UART_XOFF_CHAR_S  8
+/** UART_XON_XOFF_STILL_SEND : R/W; bitpos: [16]; default: 0;
+ *  Configures whether the UART transmitter can send XON or XOFF characters when it is
+ *  disabled.
+ *  0: Cannot send
+ *  1: Can send
+ */
+#define UART_XON_XOFF_STILL_SEND    (BIT(16))
+#define UART_XON_XOFF_STILL_SEND_M  (UART_XON_XOFF_STILL_SEND_V << UART_XON_XOFF_STILL_SEND_S)
+#define UART_XON_XOFF_STILL_SEND_V  0x00000001U
+#define UART_XON_XOFF_STILL_SEND_S  16
+/** UART_SW_FLOW_CON_EN : R/W; bitpos: [17]; default: 0;
+ *  Configures whether or not to enable software flow control.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_SW_FLOW_CON_EN    (BIT(17))
+#define UART_SW_FLOW_CON_EN_M  (UART_SW_FLOW_CON_EN_V << UART_SW_FLOW_CON_EN_S)
+#define UART_SW_FLOW_CON_EN_V  0x00000001U
+#define UART_SW_FLOW_CON_EN_S  17
+/** UART_XONOFF_DEL : R/W; bitpos: [18]; default: 0;
+ *  Configures whether or not to remove flow control characters from the received data.
+ *  0: Not move
+ *  1: Move
+ */
+#define UART_XONOFF_DEL    (BIT(18))
+#define UART_XONOFF_DEL_M  (UART_XONOFF_DEL_V << UART_XONOFF_DEL_S)
+#define UART_XONOFF_DEL_V  0x00000001U
+#define UART_XONOFF_DEL_S  18
+/** UART_FORCE_XON : R/W; bitpos: [19]; default: 0;
+ *  Configures whether the transmitter continues to sending data.
+ *  0: Not send
+ *  1: Send
+ */
+#define UART_FORCE_XON    (BIT(19))
+#define UART_FORCE_XON_M  (UART_FORCE_XON_V << UART_FORCE_XON_S)
+#define UART_FORCE_XON_V  0x00000001U
+#define UART_FORCE_XON_S  19
+/** UART_FORCE_XOFF : R/W; bitpos: [20]; default: 0;
+ *  Configures whether or not to stop the transmitter from sending data.
+ *  0: Not stop
+ *  1: Stop
+ */
+#define UART_FORCE_XOFF    (BIT(20))
+#define UART_FORCE_XOFF_M  (UART_FORCE_XOFF_V << UART_FORCE_XOFF_S)
+#define UART_FORCE_XOFF_V  0x00000001U
+#define UART_FORCE_XOFF_S  20
+/** UART_SEND_XON : R/W/SS/SC; bitpos: [21]; default: 0;
+ *  Configures whether or not to send XON characters.
+ *  0: Not send
+ *  1: Send
+ */
+#define UART_SEND_XON    (BIT(21))
+#define UART_SEND_XON_M  (UART_SEND_XON_V << UART_SEND_XON_S)
+#define UART_SEND_XON_V  0x00000001U
+#define UART_SEND_XON_S  21
+/** UART_SEND_XOFF : R/W/SS/SC; bitpos: [22]; default: 0;
+ *  Configures whether or not to send XOFF characters.
+ *  0: Not send
+ *  1: Send
+ */
+#define UART_SEND_XOFF    (BIT(22))
+#define UART_SEND_XOFF_M  (UART_SEND_XOFF_V << UART_SEND_XOFF_S)
+#define UART_SEND_XOFF_V  0x00000001U
+#define UART_SEND_XOFF_S  22
+
+/** UART_SWFC_CONF1_REG register
+ *  Software flow control character configuration
+ */
+#define UART_SWFC_CONF1_REG(i) (REG_UART_BASE(i) + 0x40)
+/** UART_XON_THRESHOLD : R/W; bitpos: [7:0]; default: 0;
+ *  Configures the threshold for data in RX FIFO to send XON characters in software
+ *  flow control.
+ *  Measurement unit: byte.
+ */
+#define UART_XON_THRESHOLD    0x000000FFU
+#define UART_XON_THRESHOLD_M  (UART_XON_THRESHOLD_V << UART_XON_THRESHOLD_S)
+#define UART_XON_THRESHOLD_V  0x000000FFU
+#define UART_XON_THRESHOLD_S  0
+/** UART_XOFF_THRESHOLD : R/W; bitpos: [15:8]; default: 224;
+ *  Configures the threshold for data in RX FIFO to send XOFF characters in software
+ *  flow control.
+ *  Measurement unit: byte.
+ */
+#define UART_XOFF_THRESHOLD    0x000000FFU
+#define UART_XOFF_THRESHOLD_M  (UART_XOFF_THRESHOLD_V << UART_XOFF_THRESHOLD_S)
+#define UART_XOFF_THRESHOLD_V  0x000000FFU
+#define UART_XOFF_THRESHOLD_S  8
+
+/** UART_TXBRK_CONF_SYNC_REG register
+ *  TX break character configuration
+ */
+#define UART_TXBRK_CONF_SYNC_REG(i) (REG_UART_BASE(i) + 0x44)
+/** UART_TX_BRK_NUM : R/W; bitpos: [7:0]; default: 10;
+ *  Configures the number of NULL characters to be sent after finishing data
+ *  transmission.
+ *  Valid only when UART_TXD_BRK is 1.
+ */
+#define UART_TX_BRK_NUM    0x000000FFU
+#define UART_TX_BRK_NUM_M  (UART_TX_BRK_NUM_V << UART_TX_BRK_NUM_S)
+#define UART_TX_BRK_NUM_V  0x000000FFU
+#define UART_TX_BRK_NUM_S  0
+
+/** UART_IDLE_CONF_SYNC_REG register
+ *  Frame end idle time configuration
+ */
+#define UART_IDLE_CONF_SYNC_REG(i) (REG_UART_BASE(i) + 0x48)
+/** UART_RX_IDLE_THRHD : R/W; bitpos: [9:0]; default: 256;
+ *  Configures the threshold to generate a frame end signal when the receiver takes
+ *  more time to receive one data byte data.
+ *  Measurement unit: bit time (the time to transmit 1 bit).
+ */
+#define UART_RX_IDLE_THRHD    0x000003FFU
+#define UART_RX_IDLE_THRHD_M  (UART_RX_IDLE_THRHD_V << UART_RX_IDLE_THRHD_S)
+#define UART_RX_IDLE_THRHD_V  0x000003FFU
+#define UART_RX_IDLE_THRHD_S  0
+/** UART_TX_IDLE_NUM : R/W; bitpos: [19:10]; default: 256;
+ *  Configures the interval between two data transfers.
+ *  Measurement unit: bit time (the time to transmit 1 bit).
+ */
+#define UART_TX_IDLE_NUM    0x000003FFU
+#define UART_TX_IDLE_NUM_M  (UART_TX_IDLE_NUM_V << UART_TX_IDLE_NUM_S)
+#define UART_TX_IDLE_NUM_V  0x000003FFU
+#define UART_TX_IDLE_NUM_S  10
+
+/** UART_RS485_CONF_SYNC_REG register
+ *  RS485 mode configuration
+ */
+#define UART_RS485_CONF_SYNC_REG(i) (REG_UART_BASE(i) + 0x4c)
+/** UART_RS485_EN : R/W; bitpos: [0]; default: 0;
+ *  Configures whether or not to enable RS485 mode.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_RS485_EN    (BIT(0))
+#define UART_RS485_EN_M  (UART_RS485_EN_V << UART_RS485_EN_S)
+#define UART_RS485_EN_V  0x00000001U
+#define UART_RS485_EN_S  0
+/** UART_DL0_EN : R/W; bitpos: [1]; default: 0;
+ *  Configures whether or not to add a turnaround delay of 1 bit before the start bit.
+ *  0: Not add
+ *  1: Add
+ */
+#define UART_DL0_EN    (BIT(1))
+#define UART_DL0_EN_M  (UART_DL0_EN_V << UART_DL0_EN_S)
+#define UART_DL0_EN_V  0x00000001U
+#define UART_DL0_EN_S  1
+/** UART_DL1_EN : R/W; bitpos: [2]; default: 0;
+ *  Configures whether or not to add a turnaround delay of 1 bit after the stop bit.
+ *  0: Not add
+ *  1: Add
+ */
+#define UART_DL1_EN    (BIT(2))
+#define UART_DL1_EN_M  (UART_DL1_EN_V << UART_DL1_EN_S)
+#define UART_DL1_EN_V  0x00000001U
+#define UART_DL1_EN_S  2
+/** UART_RS485TX_RX_EN : R/W; bitpos: [3]; default: 0;
+ *  Configures whether or not to enable the receiver for data reception when the
+ *  transmitter is transmitting data in RS485 mode.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_RS485TX_RX_EN    (BIT(3))
+#define UART_RS485TX_RX_EN_M  (UART_RS485TX_RX_EN_V << UART_RS485TX_RX_EN_S)
+#define UART_RS485TX_RX_EN_V  0x00000001U
+#define UART_RS485TX_RX_EN_S  3
+/** UART_RS485RXBY_TX_EN : R/W; bitpos: [4]; default: 0;
+ *  Configures whether to enable the RS485 transmitter for data transmission when the
+ *  RS485 receiver is busy.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_RS485RXBY_TX_EN    (BIT(4))
+#define UART_RS485RXBY_TX_EN_M  (UART_RS485RXBY_TX_EN_V << UART_RS485RXBY_TX_EN_S)
+#define UART_RS485RXBY_TX_EN_V  0x00000001U
+#define UART_RS485RXBY_TX_EN_S  4
+/** UART_RS485_RX_DLY_NUM : R/W; bitpos: [5]; default: 0;
+ *  Configures the delay of internal data signals in the receiver.
+ *  Measurement unit: bit time (the time to transmit 1 bit)..
+ */
+#define UART_RS485_RX_DLY_NUM    (BIT(5))
+#define UART_RS485_RX_DLY_NUM_M  (UART_RS485_RX_DLY_NUM_V << UART_RS485_RX_DLY_NUM_S)
+#define UART_RS485_RX_DLY_NUM_V  0x00000001U
+#define UART_RS485_RX_DLY_NUM_S  5
+/** UART_RS485_TX_DLY_NUM : R/W; bitpos: [9:6]; default: 0;
+ *  Configures the delay of internal data signals in the transmitter.
+ *  Measurement unit: bit time (the time to transmit 1 bit).
+ */
+#define UART_RS485_TX_DLY_NUM    0x0000000FU
+#define UART_RS485_TX_DLY_NUM_M  (UART_RS485_TX_DLY_NUM_V << UART_RS485_TX_DLY_NUM_S)
+#define UART_RS485_TX_DLY_NUM_V  0x0000000FU
+#define UART_RS485_TX_DLY_NUM_S  6
+
+/** UART_AT_CMD_PRECNT_SYNC_REG register
+ *  Pre-sequence timing configuration
+ */
+#define UART_AT_CMD_PRECNT_SYNC_REG(i) (REG_UART_BASE(i) + 0x50)
+/** UART_PRE_IDLE_NUM : R/W; bitpos: [15:0]; default: 2305;
+ *  Configures the idle time before the receiver receives the first AT_CMD.
+ *  Measurement unit: bit time (the time to transmit 1 bit).
+ */
+#define UART_PRE_IDLE_NUM    0x0000FFFFU
+#define UART_PRE_IDLE_NUM_M  (UART_PRE_IDLE_NUM_V << UART_PRE_IDLE_NUM_S)
+#define UART_PRE_IDLE_NUM_V  0x0000FFFFU
+#define UART_PRE_IDLE_NUM_S  0
+
+/** UART_AT_CMD_POSTCNT_SYNC_REG register
+ *  Post-sequence timing configuration
+ */
+#define UART_AT_CMD_POSTCNT_SYNC_REG(i) (REG_UART_BASE(i) + 0x54)
+/** UART_POST_IDLE_NUM : R/W; bitpos: [15:0]; default: 2305;
+ *  Configures the interval between the last AT_CMD and subsequent data.
+ *  Measurement unit: bit time (the time to transmit 1 bit).
+ */
+#define UART_POST_IDLE_NUM    0x0000FFFFU
+#define UART_POST_IDLE_NUM_M  (UART_POST_IDLE_NUM_V << UART_POST_IDLE_NUM_S)
+#define UART_POST_IDLE_NUM_V  0x0000FFFFU
+#define UART_POST_IDLE_NUM_S  0
+
+/** UART_AT_CMD_GAPTOUT_SYNC_REG register
+ *  Timeout configuration
+ */
+#define UART_AT_CMD_GAPTOUT_SYNC_REG(i) (REG_UART_BASE(i) + 0x58)
+/** UART_RX_GAP_TOUT : R/W; bitpos: [15:0]; default: 11;
+ *  Configures the interval between two AT_CMD characters.
+ *  Measurement unit: bit time (the time to transmit 1 bit).
+ */
+#define UART_RX_GAP_TOUT    0x0000FFFFU
+#define UART_RX_GAP_TOUT_M  (UART_RX_GAP_TOUT_V << UART_RX_GAP_TOUT_S)
+#define UART_RX_GAP_TOUT_V  0x0000FFFFU
+#define UART_RX_GAP_TOUT_S  0
+
+/** UART_AT_CMD_CHAR_SYNC_REG register
+ *  AT escape sequence detection configuration
+ */
+#define UART_AT_CMD_CHAR_SYNC_REG(i) (REG_UART_BASE(i) + 0x5c)
+/** UART_AT_CMD_CHAR : R/W; bitpos: [7:0]; default: 43;
+ *  Configures the AT_CMD character.
+ */
+#define UART_AT_CMD_CHAR    0x000000FFU
+#define UART_AT_CMD_CHAR_M  (UART_AT_CMD_CHAR_V << UART_AT_CMD_CHAR_S)
+#define UART_AT_CMD_CHAR_V  0x000000FFU
+#define UART_AT_CMD_CHAR_S  0
+/** UART_CHAR_NUM : R/W; bitpos: [15:8]; default: 3;
+ *  Configures the number of continuous AT_CMD characters a receiver can receive.
+ */
+#define UART_CHAR_NUM    0x000000FFU
+#define UART_CHAR_NUM_M  (UART_CHAR_NUM_V << UART_CHAR_NUM_S)
+#define UART_CHAR_NUM_V  0x000000FFU
+#define UART_CHAR_NUM_S  8
+
+/** UART_MEM_CONF_REG register
+ *  UART memory power configuration
+ */
+#define UART_MEM_CONF_REG(i) (REG_UART_BASE(i) + 0x60)
+/** UART_MEM_FORCE_PD : R/W; bitpos: [25]; default: 0;
+ *  Set this bit to force power down UART memory.
+ */
+#define UART_MEM_FORCE_PD    (BIT(25))
+#define UART_MEM_FORCE_PD_M  (UART_MEM_FORCE_PD_V << UART_MEM_FORCE_PD_S)
+#define UART_MEM_FORCE_PD_V  0x00000001U
+#define UART_MEM_FORCE_PD_S  25
+/** UART_MEM_FORCE_PU : R/W; bitpos: [26]; default: 0;
+ *  Set this bit to force power up UART memory.
+ */
+#define UART_MEM_FORCE_PU    (BIT(26))
+#define UART_MEM_FORCE_PU_M  (UART_MEM_FORCE_PU_V << UART_MEM_FORCE_PU_S)
+#define UART_MEM_FORCE_PU_V  0x00000001U
+#define UART_MEM_FORCE_PU_S  26
+
+/** UART_TOUT_CONF_SYNC_REG register
+ *  UART threshold and allocation configuration
+ */
+#define UART_TOUT_CONF_SYNC_REG(i) (REG_UART_BASE(i) + 0x64)
+/** UART_RX_TOUT_EN : R/W; bitpos: [0]; default: 0;
+ *  Configures whether or not to enable UART receiver's timeout function.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_RX_TOUT_EN    (BIT(0))
+#define UART_RX_TOUT_EN_M  (UART_RX_TOUT_EN_V << UART_RX_TOUT_EN_S)
+#define UART_RX_TOUT_EN_V  0x00000001U
+#define UART_RX_TOUT_EN_S  0
+/** UART_RX_TOUT_FLOW_DIS : R/W; bitpos: [1]; default: 0;
+ *  Set this bit to stop accumulating idle_cnt when hardware flow control works.
+ */
+#define UART_RX_TOUT_FLOW_DIS    (BIT(1))
+#define UART_RX_TOUT_FLOW_DIS_M  (UART_RX_TOUT_FLOW_DIS_V << UART_RX_TOUT_FLOW_DIS_S)
+#define UART_RX_TOUT_FLOW_DIS_V  0x00000001U
+#define UART_RX_TOUT_FLOW_DIS_S  1
+/** UART_RX_TOUT_THRHD : R/W; bitpos: [11:2]; default: 10;
+ *  Configures the amount of time that the bus can remain idle before timeout.
+ *  Measurement unit: bit time (the time to transmit 1 bit).
+ */
+#define UART_RX_TOUT_THRHD    0x000003FFU
+#define UART_RX_TOUT_THRHD_M  (UART_RX_TOUT_THRHD_V << UART_RX_TOUT_THRHD_S)
+#define UART_RX_TOUT_THRHD_V  0x000003FFU
+#define UART_RX_TOUT_THRHD_S  2
+
+/** UART_MEM_TX_STATUS_REG register
+ *  TX FIFO write and read offset address
+ */
+#define UART_MEM_TX_STATUS_REG(i) (REG_UART_BASE(i) + 0x68)
+/** UART_TX_SRAM_WADDR : RO; bitpos: [7:0]; default: 0;
+ *  Represents the offset address to write TX FIFO.
+ */
+#define UART_TX_SRAM_WADDR    0x000000FFU
+#define UART_TX_SRAM_WADDR_M  (UART_TX_SRAM_WADDR_V << UART_TX_SRAM_WADDR_S)
+#define UART_TX_SRAM_WADDR_V  0x000000FFU
+#define UART_TX_SRAM_WADDR_S  0
+/** UART_TX_SRAM_RADDR : RO; bitpos: [16:9]; default: 0;
+ *  Represents the offset address to read TX FIFO.
+ */
+#define UART_TX_SRAM_RADDR    0x000000FFU
+#define UART_TX_SRAM_RADDR_M  (UART_TX_SRAM_RADDR_V << UART_TX_SRAM_RADDR_S)
+#define UART_TX_SRAM_RADDR_V  0x000000FFU
+#define UART_TX_SRAM_RADDR_S  9
+
+/** UART_MEM_RX_STATUS_REG register
+ *  Rx FIFO write and read offset address
+ */
+#define UART_MEM_RX_STATUS_REG(i) (REG_UART_BASE(i) + 0x6c)
+/** UART_RX_SRAM_RADDR : RO; bitpos: [7:0]; default: 128;
+ *  Represents the offset address to read RX FIFO.
+ */
+#define UART_RX_SRAM_RADDR    0x000000FFU
+#define UART_RX_SRAM_RADDR_M  (UART_RX_SRAM_RADDR_V << UART_RX_SRAM_RADDR_S)
+#define UART_RX_SRAM_RADDR_V  0x000000FFU
+#define UART_RX_SRAM_RADDR_S  0
+/** UART_RX_SRAM_WADDR : RO; bitpos: [16:9]; default: 128;
+ *  Represents the offset address to write RX FIFO.
+ */
+#define UART_RX_SRAM_WADDR    0x000000FFU
+#define UART_RX_SRAM_WADDR_M  (UART_RX_SRAM_WADDR_V << UART_RX_SRAM_WADDR_S)
+#define UART_RX_SRAM_WADDR_V  0x000000FFU
+#define UART_RX_SRAM_WADDR_S  9
+
+/** UART_FSM_STATUS_REG register
+ *  UART transmit and receive status
+ */
+#define UART_FSM_STATUS_REG(i) (REG_UART_BASE(i) + 0x70)
+/** UART_ST_URX_OUT : RO; bitpos: [3:0]; default: 0;
+ *  Represents the status of the receiver.
+ */
+#define UART_ST_URX_OUT    0x0000000FU
+#define UART_ST_URX_OUT_M  (UART_ST_URX_OUT_V << UART_ST_URX_OUT_S)
+#define UART_ST_URX_OUT_V  0x0000000FU
+#define UART_ST_URX_OUT_S  0
+/** UART_ST_UTX_OUT : RO; bitpos: [7:4]; default: 0;
+ *  Represents the status of the transmitter.
+ */
+#define UART_ST_UTX_OUT    0x0000000FU
+#define UART_ST_UTX_OUT_M  (UART_ST_UTX_OUT_V << UART_ST_UTX_OUT_S)
+#define UART_ST_UTX_OUT_V  0x0000000FU
+#define UART_ST_UTX_OUT_S  4
+
+/** UART_POSPULSE_REG register
+ *  Autobaud high pulse register
+ */
+#define UART_POSPULSE_REG(i) (REG_UART_BASE(i) + 0x74)
+/** UART_POSEDGE_MIN_CNT : RO; bitpos: [11:0]; default: 4095;
+ *  Represents the minimal input clock counter value between two positive edges. It is
+ *  used for baud rate detection.
+ */
+#define UART_POSEDGE_MIN_CNT    0x00000FFFU
+#define UART_POSEDGE_MIN_CNT_M  (UART_POSEDGE_MIN_CNT_V << UART_POSEDGE_MIN_CNT_S)
+#define UART_POSEDGE_MIN_CNT_V  0x00000FFFU
+#define UART_POSEDGE_MIN_CNT_S  0
+
+/** UART_NEGPULSE_REG register
+ *  Autobaud low pulse register
+ */
+#define UART_NEGPULSE_REG(i) (REG_UART_BASE(i) + 0x78)
+/** UART_NEGEDGE_MIN_CNT : RO; bitpos: [11:0]; default: 4095;
+ *  Represents the minimal input clock counter value between two negative edges. It is
+ *  used for baud rate detection.
+ */
+#define UART_NEGEDGE_MIN_CNT    0x00000FFFU
+#define UART_NEGEDGE_MIN_CNT_M  (UART_NEGEDGE_MIN_CNT_V << UART_NEGEDGE_MIN_CNT_S)
+#define UART_NEGEDGE_MIN_CNT_V  0x00000FFFU
+#define UART_NEGEDGE_MIN_CNT_S  0
+
+/** UART_LOWPULSE_REG register
+ *  Autobaud minimum low pulse duration register
+ */
+#define UART_LOWPULSE_REG(i) (REG_UART_BASE(i) + 0x7c)
+/** UART_LOWPULSE_MIN_CNT : RO; bitpos: [11:0]; default: 4095;
+ *  Represents the minimum duration time of a low-level pulse. It is used for baud rate
+ *  detection.
+ *  Measurement unit: APB_CLK clock cycle.
+ */
+#define UART_LOWPULSE_MIN_CNT    0x00000FFFU
+#define UART_LOWPULSE_MIN_CNT_M  (UART_LOWPULSE_MIN_CNT_V << UART_LOWPULSE_MIN_CNT_S)
+#define UART_LOWPULSE_MIN_CNT_V  0x00000FFFU
+#define UART_LOWPULSE_MIN_CNT_S  0
+
+/** UART_HIGHPULSE_REG register
+ *  Autobaud minimum high pulse duration register
+ */
+#define UART_HIGHPULSE_REG(i) (REG_UART_BASE(i) + 0x80)
+/** UART_HIGHPULSE_MIN_CNT : RO; bitpos: [11:0]; default: 4095;
+ *  Represents  the maximum duration time for a high-level pulse. It is used for baud
+ *  rate detection.
+ *  Measurement unit: APB_CLK clock cycle.
+ */
+#define UART_HIGHPULSE_MIN_CNT    0x00000FFFU
+#define UART_HIGHPULSE_MIN_CNT_M  (UART_HIGHPULSE_MIN_CNT_V << UART_HIGHPULSE_MIN_CNT_S)
+#define UART_HIGHPULSE_MIN_CNT_V  0x00000FFFU
+#define UART_HIGHPULSE_MIN_CNT_S  0
+
+/** UART_RXD_CNT_REG register
+ *  Autobaud edge change count register
+ */
+#define UART_RXD_CNT_REG(i) (REG_UART_BASE(i) + 0x84)
+/** UART_RXD_EDGE_CNT : RO; bitpos: [9:0]; default: 0;
+ *  Represents the number of RXD edge changes. It is used for baud rate detection.
+ */
+#define UART_RXD_EDGE_CNT    0x000003FFU
+#define UART_RXD_EDGE_CNT_M  (UART_RXD_EDGE_CNT_V << UART_RXD_EDGE_CNT_S)
+#define UART_RXD_EDGE_CNT_V  0x000003FFU
+#define UART_RXD_EDGE_CNT_S  0
+
+/** UART_CLK_CONF_REG register
+ *  UART core clock configuration
+ */
+#define UART_CLK_CONF_REG(i) (REG_UART_BASE(i) + 0x88)
+/** UART_TX_SCLK_EN : R/W; bitpos: [24]; default: 1;
+ *  Configures whether or not to enable UART TX clock.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_TX_SCLK_EN    (BIT(24))
+#define UART_TX_SCLK_EN_M  (UART_TX_SCLK_EN_V << UART_TX_SCLK_EN_S)
+#define UART_TX_SCLK_EN_V  0x00000001U
+#define UART_TX_SCLK_EN_S  24
+/** UART_RX_SCLK_EN : R/W; bitpos: [25]; default: 1;
+ *  Configures whether or not to enable UART RX clock.
+ *  0: Disable
+ *  1: Enable
+ */
+#define UART_RX_SCLK_EN    (BIT(25))
+#define UART_RX_SCLK_EN_M  (UART_RX_SCLK_EN_V << UART_RX_SCLK_EN_S)
+#define UART_RX_SCLK_EN_V  0x00000001U
+#define UART_RX_SCLK_EN_S  25
+/** UART_TX_RST_CORE : R/W; bitpos: [26]; default: 0;
+ *  Write 1 and then write 0 to reset UART TX.
+ */
+#define UART_TX_RST_CORE    (BIT(26))
+#define UART_TX_RST_CORE_M  (UART_TX_RST_CORE_V << UART_TX_RST_CORE_S)
+#define UART_TX_RST_CORE_V  0x00000001U
+#define UART_TX_RST_CORE_S  26
+/** UART_RX_RST_CORE : R/W; bitpos: [27]; default: 0;
+ *  Write 1 and then write 0 to reset UART RX.
+ */
+#define UART_RX_RST_CORE    (BIT(27))
+#define UART_RX_RST_CORE_M  (UART_RX_RST_CORE_V << UART_RX_RST_CORE_S)
+#define UART_RX_RST_CORE_V  0x00000001U
+#define UART_RX_RST_CORE_S  27
+
+/** UART_DATE_REG register
+ *  UART version control register
+ */
+#define UART_DATE_REG(i) (REG_UART_BASE(i) + 0x8c)
+/** UART_DATE : R/W; bitpos: [31:0]; default: 36774432;
+ *  Version control register.
+ */
+#define UART_DATE    0xFFFFFFFFU
+#define UART_DATE_M  (UART_DATE_V << UART_DATE_S)
+#define UART_DATE_V  0xFFFFFFFFU
+#define UART_DATE_S  0
+
+/** UART_AFIFO_STATUS_REG register
+ *  UART asynchronous FIFO status
+ */
+#define UART_AFIFO_STATUS_REG(i) (REG_UART_BASE(i) + 0x90)
+/** UART_TX_AFIFO_FULL : RO; bitpos: [0]; default: 0;
+ *  Represents whether or not the APB TX asynchronous FIFO is full.
+ *  0: Not full
+ *  1: Full
+ */
+#define UART_TX_AFIFO_FULL    (BIT(0))
+#define UART_TX_AFIFO_FULL_M  (UART_TX_AFIFO_FULL_V << UART_TX_AFIFO_FULL_S)
+#define UART_TX_AFIFO_FULL_V  0x00000001U
+#define UART_TX_AFIFO_FULL_S  0
+/** UART_TX_AFIFO_EMPTY : RO; bitpos: [1]; default: 1;
+ *  Represents whether or not the APB TX asynchronous FIFO is empty.
+ *  0: Not empty
+ *  1: Empty
+ */
+#define UART_TX_AFIFO_EMPTY    (BIT(1))
+#define UART_TX_AFIFO_EMPTY_M  (UART_TX_AFIFO_EMPTY_V << UART_TX_AFIFO_EMPTY_S)
+#define UART_TX_AFIFO_EMPTY_V  0x00000001U
+#define UART_TX_AFIFO_EMPTY_S  1
+/** UART_RX_AFIFO_FULL : RO; bitpos: [2]; default: 0;
+ *  Represents whether or not the APB RX asynchronous FIFO is full.
+ *  0: Not full
+ *  1: Full
+ */
+#define UART_RX_AFIFO_FULL    (BIT(2))
+#define UART_RX_AFIFO_FULL_M  (UART_RX_AFIFO_FULL_V << UART_RX_AFIFO_FULL_S)
+#define UART_RX_AFIFO_FULL_V  0x00000001U
+#define UART_RX_AFIFO_FULL_S  2
+/** UART_RX_AFIFO_EMPTY : RO; bitpos: [3]; default: 1;
+ *  Represents whether or not the APB RX asynchronous FIFO is empty.
+ *  0: Not empty
+ *  1: Empty
+ */
+#define UART_RX_AFIFO_EMPTY    (BIT(3))
+#define UART_RX_AFIFO_EMPTY_M  (UART_RX_AFIFO_EMPTY_V << UART_RX_AFIFO_EMPTY_S)
+#define UART_RX_AFIFO_EMPTY_V  0x00000001U
+#define UART_RX_AFIFO_EMPTY_S  3
+
+/** UART_REG_UPDATE_REG register
+ *  UART register configuration update
+ */
+#define UART_REG_UPDATE_REG(i) (REG_UART_BASE(i) + 0x98)
+/** UART_REG_UPDATE : R/W/SC; bitpos: [0]; default: 0;
+ *  Configures whether or not to synchronize registers.
+ *  0: Not synchronize
+ *  1: Synchronize
+ */
+#define UART_REG_UPDATE    (BIT(0))
+#define UART_REG_UPDATE_M  (UART_REG_UPDATE_V << UART_REG_UPDATE_S)
+#define UART_REG_UPDATE_V  0x00000001U
+#define UART_REG_UPDATE_S  0
+
+/** UART_ID_REG register
+ *  UART ID register
+ */
+#define UART_ID_REG(i) (REG_UART_BASE(i) + 0x9c)
+/** UART_ID : R/W; bitpos: [31:0]; default: 1280;
+ *  Configures the UART ID.
+ */
+#define UART_ID    0xFFFFFFFFU
+#define UART_ID_M  (UART_ID_V << UART_ID_S)
+#define UART_ID_V  0xFFFFFFFFU
+#define UART_ID_S  0
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/target/esp32s31/ld/esp32s31.rom.api.ld
+++ b/src/target/esp32s31/ld/esp32s31.rom.api.ld
@@ -1,0 +1,67 @@
+/** ROM APIs
+ */
+
+PROVIDE ( esp_rom_crc32_le = crc32_le );
+PROVIDE ( esp_rom_crc16_le = crc16_le );
+PROVIDE ( esp_rom_crc8_le  = crc8_le );
+PROVIDE ( esp_rom_crc32_be = crc32_be );
+PROVIDE ( esp_rom_crc16_be = crc16_be );
+PROVIDE ( esp_rom_crc8_be  = crc8_be );
+
+PROVIDE ( esp_rom_gpio_pad_select_gpio    = rom_gpio_pad_select_gpio );
+PROVIDE ( esp_rom_gpio_pad_pullup_only    = rom_gpio_pad_pullup );
+PROVIDE ( esp_rom_gpio_pad_set_drv        = rom_gpio_pad_set_drv );
+PROVIDE ( esp_rom_gpio_pad_unhold         = rom_gpio_pad_unhold );
+PROVIDE ( esp_rom_gpio_connect_in_signal  = rom_gpio_matrix_in );
+PROVIDE ( esp_rom_gpio_connect_out_signal = rom_gpio_matrix_out );
+
+PROVIDE ( esp_rom_efuse_mac_address_crc8       = esp_crc8 );
+PROVIDE ( esp_rom_efuse_is_secure_boot_enabled = ets_efuse_secure_boot_enabled );
+PROVIDE ( esp_rom_efuse_flash_encryption_enabled = ets_efuse_cache_encryption_enabled );
+
+PROVIDE ( esp_rom_uart_flush_tx       = uart_tx_flush );
+PROVIDE ( esp_rom_uart_tx_one_char    = uart_tx_one_char2 );
+PROVIDE ( esp_rom_uart_tx_wait_idle   = uart_tx_wait_idle );
+PROVIDE ( esp_rom_uart_rx_one_char    = uart_rx_one_char );
+PROVIDE ( esp_rom_uart_rx_string      = UartRxString );
+PROVIDE ( esp_rom_uart_set_as_console = uart_tx_switch );
+PROVIDE ( esp_rom_uart_putc           = ets_write_char_uart );
+PROVIDE ( esp_rom_uart_attach         = uartAttach );
+PROVIDE ( esp_rom_uart_init           = Uart_Init );
+
+PROVIDE ( esp_rom_usb_serial_putc     = uart_tx_one_char3 );
+
+PROVIDE ( esp_rom_output_flush_tx       = uart_tx_flush );
+PROVIDE ( esp_rom_output_tx_one_char    = uart_tx_one_char );
+PROVIDE ( esp_rom_output_tx_wait_idle   = uart_tx_wait_idle );
+PROVIDE ( esp_rom_output_rx_one_char    = uart_rx_one_char );
+PROVIDE ( esp_rom_output_rx_string      = UartRxString );
+PROVIDE ( esp_rom_output_set_as_console = uart_tx_switch );
+PROVIDE ( esp_rom_output_putc           = ets_write_char_uart );
+
+PROVIDE ( esp_rom_get_xtal_freq = ets_clk_get_xtal_freq );
+
+PROVIDE ( esp_rom_md5_init   = MD5Init );
+PROVIDE ( esp_rom_md5_update = MD5Update );
+PROVIDE ( esp_rom_md5_final  = MD5Final );
+
+PROVIDE ( esp_rom_software_reset_system = software_reset );
+PROVIDE ( esp_rom_software_reset_cpu    = software_reset_cpu );
+
+PROVIDE ( esp_rom_printf   = ets_printf );
+PROVIDE ( esp_rom_install_uart_printf = ets_install_uart_printf );
+PROVIDE ( esp_rom_delay_us = ets_delay_us );
+PROVIDE ( esp_rom_get_reset_reason = rtc_get_reset_reason );
+PROVIDE ( esp_rom_route_intr_matrix = intr_matrix_set );
+PROVIDE ( esp_rom_get_cpu_ticks_per_us = ets_get_cpu_frequency );
+PROVIDE ( esp_rom_set_cpu_ticks_per_us = ets_update_cpu_frequency );
+
+PROVIDE ( esp_rom_spiflash_attach = spi_flash_attach );
+PROVIDE ( esp_rom_spiflash_clear_bp = esp_rom_spiflash_unlock );
+PROVIDE ( esp_rom_spiflash_write_enable = SPI_write_enable );
+PROVIDE ( esp_rom_spiflash_erase_area = SPIEraseArea );
+
+PROVIDE ( esp_rom_spiflash_fix_dummylen = spi_dummy_len_fix );
+PROVIDE ( esp_rom_spiflash_set_drvs = SetSpiDrvs);
+PROVIDE ( esp_rom_spiflash_select_padsfunc = SelectSpiFunction );
+PROVIDE ( esp_rom_spiflash_common_cmd = SPI_Common_Command );

--- a/src/target/esp32s31/ld/esp32s31.rom.ld
+++ b/src/target/esp32s31/ld/esp32s31.rom.ld
@@ -1,0 +1,607 @@
+/* ROM function interface esp32s31.rom.ld for esp32s31
+ *
+ *
+ * Generated from ../../rom/target/esp32s31/interface-esp32s31.yml md5sum 0cb775308c66eebf0757e406021ad5be
+ *
+ * Compatible with ROM where ECO version equal or greater to 0.
+ *
+ * THIS FILE WAS AUTOMATICALLY GENERATED. DO NOT EDIT.
+ */
+
+/***************************************
+ Group common
+ ***************************************/
+
+/* Functions */
+rtc_get_reset_reason = 0x2f800018;
+rtc_get_wakeup_cause = 0x2f80001c;
+pmu_enable_unhold_pads = 0x2f800020;
+ets_printf = 0x2f800024;
+ets_install_putc1 = 0x2f800028;
+ets_install_putc2 = 0x2f80002c;
+ets_install_uart_printf = 0x2f800030;
+ets_install_usb_printf = 0x2f800034;
+ets_get_printf_channel = 0x2f800038;
+ets_delay_us = 0x2f80003c;
+ets_get_cpu_frequency = 0x2f800040;
+ets_update_cpu_frequency = 0x2f800044;
+ets_install_lock = 0x2f800048;
+UartRxString = 0x2f80004c;
+UartGetCmdLn = 0x2f800050;
+uart_tx_one_char = 0x2f800054;
+uart_tx_one_char2 = 0x2f800058;
+uart_tx_one_char3 = 0x2f80005c;
+uart_rx_one_char = 0x2f800060;
+uart_rx_one_char_block = 0x2f800064;
+uart_rx_intr_handler = 0x2f800068;
+uart_rx_readbuff = 0x2f80006c;
+uartAttach = 0x2f800070;
+uart_tx_flush = 0x2f800074;
+uart_tx_wait_idle = 0x2f800078;
+uart_div_modify = 0x2f80007c;
+ets_write_char_uart = 0x2f800080;
+uart_tx_switch = 0x2f800084;
+uart_buff_switch = 0x2f800088;
+roundup2 = 0x2f80008c;
+multofup = 0x2f800090;
+software_reset = 0x2f800094;
+software_reset_cpu = 0x2f800098;
+ets_clk_assist_debug_clock_enable = 0x2f80009c;
+clear_super_wdt_reset_flag = 0x2f8000a0;
+disable_default_watchdog = 0x2f8000a4;
+ets_set_appcpu_boot_addr = 0x2f8000a8;
+esp_rom_set_rtc_wake_addr = 0x2f8000ac;
+esp_rom_get_rtc_wake_addr = 0x2f8000b0;
+send_packet = 0x2f8000b4;
+recv_packet = 0x2f8000b8;
+GetUartDevice = 0x2f8000bc;
+UartDwnLdProc = 0x2f8000c0;
+GetSecurityInfoProc = 0x2f8000c4;
+Uart_Init = 0x2f8000c8;
+ets_set_user_start = 0x2f8000cc;
+/* Data (.data, .bss, .rodata) */
+ets_rom_layout_p = 0x2f84fffc;
+ets_ops_table_ptr = 0x2f07fff4;
+g_saved_pc = 0x2f07fff8;
+
+
+/***************************************
+ Group miniz
+ ***************************************/
+
+/* Functions */
+mz_adler32 = 0x2f8000d0;
+mz_free = 0x2f8000d4;
+tdefl_compress = 0x2f8000d8;
+tdefl_compress_buffer = 0x2f8000dc;
+tdefl_compress_mem_to_heap = 0x2f8000e0;
+tdefl_compress_mem_to_mem = 0x2f8000e4;
+tdefl_compress_mem_to_output = 0x2f8000e8;
+tdefl_get_adler32 = 0x2f8000ec;
+tdefl_get_prev_return_status = 0x2f8000f0;
+tdefl_init = 0x2f8000f4;
+tdefl_write_image_to_png_file_in_memory = 0x2f8000f8;
+tdefl_write_image_to_png_file_in_memory_ex = 0x2f8000fc;
+tinfl_decompress = 0x2f800100;
+tinfl_decompress_mem_to_callback = 0x2f800104;
+tinfl_decompress_mem_to_heap = 0x2f800108;
+tinfl_decompress_mem_to_mem = 0x2f80010c;
+
+
+/***************************************
+ Group tjpgd
+ ***************************************/
+
+/* Functions */
+jd_prepare = 0x2f800110;
+jd_decomp = 0x2f800114;
+
+
+/***************************************
+ Group esp_dsp
+ ***************************************/
+
+/* Data (.data, .bss, .rodata) */
+dsps_fft2r_w_table_fc32_1024 = 0x2f07fff0;
+
+
+/***************************************
+ Group spi_common_usr_cmd
+ ***************************************/
+
+/* Functions */
+esp_rom_opiflash_exec_cmd = 0x2f800118;
+/* Data (.data, .bss, .rodata) */
+rom_spi_usr_cmd_legacy_funcs = 0x2f07ffec;
+
+
+/***************************************
+ Group spi_extmem_common
+ ***************************************/
+
+/* Functions */
+esp_rom_spi_cmd_config = 0x2f80011c;
+esp_rom_spi_cmd_start = 0x2f800120;
+esp_rom_spi_set_op_mode = 0x2f800124;
+esp_rom_spi_set_dtr_swap_mode = 0x2f800128;
+
+
+/***************************************
+ Group spiflash_legacy
+ ***************************************/
+
+/* Functions */
+esp_rom_spiflash_wait_idle = 0x2f80012c;
+esp_rom_spiflash_write_encrypted = 0x2f800130;
+esp_rom_spiflash_write_encrypted_dest = 0x2f800134;
+esp_rom_spiflash_write_encrypted_enable = 0x2f800138;
+esp_rom_spiflash_write_encrypted_disable = 0x2f80013c;
+esp_rom_spiflash_erase_chip = 0x2f800140;
+_esp_rom_spiflash_erase_sector = 0x2f800144;
+_esp_rom_spiflash_erase_block = 0x2f800148;
+_esp_rom_spiflash_write = 0x2f80014c;
+_esp_rom_spiflash_read = 0x2f800150;
+_esp_rom_spiflash_unlock = 0x2f800154;
+_SPIEraseArea = 0x2f800158;
+_SPI_write_enable = 0x2f80015c;
+esp_rom_spiflash_erase_sector = 0x2f800160;
+esp_rom_spiflash_erase_block = 0x2f800164;
+esp_rom_spiflash_write = 0x2f800168;
+esp_rom_spiflash_read = 0x2f80016c;
+esp_rom_spiflash_unlock = 0x2f800170;
+SPIEraseArea = 0x2f800174;
+SPI_write_enable = 0x2f800178;
+esp_rom_spiflash_config_param = 0x2f80017c;
+esp_rom_spiflash_read_user_cmd = 0x2f800180;
+esp_rom_spiflash_select_qio_pins = 0x2f800184;
+esp_rom_spi_flash_auto_sus_res = 0x2f800188;
+esp_rom_spiflash_cache_mode_config = 0x2f80018c;
+esp_rom_spi_flash_send_resume = 0x2f800190;
+esp_rom_spi_flash_update_id = 0x2f800194;
+esp_rom_spiflash_config_clk = 0x2f800198;
+esp_rom_spiflash_config_readmode = 0x2f80019c;
+esp_rom_spiflash_read_status = 0x2f8001a0;
+esp_rom_spiflash_read_statushigh = 0x2f8001a4;
+esp_rom_spiflash_write_status = 0x2f8001a8;
+esp_rom_spiflash_write_disable = 0x2f8001ac;
+spi_cache_mode_switch = 0x2f8001b0;
+spi_common_set_dummy_output = 0x2f8001b4;
+spi_common_set_flash_cs_timing = 0x2f8001b8;
+esp_rom_spi_set_address_bit_len = 0x2f8001bc;
+SPILock = 0x2f8001c0;
+SPIMasterReadModeCnfig = 0x2f8001c4;
+SPI_Common_Command = 0x2f8001c8;
+SPI_WakeUp = 0x2f8001cc;
+SPI_block_erase = 0x2f8001d0;
+SPI_chip_erase = 0x2f8001d4;
+SPI_init = 0x2f8001d8;
+SPI_page_program = 0x2f8001dc;
+SPI_read_data = 0x2f8001e0;
+SPI_sector_erase = 0x2f8001e4;
+SelectSpiFunction = 0x2f8001e8;
+SetSpiDrvs = 0x2f8001ec;
+Wait_SPI_Idle = 0x2f8001f0;
+spi_dummy_len_fix = 0x2f8001f4;
+Disable_QMode = 0x2f8001f8;
+Enable_QMode = 0x2f8001fc;
+spi_flash_attach = 0x2f800200;
+spi_flash_get_chip_size = 0x2f800204;
+spi_flash_guard_set = 0x2f800208;
+spi_flash_guard_get = 0x2f80020c;
+spi_flash_read_encrypted = 0x2f800210;
+/* Data (.data, .bss, .rodata) */
+rom_spiflash_legacy_funcs = 0x2f07ffe4;
+rom_spiflash_legacy_data = 0x2f07ffe0;
+g_flash_guard_ops = 0x2f07ffe8;
+
+
+/***************************************
+ Group cache
+ ***************************************/
+
+/* Functions */
+Cache_Get_L1_ICache_Line_Size = 0x2f8005d0;
+Cache_Get_L1_DCache_Line_Size = 0x2f8005d4;
+Cache_Get_Mode = 0x2f8005d8;
+Cache_Address_Through_Cache = 0x2f8005dc;
+ROM_Boot_Cache_Init = 0x2f8005e0;
+Cache_Sync_Addr = 0x2f8005e4;
+Cache_Invalidate_Addr = 0x2f8005e8;
+Cache_Clean_Addr = 0x2f8005ec;
+Cache_WriteBack_Addr = 0x2f8005f0;
+Cache_WriteBack_Invalidate_Addr = 0x2f8005f4;
+Cache_Invalidate_All = 0x2f8005f8;
+Cache_Clean_All = 0x2f8005fc;
+Cache_WriteBack_All = 0x2f800600;
+Cache_WriteBack_Invalidate_All = 0x2f800604;
+Cache_Mask_All = 0x2f800608;
+Cache_Suspend_L1_CORE0_ICache_Autoload = 0x2f80060c;
+Cache_Resume_L1_CORE0_ICache_Autoload = 0x2f800610;
+Cache_Suspend_L1_CORE1_ICache_Autoload = 0x2f800614;
+Cache_Resume_L1_CORE1_ICache_Autoload = 0x2f800618;
+Cache_Suspend_L1_DCache_Autoload = 0x2f80061c;
+Cache_Resume_L1_DCache_Autoload = 0x2f800620;
+Cache_Start_L1_CORE0_ICache_Preload = 0x2f800624;
+Cache_L1_CORE0_ICache_Preload_Done = 0x2f800628;
+Cache_End_L1_CORE0_ICache_Preload = 0x2f80062c;
+Cache_Start_L1_CORE1_ICache_Preload = 0x2f800630;
+Cache_L1_CORE1_ICache_Preload_Done = 0x2f800634;
+Cache_End_L1_CORE1_ICache_Preload = 0x2f800638;
+Cache_Start_L1_DCache_Preload = 0x2f80063c;
+Cache_L1_DCache_Preload_Done = 0x2f800640;
+Cache_End_L1_DCache_Preload = 0x2f800644;
+Cache_Config_L1_CORE0_ICache_Autoload = 0x2f800648;
+Cache_Enable_L1_CORE0_ICache_Autoload = 0x2f80064c;
+Cache_Disable_L1_CORE0_ICache_Autoload = 0x2f800650;
+Cache_Config_L1_CORE1_ICache_Autoload = 0x2f800654;
+Cache_Enable_L1_CORE1_ICache_Autoload = 0x2f800658;
+Cache_Disable_L1_CORE1_ICache_Autoload = 0x2f80065c;
+Cache_Config_L1_DCache_Autoload = 0x2f800660;
+Cache_Enable_L1_DCache_Autoload = 0x2f800664;
+Cache_Disable_L1_DCache_Autoload = 0x2f800668;
+Cache_Enable_L1_CORE0_ICache_PreLock = 0x2f80066c;
+Cache_Disable_L1_CORE0_ICache_PreLock = 0x2f800670;
+Cache_Enable_L1_CORE1_ICache_PreLock = 0x2f800674;
+Cache_Disable_L1_CORE1_ICache_PreLock = 0x2f800678;
+Cache_Enable_L1_DCache_PreLock = 0x2f80067c;
+Cache_Disable_L1_DCache_PreLock = 0x2f800680;
+Cache_Lock_Addr = 0x2f800684;
+Cache_Unlock_Addr = 0x2f800688;
+Cache_Disable_L1_CORE0_ICache = 0x2f80068c;
+Cache_Enable_L1_CORE0_ICache = 0x2f800690;
+Cache_Suspend_L1_CORE0_ICache = 0x2f800694;
+Cache_Resume_L1_CORE0_ICache = 0x2f800698;
+Cache_Disable_L1_CORE1_ICache = 0x2f80069c;
+Cache_Enable_L1_CORE1_ICache = 0x2f8006a0;
+Cache_Suspend_L1_CORE1_ICache = 0x2f8006a4;
+Cache_Resume_L1_CORE1_ICache = 0x2f8006a8;
+Cache_Disable_L1_DCache = 0x2f8006ac;
+Cache_Enable_L1_DCache = 0x2f8006b0;
+Cache_Suspend_L1_DCache = 0x2f8006b4;
+Cache_Resume_L1_DCache = 0x2f8006b8;
+Cache_FLASH_MMU_Init = 0x2f8006bc;
+Cache_PSRAM_MMU_Init = 0x2f8006c0;
+Cache_FLASH_MMU_Set = 0x2f8006c4;
+Cache_FLASH_MMU_Set_Secure = 0x2f8006c8;
+Cache_PSRAM_MMU_Set = 0x2f8006cc;
+Cache_PSRAM_MMU_Set_Secure = 0x2f8006d0;
+Cache_Count_Flash_Pages = 0x2f8006d4;
+Cache_Flash_To_SPIRAM_Copy = 0x2f8006d8;
+Cache_Travel_Tag_Memory = 0x2f8006dc;
+Cache_Travel_Tag_Memory2 = 0x2f8006e0;
+Cache_Get_Virtual_Addr = 0x2f8006e4;
+Cache_Set_IDROM_MMU_Size = 0x2f8006e8;
+flash2spiram_instruction_offset = 0x2f8006ec;
+flash2spiram_rodata_offset = 0x2f8006f0;
+flash_instr_rodata_start_page = 0x2f8006f4;
+flash_instr_rodata_end_page = 0x2f8006f8;
+Cache_Set_IDROM_MMU_Info = 0x2f8006fc;
+Cache_Get_IROM_MMU_End = 0x2f800700;
+Cache_Get_DROM_MMU_End = 0x2f800704;
+/* Data (.data, .bss, .rodata) */
+rom_cache_op_cb = 0x2f07ffc0;
+rom_cache_internal_table_ptr = 0x2f07ffbc;
+
+
+/***************************************
+ Group clock
+ ***************************************/
+
+/* Functions */
+ets_clk_get_xtal_freq = 0x2f800708;
+ets_clk_get_cpu_freq = 0x2f80070c;
+
+
+/***************************************
+ Group gpio
+ ***************************************/
+
+/* Functions */
+rom_gpio_set_output_level = 0x2f800710;
+rom_gpio_get_input_level = 0x2f800714;
+rom_gpio_matrix_in = 0x2f800718;
+rom_gpio_matrix_out = 0x2f80071c;
+rom_gpio_bypass_matrix_in = 0x2f800720;
+rom_gpio_output_disable = 0x2f800724;
+rom_gpio_output_enable = 0x2f800728;
+rom_gpio_pad_input_disable = 0x2f80072c;
+rom_gpio_pad_input_enable = 0x2f800730;
+rom_gpio_pad_pulldown = 0x2f800734;
+rom_gpio_pad_pullup = 0x2f800738;
+rom_gpio_pad_select_gpio = 0x2f80073c;
+rom_gpio_pad_set_drv = 0x2f800740;
+rom_gpio_pad_unhold = 0x2f800744;
+rom_gpio_pad_hold = 0x2f800748;
+rom_gpio_lppad_select_mux = 0x2f80074c;
+
+
+/***************************************
+ Group interrupts
+ ***************************************/
+
+/* Functions */
+esprv_intc_int_set_priority = 0x2f800750;
+esprv_intc_int_set_threshold = 0x2f800754;
+esprv_intc_int_enable = 0x2f800758;
+esprv_intc_int_disable = 0x2f80075c;
+esprv_intc_int_set_type = 0x2f800760;
+PROVIDE( intr_handler_set = 0x2f800764 );
+intr_matrix_set = 0x2f800768;
+ets_intr_register_ctx = 0x2f80076c;
+ets_intr_lock = 0x2f800770;
+ets_intr_unlock = 0x2f800774;
+ets_isr_attach = 0x2f800778;
+ets_isr_mask = 0x2f80077c;
+ets_isr_unmask = 0x2f800780;
+
+
+/***************************************
+ Group crc
+ ***************************************/
+
+/* Functions */
+crc32_le = 0x2f800784;
+crc16_le = 0x2f800788;
+crc8_le = 0x2f80078c;
+crc32_be = 0x2f800790;
+crc16_be = 0x2f800794;
+crc8_be = 0x2f800798;
+esp_crc8 = 0x2f80079c;
+/* Data (.data, .bss, .rodata) */
+crc32_le_table_ptr = 0x2f84fff8;
+crc16_le_table_ptr = 0x2f84fff4;
+crc8_le_table_ptr = 0x2f84fff0;
+crc32_be_table_ptr = 0x2f84ffec;
+crc16_be_table_ptr = 0x2f84ffe8;
+crc8_be_table_ptr = 0x2f84ffe4;
+
+
+/***************************************
+ Group md5
+ ***************************************/
+
+/* Functions */
+md5_vector = 0x2f8007a0;
+MD5Init = 0x2f8007a4;
+MD5Update = 0x2f8007a8;
+MD5Final = 0x2f8007ac;
+
+
+/***************************************
+ Group hwcrypto
+ ***************************************/
+
+/* Functions */
+ets_sha_enable = 0x2f8007b0;
+ets_sha_disable = 0x2f8007b4;
+ets_sha_get_state = 0x2f8007b8;
+ets_sha_init = 0x2f8007bc;
+ets_sha_process = 0x2f8007c0;
+ets_sha_starts = 0x2f8007c4;
+ets_sha_update = 0x2f8007c8;
+ets_sha_finish = 0x2f8007cc;
+ets_sha_clone = 0x2f8007d0;
+ets_hmac_enable = 0x2f8007d4;
+ets_hmac_disable = 0x2f8007d8;
+ets_hmac_calculate_message = 0x2f8007dc;
+ets_hmac_calculate_downstream = 0x2f8007e0;
+ets_hmac_invalidate_downstream = 0x2f8007e4;
+ets_aes_enable = 0x2f8007e8;
+ets_aes_disable = 0x2f8007ec;
+ets_aes_setkey = 0x2f8007f0;
+ets_aes_block = 0x2f8007f4;
+ets_aes_setkey_dec = 0x2f8007f8;
+ets_aes_setkey_enc = 0x2f8007fc;
+ets_bigint_enable = 0x2f800800;
+ets_bigint_disable = 0x2f800804;
+ets_bigint_multiply = 0x2f800808;
+ets_bigint_modmult = 0x2f80080c;
+ets_bigint_modexp = 0x2f800810;
+ets_bigint_wait_finish = 0x2f800814;
+ets_bigint_getz = 0x2f800818;
+ets_ds_enable = 0x2f80081c;
+ets_ds_disable = 0x2f800820;
+ets_ds_start_sign = 0x2f800824;
+ets_ds_is_busy = 0x2f800828;
+ets_ds_finish_sign = 0x2f80082c;
+ets_ds_encrypt_params = 0x2f800830;
+
+
+/***************************************
+ Group efuse
+ ***************************************/
+
+/* Functions */
+ets_efuse_read = 0x2f800834;
+ets_efuse_program = 0x2f800838;
+ets_efuse_clear_program_registers = 0x2f80083c;
+ets_efuse_write_key = 0x2f800840;
+ets_efuse_get_read_register_address = 0x2f800844;
+ets_efuse_get_key_purpose = 0x2f800848;
+ets_efuse_key_block_unused = 0x2f80084c;
+ets_efuse_find_unused_key_block = 0x2f800850;
+ets_efuse_rs_calculate = 0x2f800854;
+ets_efuse_count_unused_key_blocks = 0x2f800858;
+ets_efuse_secure_boot_enabled = 0x2f80085c;
+ets_efuse_secure_boot_aggressive_revoke_enabled = 0x2f800860;
+ets_efuse_cache_encryption_enabled = 0x2f800864;
+ets_efuse_download_modes_disabled = 0x2f800868;
+ets_efuse_find_purpose = 0x2f80086c;
+ets_efuse_force_send_resume = 0x2f800870;
+ets_efuse_get_flash_delay_us = 0x2f800874;
+ets_efuse_get_uart_print_control = 0x2f800878;
+ets_efuse_direct_boot_mode_disabled = 0x2f80087c;
+ets_efuse_security_download_modes_enabled = 0x2f800880;
+ets_efuse_jtag_disabled = 0x2f800884;
+ets_efuse_usb_print_is_disabled = 0x2f800888;
+ets_efuse_usb_download_mode_disabled = 0x2f80088c;
+ets_efuse_usb_device_disabled = 0x2f800890;
+ets_efuse_get_km_huk_gen_state = 0x2f800894;
+ets_efuse_get_km_deploy_only_once = 0x2f800898;
+ets_efuse_get_force_use_km_key = 0x2f80089c;
+ets_efuse_xts_key_length_256 = 0x2f8008a0;
+ets_efuse_get_km_key_lock = 0x2f8008a4;
+ets_jtag_enable_temporarily = 0x2f8008a8;
+
+
+/***************************************
+ Group key_mgr
+ ***************************************/
+
+/* Functions */
+esp_rom_check_recover_key = 0x2f8008ac;
+esp_rom_km_huk_conf = 0x2f8008b0;
+esp_rom_km_huk_risk = 0x2f8008b4;
+esp_rom_recover_key = 0x2f8008b8;
+
+
+/***************************************
+ Group secureboot
+ ***************************************/
+
+/* Functions */
+ets_emsa_pss_verify = 0x2f8008bc;
+ets_rsa_pss_verify = 0x2f8008c0;
+ets_ecdsa_verify = 0x2f8008c4;
+ets_secure_boot_verify_bootloader_with_keys = 0x2f8008c8;
+ets_secure_boot_verify_signature = 0x2f8008cc;
+ets_secure_boot_read_key_digests = 0x2f8008d0;
+ets_mgf1_sha256 = 0x2f8008d4;
+ets_secure_boot_revoke_public_key_digest = 0x2f8008d8;
+
+
+/***************************************
+ Group usb_device_uart
+ ***************************************/
+
+/* Functions */
+usb_serial_device_rx_one_char = 0x2f800a4c;
+usb_serial_device_rx_one_char_block = 0x2f800a50;
+usb_serial_device_tx_flush = 0x2f800a54;
+usb_serial_device_tx_one_char = 0x2f800a58;
+
+
+/***************************************
+ Group usb_dwcotg_uart
+ ***************************************/
+
+/* Functions */
+Uart_Init_USB = 0x2f800a5c;
+usb_serial_otg_rx_one_char = 0x2f800a60;
+usb_serial_otg_rx_one_char_block = 0x2f800a64;
+usb_serial_otg_tx_flush = 0x2f800a68;
+usb_serial_otg_tx_one_char = 0x2f800a6c;
+/* Data (.data, .bss, .rodata) */
+uart_acm_dev = 0x2f07ffb8;
+
+
+/***************************************
+ Group usb_dwcotg_module
+ ***************************************/
+
+/* Functions */
+cdc_acm_class_handle_req = 0x2f800a70;
+cdc_acm_init = 0x2f800a74;
+cdc_acm_fifo_fill = 0x2f800a78;
+cdc_acm_rx_fifo_cnt = 0x2f800a7c;
+cdc_acm_fifo_read = 0x2f800a80;
+cdc_acm_irq_tx_enable = 0x2f800a84;
+cdc_acm_irq_tx_disable = 0x2f800a88;
+cdc_acm_irq_state_enable = 0x2f800a8c;
+cdc_acm_irq_state_disable = 0x2f800a90;
+cdc_acm_irq_tx_ready = 0x2f800a94;
+cdc_acm_irq_rx_enable = 0x2f800a98;
+cdc_acm_irq_rx_disable = 0x2f800a9c;
+cdc_acm_irq_rx_ready = 0x2f800aa0;
+cdc_acm_irq_is_pending = 0x2f800aa4;
+cdc_acm_irq_callback_set = 0x2f800aa8;
+cdc_acm_line_ctrl_set = 0x2f800aac;
+cdc_acm_line_ctrl_get = 0x2f800ab0;
+cdc_acm_poll_out = 0x2f800ab4;
+chip_usb_dw_did_persist = 0x2f800ab8;
+chip_usb_dw_init = 0x2f800abc;
+chip_usb_detach = 0x2f800ac0;
+chip_usb_dw_prepare_persist = 0x2f800ac4;
+chip_usb_get_persist_flags = 0x2f800ac8;
+chip_usb_set_persist_flags = 0x2f800acc;
+cpio_start = 0x2f800ad0;
+cpio_feed = 0x2f800ad4;
+cpio_done = 0x2f800ad8;
+cpio_destroy = 0x2f800adc;
+dfu_flash_init = 0x2f800ae0;
+dfu_flash_erase = 0x2f800ae4;
+dfu_flash_program = 0x2f800ae8;
+dfu_flash_read = 0x2f800aec;
+dfu_flash_attach = 0x2f800af0;
+dfu_cpio_callback = 0x2f800af4;
+dfu_updater_get_err = 0x2f800af8;
+dfu_updater_clear_err = 0x2f800afc;
+dfu_updater_enable = 0x2f800b00;
+dfu_updater_begin = 0x2f800b04;
+dfu_updater_feed = 0x2f800b08;
+dfu_updater_end = 0x2f800b0c;
+dfu_updater_set_raw_addr = 0x2f800b10;
+dfu_updater_flash_read = 0x2f800b14;
+usb_dc_prepare_persist = 0x2f800b18;
+usb_dw_isr_handler = 0x2f800b1c;
+usb_dc_attach = 0x2f800b20;
+usb_dc_detach = 0x2f800b24;
+usb_dc_reset = 0x2f800b28;
+usb_dc_set_address = 0x2f800b2c;
+usb_dc_ep_check_cap = 0x2f800b30;
+usb_dc_ep_configure = 0x2f800b34;
+usb_dc_ep_set_stall = 0x2f800b38;
+usb_dc_ep_clear_stall = 0x2f800b3c;
+usb_dc_ep_halt = 0x2f800b40;
+usb_dc_ep_is_stalled = 0x2f800b44;
+usb_dc_ep_enable = 0x2f800b48;
+usb_dc_ep_disable = 0x2f800b4c;
+usb_dc_ep_flush = 0x2f800b50;
+usb_dc_ep_write_would_block = 0x2f800b54;
+usb_dc_ep_write = 0x2f800b58;
+usb_dc_ep_read_wait = 0x2f800b5c;
+usb_dc_ep_read_continue = 0x2f800b60;
+usb_dc_ep_read = 0x2f800b64;
+usb_dc_ep_set_callback = 0x2f800b68;
+usb_dc_set_status_callback = 0x2f800b6c;
+usb_dc_ep_mps = 0x2f800b70;
+usb_dc_check_poll_for_interrupts = 0x2f800b74;
+mac_addr_to_serial_str_desc = 0x2f800b78;
+usb_set_current_descriptor = 0x2f800b7c;
+usb_get_descriptor = 0x2f800b80;
+usb_dev_resume = 0x2f800b84;
+usb_dev_get_configuration = 0x2f800b88;
+usb_set_config = 0x2f800b8c;
+usb_deconfig = 0x2f800b90;
+usb_enable = 0x2f800b94;
+usb_disable = 0x2f800b98;
+usb_write_would_block = 0x2f800b9c;
+usb_write = 0x2f800ba0;
+usb_read = 0x2f800ba4;
+usb_ep_set_stall = 0x2f800ba8;
+usb_ep_clear_stall = 0x2f800bac;
+usb_ep_read_wait = 0x2f800bb0;
+usb_ep_read_continue = 0x2f800bb4;
+usb_transfer_ep_callback = 0x2f800bb8;
+usb_transfer = 0x2f800bbc;
+usb_cancel_transfer = 0x2f800bc0;
+usb_transfer_sync = 0x2f800bc4;
+usb_dfu_set_detach_cb = 0x2f800bc8;
+dfu_class_handle_req = 0x2f800bcc;
+dfu_status_cb = 0x2f800bd0;
+dfu_custom_handle_req = 0x2f800bd4;
+usb_dfu_init = 0x2f800bd8;
+usb_dfu_force_detach = 0x2f800bdc;
+usb_dev_deinit = 0x2f800be0;
+usb_dw_ctrl_deinit = 0x2f800be4;
+/* Data (.data, .bss, .rodata) */
+s_usb_osglue = 0x2f07ffac;
+
+
+/***************************************
+ Group recovery_bootloader
+ ***************************************/
+
+/* Functions */
+ets_get_bootloader_offset = 0x2f800be8;
+ets_set_bootloader_offset = 0x2f800bec;

--- a/src/target/esp32s31/ld/esp32s31.rom.libc.ld
+++ b/src/target/esp32s31/ld/esp32s31.rom.libc.ld
@@ -1,0 +1,75 @@
+/* ROM function interface esp32s31.rom.libc.ld for esp32s31
+ *
+ *
+ * Generated from ../../rom/target/esp32s31/interface-esp32s31.yml md5sum 0cb775308c66eebf0757e406021ad5be
+ *
+ * Compatible with ROM where ECO version equal or greater to 0.
+ *
+ * THIS FILE WAS AUTOMATICALLY GENERATED. DO NOT EDIT.
+ */
+
+/***************************************
+ Group libc
+ ***************************************/
+
+/* Functions */
+esp_rom_newlib_init_common_mutexes = 0x2f8004bc;
+memset = 0x2f8004c0;
+memcpy = 0x2f8004c4;
+memmove = 0x2f8004c8;
+memcmp = 0x2f8004cc;
+strcpy = 0x2f8004d0;
+strncpy = 0x2f8004d4;
+strcmp = 0x2f8004d8;
+strncmp = 0x2f8004dc;
+strlen = 0x2f8004e0;
+strstr = 0x2f8004e4;
+bzero = 0x2f8004e8;
+sbrk = 0x2f8004ec;
+isalnum = 0x2f8004f0;
+isalpha = 0x2f8004f4;
+isascii = 0x2f8004f8;
+isblank = 0x2f8004fc;
+iscntrl = 0x2f800500;
+isdigit = 0x2f800504;
+islower = 0x2f800508;
+isgraph = 0x2f80050c;
+isprint = 0x2f800510;
+ispunct = 0x2f800514;
+isspace = 0x2f800518;
+isupper = 0x2f80051c;
+toupper = 0x2f800520;
+tolower = 0x2f800524;
+toascii = 0x2f800528;
+memccpy = 0x2f80052c;
+memchr = 0x2f800530;
+memrchr = 0x2f800534;
+strcasecmp = 0x2f800538;
+strcasestr = 0x2f80053c;
+strcat = 0x2f800540;
+strchr = 0x2f800544;
+strcspn = 0x2f800548;
+strcoll = 0x2f80054c;
+strlcat = 0x2f800550;
+strlcpy = 0x2f800554;
+strlwr = 0x2f800558;
+strncasecmp = 0x2f80055c;
+strncat = 0x2f800560;
+strnlen = 0x2f800564;
+strrchr = 0x2f800568;
+strsep = 0x2f80056c;
+strspn = 0x2f800570;
+strtok_r = 0x2f800574;
+strupr = 0x2f800578;
+longjmp = 0x2f80057c;
+setjmp = 0x2f800580;
+abs = 0x2f800584;
+div = 0x2f800588;
+labs = 0x2f80058c;
+ldiv = 0x2f800590;
+qsort = 0x2f800594;
+utoa = 0x2f800598;
+itoa = 0x2f80059c;
+/* Data (.data, .bss, .rodata) */
+syscall_table_ptr = 0x2f07ffc8;
+_global_impure_ptr = 0x2f07ffc4;

--- a/src/target/esp32s31/ld/esp32s31.rom.libgcc.ld
+++ b/src/target/esp32s31/ld/esp32s31.rom.libgcc.ld
@@ -1,0 +1,91 @@
+/* ROM function interface esp32s31.rom.libgcc.ld for esp32s31
+ *
+ *
+ * Generated from ../../rom/target/esp32s31/interface-esp32s31.yml md5sum 0cb775308c66eebf0757e406021ad5be
+ *
+ * Compatible with ROM where ECO version equal or greater to 0.
+ *
+ * THIS FILE WAS AUTOMATICALLY GENERATED. DO NOT EDIT.
+ */
+
+/***************************************
+ Group libgcc_general
+ ***************************************/
+
+/* Functions */
+__powisf2 = 0x2f8008dc;
+__truncdfsf2 = 0x2f8008e0;
+__absvdi2 = 0x2f8008e4;
+__absvsi2 = 0x2f8008e8;
+__adddf3 = 0x2f8008ec;
+__addvdi3 = 0x2f8008f0;
+__addvsi3 = 0x2f8008f4;
+__ashldi3 = 0x2f8008f8;
+__ashrdi3 = 0x2f8008fc;
+__bswapdi2 = 0x2f800900;
+__bswapsi2 = 0x2f800904;
+__clrsbdi2 = 0x2f800908;
+__clrsbsi2 = 0x2f80090c;
+__clzdi2 = 0x2f800910;
+__clzsi2 = 0x2f800914;
+__cmpdi2 = 0x2f800918;
+__ctzdi2 = 0x2f80091c;
+__ctzsi2 = 0x2f800920;
+__divdc3 = 0x2f800924;
+__divdf3 = 0x2f800928;
+__divdi3 = 0x2f80092c;
+__divsc3 = 0x2f800930;
+__divsi3 = 0x2f800934;
+__eqdf2 = 0x2f800938;
+__extendsfdf2 = 0x2f80093c;
+__ffsdi2 = 0x2f800940;
+__ffssi2 = 0x2f800944;
+__fixdfdi = 0x2f800948;
+__fixdfsi = 0x2f80094c;
+__fixsfdi = 0x2f800950;
+__fixunsdfsi = 0x2f800954;
+__fixunssfdi = 0x2f800958;
+__fixunssfsi = 0x2f80095c;
+__floatdidf = 0x2f800960;
+__floatdisf = 0x2f800964;
+__floatsidf = 0x2f800968;
+__floatundidf = 0x2f80096c;
+__floatundisf = 0x2f800970;
+__floatunsidf = 0x2f800974;
+__gcc_bcmp = 0x2f800978;
+__gedf2 = 0x2f80097c;
+__gtdf2 = 0x2f800980;
+__ledf2 = 0x2f800984;
+__lshrdi3 = 0x2f800988;
+__ltdf2 = 0x2f80098c;
+__moddi3 = 0x2f800990;
+__modsi3 = 0x2f800994;
+__muldc3 = 0x2f800998;
+__muldf3 = 0x2f80099c;
+__muldi3 = 0x2f8009a0;
+__mulsc3 = 0x2f8009a4;
+__mulsi3 = 0x2f8009a8;
+__mulvdi3 = 0x2f8009ac;
+__mulvsi3 = 0x2f8009b0;
+__nedf2 = 0x2f8009b4;
+__negdf2 = 0x2f8009b8;
+__negdi2 = 0x2f8009bc;
+__negvdi2 = 0x2f8009c0;
+__negvsi2 = 0x2f8009c4;
+__paritysi2 = 0x2f8009c8;
+__popcountdi2 = 0x2f8009cc;
+__popcountsi2 = 0x2f8009d0;
+__powidf2 = 0x2f8009d4;
+__subdf3 = 0x2f8009d8;
+__subvdi3 = 0x2f8009dc;
+__subvsi3 = 0x2f8009e0;
+__ucmpdi2 = 0x2f8009e4;
+__udivdi3 = 0x2f8009e8;
+__udivmoddi4 = 0x2f8009ec;
+__udivsi3 = 0x2f8009f0;
+__udiv_w_sdiv = 0x2f8009f4;
+__umoddi3 = 0x2f8009f8;
+__umodsi3 = 0x2f8009fc;
+__unorddf2 = 0x2f800a00;
+__extenddftf2 = 0x2f800a04;
+__trunctfdf2 = 0x2f800a08;

--- a/src/target/esp32s31/src/flash.c
+++ b/src/target/esp32s31/src/flash.c
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <esp-stub-lib/soc_utils.h>
+
+#include <target/flash.h>
+
+#include <soc/spi_mem_compat.h>
+
+void stub_target_spi_wait_ready(void)
+{
+    while (REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_MST_ST) ||
+           REG_GET_FIELD(SPI_MEM_CMD_REG(FLASH_SPI_NUM), SPI_MEM_SLV_ST)) {
+        /* busy wait */
+    }
+}

--- a/src/target/esp32s31/src/uart.c
+++ b/src/target/esp32s31/src/uart.c
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stdint.h>
+
+#include <target/uart.h>
+
+// ROM functions for targets using common implementation
+extern void esp_rom_uart_attach(void *rxBuffer);
+extern void esp_rom_uart_init(uint8_t uart_no);
+
+void stub_target_rom_uart_attach(void *rxBuffer)
+{
+    esp_rom_uart_attach(rxBuffer);
+}
+
+void stub_target_rom_uart_init(uint8_t uart_no, uint32_t clock)
+{
+    (void)clock; // Ignore clock parameter for 1-param ROM function
+    esp_rom_uart_init(uart_no);
+}


### PR DESCRIPTION
- Add `esp32s31` as a new target with minimal base support (flash + UART)
- Pull SOC headers, ROM linker scripts, and `esp_rom_caps.h` from ESP-IDF
- Add common `clock.c` weak default so targets that do not need a clock override can skip it
- Document lessons from this port in CONTRIBUTING.md:
  - Guidance on SPI register naming variants (`SPI1_MEM_C_*` split headers)
  - Incremental approach: start with `flash.c` + `uart.c`, add overrides later

Note: OpenOCD do not have esp32s31 target support yet, so flash and UART functionality could not be runtime tested.

