### PR TITLE
feat(flash): add explicit flash attach policy

### DIFF
--- a/example/stub_main.c
+++ b/example/stub_main.c
@@ -138,6 +138,7 @@ static int __attribute__((unused)) handle_test_flash(void)
     uint8_t buffer[256];
 
     (void)stub_lib_flash_init(&flash_state);
+    (void)stub_lib_flash_init_ex(&flash_state, STUB_LIB_FLASH_ATTACH_IF_NEEDED);
     stub_lib_flash_get_config(&flash_config);
     (void)stub_lib_flash_update_config(&flash_config);
     stub_lib_flash_attach(0, false);

--- a/include/esp-stub-lib/flash.h
+++ b/include/esp-stub-lib/flash.h
@@ -18,6 +18,11 @@ typedef struct stub_lib_flash_config {
     uint32_t status_mask;
 } stub_lib_flash_config_t;
 
+typedef enum {
+    STUB_LIB_FLASH_ATTACH_ALWAYS = 0,
+    STUB_LIB_FLASH_ATTACH_IF_NEEDED,
+} stub_lib_flash_attach_policy_t;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -54,6 +59,20 @@ void stub_lib_flash_attach(uint32_t ishspi, bool legacy);
  * - STUB_LIB_ERR_UNKNOWN_FLASH_ID
  */
 int stub_lib_flash_init(void **state);
+
+/**
+ * @brief Initialize SPI Flash before any use with explicit attach policy.
+ *
+ * Configure SPI, Flash ID, flash size, and the internal ROM's config.
+ *
+ * @param state If non-NULL, the state is saved to this pointer to be restored later.
+ * @param attach_policy Whether to always perform ROM flash attach or skip it when not needed.
+ *
+ * @return Error code:
+ * - STUB_LIB_OK
+ * - STUB_LIB_ERR_UNKNOWN_FLASH_ID
+ */
+int stub_lib_flash_init_ex(void **state, stub_lib_flash_attach_policy_t attach_policy);
 
 /**
  * @brief Restore flash state at the end of the stub.

--- a/src/flash.c
+++ b/src/flash.c
@@ -45,7 +45,12 @@ void stub_lib_flash_attach(uint32_t ishspi, bool legacy)
 
 int stub_lib_flash_init(void **state)
 {
-    stub_target_flash_init(state);
+    return stub_lib_flash_init_ex(state, STUB_LIB_FLASH_ATTACH_ALWAYS);
+}
+
+int stub_lib_flash_init_ex(void **state, stub_lib_flash_attach_policy_t attach_policy)
+{
+    stub_target_flash_init(state, attach_policy);
 
     uint32_t flash_id = stub_target_flash_get_flash_id();
     uint32_t flash_size = stub_target_flash_id_to_flash_size(flash_id);

--- a/src/target/base/include/target/flash.h
+++ b/src/target/base/include/target/flash.h
@@ -9,6 +9,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <esp-stub-lib/flash.h>
+
 #include <private/rom_flash.h>
 
 /**
@@ -55,7 +57,18 @@ void stub_target_reset_default_spi_pins(void);
  *
  * @param state If non-NULL, the state is saved.
  */
-void stub_target_flash_init(void **state);
+void stub_target_flash_init(void **state, stub_lib_flash_attach_policy_t attach_policy);
+
+/**
+ * @brief Check whether flash attach is needed for the current hardware state.
+ *
+ * The default weak implementation returns true. Targets with live cache/MMU/XIP
+ * state that should not be disturbed can override this to return false when
+ * attach should be skipped.
+ *
+ * @return true if ROM flash attach should run, false otherwise.
+ */
+bool stub_target_flash_needs_attach(void);
 
 /**
  * @brief Restore SPI Flash hardware state.

--- a/src/target/common/src/flash.c
+++ b/src/target/common/src/flash.c
@@ -105,11 +105,19 @@ void __attribute__((weak)) stub_target_flash_state_restore(const void *state)
     (void)state;
 }
 
-void __attribute__((weak)) stub_target_flash_init(void **state)
+void __attribute__((weak)) stub_target_flash_init(void **state, stub_lib_flash_attach_policy_t attach_policy)
 {
     (void)state;
-    uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();
-    stub_target_flash_attach(spiconfig, 0);
+
+    if (attach_policy == STUB_LIB_FLASH_ATTACH_ALWAYS || stub_target_flash_needs_attach()) {
+        uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();
+        stub_target_flash_attach(spiconfig, 0);
+    }
+}
+
+bool __attribute__((weak)) stub_target_flash_needs_attach(void)
+{
+    return true;
 }
 
 void __attribute__((weak)) stub_target_flash_attach(uint32_t ishspi, bool legacy)

--- a/src/target/esp32/src/flash.c
+++ b/src/target/esp32/src/flash.c
@@ -111,20 +111,23 @@ int stub_target_rom_spiflash_erase_area(uint32_t addr, uint32_t size)
     return rom_res;
 }
 
-void stub_target_flash_init(void **state)
+bool stub_target_flash_needs_attach(void)
 {
+    return (READ_PERI_REG(SPI_CACHE_FCTRL_REG(0)) & SPI_CACHE_FLASH_USR_CMD) == 0;
+}
+
+void stub_target_flash_init(void **state, stub_lib_flash_attach_policy_t attach_policy)
+{
+    (void)state;
     uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();
 
-    if (state) {
-        stub_target_flash_state_save(state);
+    if (attach_policy == STUB_LIB_FLASH_ATTACH_ALWAYS || stub_target_flash_needs_attach()) {
+        stub_target_flash_attach(spiconfig, 0);
+        /*
+         * Command phase is always set in download mode.
+         * But in reset-run case, it seems to be not set.
+         * So we need to set it here before sending any command.
+         */
+        REG_SET_BIT(SPI_USER_REG(1), SPI_USR_COMMAND);
     }
-
-    stub_target_flash_attach(spiconfig, 0);
-
-    /*
-     * Command phase is always set in download mode.
-     * But in reset-run case, it seems to be not set.
-     * So we need to set it here before sending any command.
-     */
-    REG_SET_BIT(SPI_USER_REG(1), SPI_USR_COMMAND);
 }

--- a/src/target/esp32s2/src/flash.c
+++ b/src/target/esp32s2/src/flash.c
@@ -41,3 +41,8 @@ void stub_target_spi_wait_ready(void)
         /* busy wait */
     }
 }
+
+bool stub_target_flash_needs_attach(void)
+{
+    return (READ_PERI_REG(SPI_MEM_CACHE_FCTRL_REG(0)) & SPI_MEM_CACHE_FLASH_USR_CMD) == 0;
+}

--- a/src/target/esp32s3/src/flash.c
+++ b/src/target/esp32s3/src/flash.c
@@ -56,14 +56,22 @@ static void stub_target_flash_init_funcs(void)
     rom_spiflash_legacy_funcs = &funcs;
 }
 
-void stub_target_flash_init(void **state)
+bool stub_target_flash_needs_attach(void)
+{
+    return (READ_PERI_REG(SPI_MEM_CACHE_FCTRL_REG(0)) & SPI_MEM_CACHE_FLASH_USR_CMD) == 0;
+}
+
+void stub_target_flash_init(void **state, stub_lib_flash_attach_policy_t attach_policy)
 {
     (void)state;
     uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();
-    stub_target_flash_attach(spiconfig, 0);
-    if (ets_efuse_flash_octal_mode()) {
-        STUB_LOGD("octal mode is on\n");
-        stub_target_flash_init_funcs();
+
+    if (attach_policy == STUB_LIB_FLASH_ATTACH_ALWAYS || stub_target_flash_needs_attach()) {
+        stub_target_flash_attach(spiconfig, 0);
+        if (ets_efuse_flash_octal_mode()) {
+            STUB_LOGD("octal mode is on\n");
+            stub_target_flash_init_funcs();
+        }
     }
 }
 


### PR DESCRIPTION
Add an explicit flash attach policy to `stub_lib_flash_init` so callers can choose between:

- always calling ROM flash attach
- attaching only when needed

This keeps the default behavior unchanged for esptool while allowing OpenOCD-specific flows to skip full attach when the target already has live flash/cache state.

