### PR TITLE
feat(flash): add rom erase area API

### DIFF
--- a/example/stub_main.c
+++ b/example/stub_main.c
@@ -144,6 +144,7 @@ static int __attribute__((unused)) handle_test_flash(void)
     (void)stub_lib_flash_read_buff(0x1000, buffer, sizeof(buffer));
     (void)stub_lib_flash_write_buff(0x10000, buffer, sizeof(buffer), 0);
     (void)stub_lib_flash_erase_area(0x20000, 0x10000);
+    (void)stub_lib_flash_rom_erase_area(0x30000, 0x10000);
     (void)stub_lib_flash_erase_chip();
     (void)stub_lib_flash_start_next_erase(NULL, NULL, 0);
     (void)stub_lib_flash_wait_ready(0);

--- a/include/esp-stub-lib/flash.h
+++ b/include/esp-stub-lib/flash.h
@@ -112,6 +112,24 @@ int stub_lib_flash_write_buff(uint32_t addr, const void *buffer, uint32_t size, 
 int stub_lib_flash_erase_area(uint32_t addr, uint32_t size);
 
 /**
+ * @brief ROM SPIEraseArea path for a flash region
+ *
+ * For internal flash <= 16MB only. Callers that need the ROM routine explicitly
+ * can use this API. For > 16MB flash, returns STUB_LIB_ERR_NOT_SUPPORTED
+ * and stub_lib_flash_erase_area must be used instead.
+ *
+ * @param addr Sector-aligned start address.
+ * @param size Sector-aligned size.
+ *
+ * @return Result:
+ * - STUB_LIB_OK
+ * - STUB_LIB_ERR_INVALID_ARG
+ * - STUB_LIB_ERR_NOT_SUPPORTED (large-flash / 4-byte mode)
+ * - STUB_LIB_FAIL if ROM erase fails
+ */
+int stub_lib_flash_rom_erase_area(uint32_t addr, uint32_t size);
+
+/**
  * @brief Erase the entire flash chip.
  *
  * @return Result:

--- a/src/flash.c
+++ b/src/flash.c
@@ -21,6 +21,8 @@
 // For flash size > 16MB, we use 4-byte addressing, only some targets support this.
 static bool large_flash_mode = false;
 
+#define STUB_FLASH_ERASE_TIMEOUT_US 1000000U
+
 int stub_lib_flash_update_config(stub_lib_flash_config_t *config)
 {
     if (config == NULL) {
@@ -212,15 +214,34 @@ int stub_lib_flash_erase_area(uint32_t addr, uint32_t size)
         return STUB_LIB_ERR_INVALID_ARG;
     }
 
-    const uint32_t timeout_us = 1000000; // 1 second per block or sector
-
     while (size > 0) {
-        int res = stub_lib_flash_start_next_erase(&addr, &size, timeout_us);
+        int res = stub_lib_flash_start_next_erase(&addr, &size, STUB_FLASH_ERASE_TIMEOUT_US);
         if (res != STUB_LIB_OK) {
             STUB_LOGE("Erase area failed at 0x%x, remaining %u with error 0x%x\n", addr, size, res);
             return res;
         }
     }
 
-    return stub_lib_flash_wait_ready(timeout_us);
+    return stub_lib_flash_wait_ready(STUB_FLASH_ERASE_TIMEOUT_US);
+}
+
+int stub_lib_flash_rom_erase_area(uint32_t addr, uint32_t size)
+{
+    if (large_flash_mode) {
+        return STUB_LIB_ERR_NOT_SUPPORTED;
+    }
+
+    if (!IS_ALIGNED(addr, STUB_FLASH_SECTOR_SIZE) || !IS_ALIGNED(size, STUB_FLASH_SECTOR_SIZE)) {
+        STUB_LOGE("Erase area addr 0x%x or size 0x%x not sector-aligned\n", addr, size);
+        return STUB_LIB_ERR_INVALID_ARG;
+    }
+
+    int res = stub_target_rom_spiflash_erase_area(addr, size);
+    if (res != ESP_ROM_SPIFLASH_RESULT_OK) {
+        STUB_LOGE("esp_rom_spiflash_erase_area(0x%x, %u) failed (%d)\n", addr, size, res);
+        return STUB_LIB_FAIL;
+    }
+
+    /* ROM waits for IDLE before returning. No extra wait_ready needed. */
+    return STUB_LIB_OK;
 }

--- a/src/target/base/include/private/rom_flash.h
+++ b/src/target/base/include/private/rom_flash.h
@@ -61,6 +61,16 @@ int esp_rom_spiflash_read(uint32_t src_addr, uint32_t *dest, int32_t len);
 int esp_rom_spiflash_unlock(void);
 
 /**
+ * @brief Erase an area of SPI flash using ROM implementation.
+ *
+ * @return Result
+ * - ESP_ROM_SPIFLASH_RESULT_OK
+ * - ESP_ROM_SPIFLASH_RESULT_ERR
+ * - ESP_ROM_SPIFLASH_RESULT_TIMEOUT
+ */
+int esp_rom_spiflash_erase_area(uint32_t start_addr, uint32_t area_len);
+
+/**
  * @brief Check if Flash is OPI.
  *
  * @return true if eFuse indicates an OPI flash is attached.

--- a/src/target/base/include/target/flash.h
+++ b/src/target/base/include/target/flash.h
@@ -79,6 +79,13 @@ void stub_target_flash_state_save(void **state);
 void stub_target_flash_state_restore(const void *state);
 
 /**
+ * @brief Target wrapper for esp_rom_spiflash_erase_area().
+ *
+ * @return Raw ROM result code.
+ */
+int stub_target_rom_spiflash_erase_area(uint32_t addr, uint32_t size);
+
+/**
  * @brief Retrieve Flash ID (aka flash device id, aka flash chip id) from internal hw.
  *
  * @return Flash ID, that includes manufacture and size information.

--- a/src/target/common/src/flash.c
+++ b/src/target/common/src/flash.c
@@ -230,3 +230,8 @@ int __attribute__((weak)) stub_target_flash_unlock(void)
     }
     return STUB_LIB_FAIL;
 }
+
+int __attribute__((weak)) stub_target_rom_spiflash_erase_area(uint32_t addr, uint32_t size)
+{
+    return esp_rom_spiflash_erase_area(addr, size);
+}

--- a/src/target/esp32/src/flash.c
+++ b/src/target/esp32/src/flash.c
@@ -85,6 +85,32 @@ void stub_target_flash_state_restore(const void *state)
     WRITE_PERI_REG(SPI_USER_REG(FLASH_SPI_NUM), s->spi_regs[SPI_USER_REG_ID]);
 }
 
+/*
+ * ESP32 ROM SPIEraseArea() switches flash read mode to slow read before erase.
+ * That reprograms SPI0 read-mode bits and cache/XIP user registers, but ROM
+ * does not restore the previous controller state before returning. Restore the
+ * clobbered registers here so cache/XIP reads remain consistent after the ROM
+ * erase call.
+ */
+int stub_target_rom_spiflash_erase_area(uint32_t addr, uint32_t size)
+{
+    uint32_t spi0_ctrl = READ_PERI_REG(SPI_CTRL_REG(0));
+    uint32_t spi0_user = READ_PERI_REG(SPI_USER_REG(0));
+    uint32_t spi0_user1 = READ_PERI_REG(SPI_USER1_REG(0));
+    uint32_t spi0_user2 = READ_PERI_REG(SPI_USER2_REG(0));
+    uint32_t spi1_ctrl = READ_PERI_REG(SPI_CTRL_REG(1));
+
+    int rom_res = esp_rom_spiflash_erase_area(addr, size);
+
+    WRITE_PERI_REG(SPI_CTRL_REG(0), spi0_ctrl);
+    WRITE_PERI_REG(SPI_USER_REG(0), spi0_user);
+    WRITE_PERI_REG(SPI_USER1_REG(0), spi0_user1);
+    WRITE_PERI_REG(SPI_USER2_REG(0), spi0_user2);
+    WRITE_PERI_REG(SPI_CTRL_REG(1), spi1_ctrl);
+
+    return rom_res;
+}
+
 void stub_target_flash_init(void **state)
 {
     uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();


### PR DESCRIPTION
Add an explicit `stub_lib_flash_rom_erase_area()` API for callers running on the non-attach path.

The reason is that `stub_lib_flash_erase_area()` uses the normal stub erase backend, which issues direct erase commands through the stub controlled SPI flash path. That path assumes the flash interface has already been attached and initialized for stub issued commands. In the non-attach flow, we intentionally skip full attach, so that assumption does not hold.

For this case we need a caller visible way to request the ROM erase area path explicitly instead of going through the generic erase API.

On ESP32, the ROM erase path also changes controller read-mode state and does not restore it before returning, so the ESP32 target wrapper preserves the affected controller registers around the ROM call.




