### PR TITLE
feat(flash): add flash state size api (BREAKING CHANGE)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,21 +134,18 @@ This is the core pattern. Get familiar with it before contributing.
 `src/target/common/src/` has weak defaults:
 
 ```c
-int __attribute__((weak)) stub_target_flash_state_save(void **state)
+bool __attribute__((weak)) stub_target_flash_needs_attach(void)
 {
-    *state = NULL;
-    return 0;
+    return true;
 }
 ```
 
 `src/target/<chip>/src/` has strong overrides when needed:
 
 ```c
-int stub_target_flash_state_save(void **state)
+bool stub_target_flash_needs_attach(void)
 {
-    s_saved_state.usr_reg = REG_READ(SPI_MEM_USER_REG(1));
-    *state = &s_saved_state;
-    return 0;
+    return (READ_PERI_REG(SPI_MEM_CACHE_FCTRL_REG(0)) & SPI_MEM_CACHE_FLASH_USR_CMD) == 0;
 }
 ```
 

--- a/example/stub_main.c
+++ b/example/stub_main.c
@@ -133,12 +133,14 @@ static int __attribute__((unused)) handle_test_uart(void)
 
 static int __attribute__((unused)) handle_test_flash(void)
 {
-    void *flash_state = NULL;
+    size_t flash_state_sz = stub_lib_flash_state_size();
+    uint8_t flash_state_buf[flash_state_sz ? flash_state_sz : 1] __attribute__((aligned(__alignof__(uint32_t))));
+    void *flash_state = flash_state_sz ? flash_state_buf : NULL;
     stub_lib_flash_config_t flash_config;
     uint8_t buffer[256];
 
-    (void)stub_lib_flash_init(&flash_state);
-    (void)stub_lib_flash_init_ex(&flash_state, STUB_LIB_FLASH_ATTACH_IF_NEEDED);
+    (void)stub_lib_flash_init(flash_state);
+    (void)stub_lib_flash_init_ex(flash_state, STUB_LIB_FLASH_ATTACH_IF_NEEDED);
     stub_lib_flash_get_config(&flash_config);
     (void)stub_lib_flash_update_config(&flash_config);
     stub_lib_flash_attach(0, false);
@@ -248,7 +250,7 @@ int stub_main(int cmd, ...)
 
     STUB_LOGI("Command: 0x%x\n", cmd);
 
-    int lib_ret = stub_lib_flash_init(&flash_state);
+    int lib_ret = stub_lib_flash_init(flash_state);
     if (lib_ret != STUB_LIB_OK) {
         STUB_LOGE("Flash init failure: (0x%X) %s\n", lib_ret, stub_err_str(lib_ret));
         return lib_ret;

--- a/include/esp-stub-lib/flash.h
+++ b/include/esp-stub-lib/flash.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 typedef struct stub_lib_flash_config {
@@ -48,31 +49,42 @@ int stub_lib_flash_update_config(stub_lib_flash_config_t *config);
 void stub_lib_flash_attach(uint32_t ishspi, bool legacy);
 
 /**
+ * @brief Return the size in bytes of the target-specific flash state buffer.
+ *
+ * The caller must allocate at least this many bytes, aligned to uint32_t, and
+ * pass the buffer to stub_lib_flash_init() / stub_lib_flash_init_ex().
+ * Returns 0 if the target does not require any state save/restore.
+ */
+size_t stub_lib_flash_state_size(void) __attribute__((const));
+
+/**
  * @brief Initialize SPI Flash before any use.
  *
- * Configure SPI, Flash ID, flash size, and the internal ROM's config
+ * Configure SPI, Flash ID, flash size, and the internal ROM's config.
  *
- * @param state If non-NULL, the state is saved to this pointer to be restored later.
+ * @param state Pre-allocated buffer of at least stub_lib_flash_state_size()
+ *              bytes, or NULL if no state save is needed.
  *
  * @return Error code:
  * - STUB_LIB_OK
  * - STUB_LIB_ERR_UNKNOWN_FLASH_ID
  */
-int stub_lib_flash_init(void **state);
+int stub_lib_flash_init(void *state);
 
 /**
  * @brief Initialize SPI Flash before any use with explicit attach policy.
  *
  * Configure SPI, Flash ID, flash size, and the internal ROM's config.
  *
- * @param state If non-NULL, the state is saved to this pointer to be restored later.
+ * @param state Pre-allocated buffer of at least stub_lib_flash_state_size()
+ *              bytes, or NULL if no state save is needed.
  * @param attach_policy Whether to always perform ROM flash attach or skip it when not needed.
  *
  * @return Error code:
  * - STUB_LIB_OK
  * - STUB_LIB_ERR_UNKNOWN_FLASH_ID
  */
-int stub_lib_flash_init_ex(void **state, stub_lib_flash_attach_policy_t attach_policy);
+int stub_lib_flash_init_ex(void *state, stub_lib_flash_attach_policy_t attach_policy);
 
 /**
  * @brief Restore flash state at the end of the stub.

--- a/src/flash.c
+++ b/src/flash.c
@@ -43,12 +43,17 @@ void stub_lib_flash_attach(uint32_t ishspi, bool legacy)
     stub_target_flash_attach(ishspi, legacy);
 }
 
-int stub_lib_flash_init(void **state)
+size_t stub_lib_flash_state_size(void)
+{
+    return stub_target_flash_state_size();
+}
+
+int stub_lib_flash_init(void *state)
 {
     return stub_lib_flash_init_ex(state, STUB_LIB_FLASH_ATTACH_ALWAYS);
 }
 
-int stub_lib_flash_init_ex(void **state, stub_lib_flash_attach_policy_t attach_policy)
+int stub_lib_flash_init_ex(void *state, stub_lib_flash_attach_policy_t attach_policy)
 {
     stub_target_flash_init(state, attach_policy);
 

--- a/src/target/base/include/target/flash.h
+++ b/src/target/base/include/target/flash.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include <esp-stub-lib/flash.h>
@@ -51,13 +52,21 @@ typedef enum {
 void stub_target_reset_default_spi_pins(void);
 
 /**
+ * @brief Return the size in bytes needed for the target flash state buffer.
+ *
+ * Weak default returns 0 (no state). Targets that save SPI register state
+ * override this to return sizeof(their_state_struct).
+ */
+size_t stub_target_flash_state_size(void) __attribute__((const));
+
+/**
  * @brief Initialize SPI Flash hardware.
  *
  * Configure SPI pins, registers, mode, etc.
  *
- * @param state If non-NULL, the state is saved.
+ * @param state Pre-allocated buffer of stub_target_flash_state_size() bytes, or NULL.
  */
-void stub_target_flash_init(void **state, stub_lib_flash_attach_policy_t attach_policy);
+void stub_target_flash_init(void *state, stub_lib_flash_attach_policy_t attach_policy);
 
 /**
  * @brief Check whether flash attach is needed for the current hardware state.
@@ -80,9 +89,9 @@ void stub_target_flash_deinit(const void *state);
 /**
  * @brief Save SPI Flash hardware state before sending any command.
  *
- * @param state If non-NULL, the state is saved.
+ * @param state Pre-allocated buffer of stub_target_flash_state_size() bytes, or NULL.
  */
-void stub_target_flash_state_save(void **state);
+void stub_target_flash_state_save(void *state);
 
 /**
  * @brief Restore SPI Flash hardware state before leaving the stub.

--- a/src/target/common/src/flash.c
+++ b/src/target/common/src/flash.c
@@ -95,7 +95,12 @@ uint32_t __attribute__((weak)) stub_target_flash_get_spiconfig_efuse(void)
     return 0;
 }
 
-void __attribute__((weak)) stub_target_flash_state_save(void **state)
+size_t __attribute__((weak, const)) stub_target_flash_state_size(void)
+{
+    return 0;
+}
+
+void __attribute__((weak)) stub_target_flash_state_save(void *state)
 {
     (void)state;
 }
@@ -105,7 +110,7 @@ void __attribute__((weak)) stub_target_flash_state_restore(const void *state)
     (void)state;
 }
 
-void __attribute__((weak)) stub_target_flash_init(void **state, stub_lib_flash_attach_policy_t attach_policy)
+void __attribute__((weak)) stub_target_flash_init(void *state, stub_lib_flash_attach_policy_t attach_policy)
 {
     (void)state;
 

--- a/src/target/esp32/src/flash.c
+++ b/src/target/esp32/src/flash.c
@@ -29,8 +29,6 @@ typedef struct {
     uint32_t spi_regs[SPI_REGS_NUM];
 } stub_esp32_flash_state_t;
 
-static stub_esp32_flash_state_t s_flash_state;
-
 uint32_t stub_target_flash_get_spiconfig_efuse(void)
 {
     return esp_rom_efuse_get_flash_gpio_info();
@@ -59,15 +57,14 @@ void stub_target_spi_wait_ready(void)
     }
 }
 
-void stub_target_flash_state_save(void **state)
+void stub_target_flash_state_save(void *state)
 {
     if (!state) {
         return;
     }
 
-    s_flash_state.spi_regs[SPI_USER_REG_ID] = READ_PERI_REG(SPI_USER_REG(FLASH_SPI_NUM));
-
-    *state = &s_flash_state;
+    stub_esp32_flash_state_t *s = state;
+    s->spi_regs[SPI_USER_REG_ID] = READ_PERI_REG(SPI_USER_REG(FLASH_SPI_NUM));
 }
 
 void stub_target_flash_state_restore(const void *state)
@@ -116,7 +113,7 @@ bool stub_target_flash_needs_attach(void)
     return (READ_PERI_REG(SPI_CACHE_FCTRL_REG(0)) & SPI_CACHE_FLASH_USR_CMD) == 0;
 }
 
-void stub_target_flash_init(void **state, stub_lib_flash_attach_policy_t attach_policy)
+void stub_target_flash_init(void *state, stub_lib_flash_attach_policy_t attach_policy)
 {
     (void)state;
     uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();

--- a/src/target/esp32s3/src/flash.c
+++ b/src/target/esp32s3/src/flash.c
@@ -61,7 +61,7 @@ bool stub_target_flash_needs_attach(void)
     return (READ_PERI_REG(SPI_MEM_CACHE_FCTRL_REG(0)) & SPI_MEM_CACHE_FLASH_USR_CMD) == 0;
 }
 
-void stub_target_flash_init(void **state, stub_lib_flash_attach_policy_t attach_policy)
+void stub_target_flash_init(void *state, stub_lib_flash_attach_policy_t attach_policy)
 {
     (void)state;
     uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();


### PR DESCRIPTION
This change makes flash state save/restore use caller-provided storage instead of internal static storage.

The reason for doing this is the rule in `CONTRIBUTING.md` to avoid using internal static state in `esp-stub-lib`, since the library is shared by different callers and should not carry caller-specific runtime state internally.

!!! This is a breaking API change.

Callers must now:
- query the required flash state buffer size with `stub_lib_flash_state_size()`
- allocate a buffer of at least that size
- pass that buffer to flash init/deinit APIs when state save/restore is needed

If no flash state save/restore is needed for a given flow, callers may still pass `NULL`.




