### PR TITLE
Flash state save restore

### DIFF
--- a/src/target/base/include/target/flash.h
+++ b/src/target/base/include/target/flash.h
@@ -40,7 +40,8 @@ typedef enum {
     SPI_FLASH_QPI_MODE,
 } spi_flash_mode_t;
 
-#define FLASH_SPI_NUM 1
+#define FLASH_SPI_NUM_INT 0 /* SPI flash controller used by cache */
+#define FLASH_SPI_NUM     1 /* SPI flash controller used by host CPU */
 
 /**
  * @brief Reset default SPI IOMUX pins to GPIO mode

--- a/src/target/esp32/src/flash.c
+++ b/src/target/esp32/src/flash.c
@@ -18,16 +18,27 @@
 
 extern esp_rom_spiflash_chip_t g_rom_flashchip;
 extern uint32_t esp_rom_efuse_get_flash_gpio_info(void);
+extern uint8_t g_rom_spiflash_dummy_len_plus[];
 
-/* Save/restore SPI registers. Can be extended to more registers if needed. */
 enum {
     SPI_USER_REG_ID = 0,
+    SPI_USER1_REG_ID,
+    SPI_USER2_REG_ID,
+    SPI_SLAVE_REG_ID,
+    SPI_CLOCK_REG_ID,
+    SPI_CTRL_REG_ID,
     SPI_REGS_NUM,
 };
 
 typedef struct {
     uint32_t spi_regs[SPI_REGS_NUM];
+    uint8_t dummy_len_plus;
 } stub_esp32_flash_state_t;
+
+size_t stub_target_flash_state_size(void)
+{
+    return sizeof(stub_esp32_flash_state_t);
+}
 
 uint32_t stub_target_flash_get_spiconfig_efuse(void)
 {
@@ -65,6 +76,12 @@ void stub_target_flash_state_save(void *state)
 
     stub_esp32_flash_state_t *s = state;
     s->spi_regs[SPI_USER_REG_ID] = READ_PERI_REG(SPI_USER_REG(FLASH_SPI_NUM));
+    s->spi_regs[SPI_USER1_REG_ID] = READ_PERI_REG(SPI_USER1_REG(FLASH_SPI_NUM));
+    s->spi_regs[SPI_USER2_REG_ID] = READ_PERI_REG(SPI_USER2_REG(FLASH_SPI_NUM));
+    s->spi_regs[SPI_SLAVE_REG_ID] = READ_PERI_REG(SPI_SLAVE_REG(FLASH_SPI_NUM));
+    s->spi_regs[SPI_CLOCK_REG_ID] = READ_PERI_REG(SPI_CLOCK_REG(FLASH_SPI_NUM));
+    s->spi_regs[SPI_CTRL_REG_ID] = READ_PERI_REG(SPI_CTRL_REG(FLASH_SPI_NUM));
+    s->dummy_len_plus = g_rom_spiflash_dummy_len_plus[FLASH_SPI_NUM];
 }
 
 void stub_target_flash_state_restore(const void *state)
@@ -75,11 +92,13 @@ void stub_target_flash_state_restore(const void *state)
 
     const stub_esp32_flash_state_t *s = state;
 
-    STUB_LOGD("SPI_USER_REG(1) was:0x%x, restored to:0x%x\n",
-              READ_PERI_REG(SPI_USER_REG(1)),
-              s->spi_regs[SPI_USER_REG_ID]);
-
+    WRITE_PERI_REG(SPI_USER1_REG(FLASH_SPI_NUM), s->spi_regs[SPI_USER1_REG_ID]);
+    WRITE_PERI_REG(SPI_USER2_REG(FLASH_SPI_NUM), s->spi_regs[SPI_USER2_REG_ID]);
+    WRITE_PERI_REG(SPI_SLAVE_REG(FLASH_SPI_NUM), s->spi_regs[SPI_SLAVE_REG_ID]);
+    WRITE_PERI_REG(SPI_CLOCK_REG(FLASH_SPI_NUM), s->spi_regs[SPI_CLOCK_REG_ID]);
+    WRITE_PERI_REG(SPI_CTRL_REG(FLASH_SPI_NUM), s->spi_regs[SPI_CTRL_REG_ID]);
     WRITE_PERI_REG(SPI_USER_REG(FLASH_SPI_NUM), s->spi_regs[SPI_USER_REG_ID]);
+    g_rom_spiflash_dummy_len_plus[FLASH_SPI_NUM] = s->dummy_len_plus;
 }
 
 /*
@@ -91,40 +110,61 @@ void stub_target_flash_state_restore(const void *state)
  */
 int stub_target_rom_spiflash_erase_area(uint32_t addr, uint32_t size)
 {
-    uint32_t spi0_ctrl = READ_PERI_REG(SPI_CTRL_REG(0));
-    uint32_t spi0_user = READ_PERI_REG(SPI_USER_REG(0));
-    uint32_t spi0_user1 = READ_PERI_REG(SPI_USER1_REG(0));
-    uint32_t spi0_user2 = READ_PERI_REG(SPI_USER2_REG(0));
-    uint32_t spi1_ctrl = READ_PERI_REG(SPI_CTRL_REG(1));
+    uint32_t spi0_ctrl = READ_PERI_REG(SPI_CTRL_REG(FLASH_SPI_NUM_INT));
+    uint32_t spi0_user = READ_PERI_REG(SPI_USER_REG(FLASH_SPI_NUM_INT));
+    uint32_t spi0_user1 = READ_PERI_REG(SPI_USER1_REG(FLASH_SPI_NUM_INT));
+    uint32_t spi0_user2 = READ_PERI_REG(SPI_USER2_REG(FLASH_SPI_NUM_INT));
+    uint32_t spi1_ctrl = READ_PERI_REG(SPI_CTRL_REG(FLASH_SPI_NUM));
 
     int rom_res = esp_rom_spiflash_erase_area(addr, size);
 
-    WRITE_PERI_REG(SPI_CTRL_REG(0), spi0_ctrl);
-    WRITE_PERI_REG(SPI_USER_REG(0), spi0_user);
-    WRITE_PERI_REG(SPI_USER1_REG(0), spi0_user1);
-    WRITE_PERI_REG(SPI_USER2_REG(0), spi0_user2);
-    WRITE_PERI_REG(SPI_CTRL_REG(1), spi1_ctrl);
+    WRITE_PERI_REG(SPI_CTRL_REG(FLASH_SPI_NUM_INT), spi0_ctrl);
+    WRITE_PERI_REG(SPI_USER_REG(FLASH_SPI_NUM_INT), spi0_user);
+    WRITE_PERI_REG(SPI_USER1_REG(FLASH_SPI_NUM_INT), spi0_user1);
+    WRITE_PERI_REG(SPI_USER2_REG(FLASH_SPI_NUM_INT), spi0_user2);
+    WRITE_PERI_REG(SPI_CTRL_REG(FLASH_SPI_NUM), spi1_ctrl);
 
     return rom_res;
 }
 
 bool stub_target_flash_needs_attach(void)
 {
-    return (READ_PERI_REG(SPI_CACHE_FCTRL_REG(0)) & SPI_CACHE_FLASH_USR_CMD) == 0;
+    return (READ_PERI_REG(SPI_CACHE_FCTRL_REG(FLASH_SPI_NUM_INT)) & SPI_CACHE_FLASH_USR_CMD) == 0;
+}
+
+static void stub_target_spi_init(void)
+{
+    /*
+     * Trimmed version of ROM SPI_init(SLOWRD_MODE, 4).
+     * We skip the module reset to avoid breaking communication with PSRAM.
+     */
+    WRITE_PERI_REG(SPI_CTRL_REG(FLASH_SPI_NUM), SPI_WP_REG | SPI_RESANDRES);
+    WRITE_PERI_REG(SPI_CLOCK_REG(FLASH_SPI_NUM), 0x3043U); /* precalculated for SPI_CLK_DIV(4) */
+
+    WRITE_PERI_REG(SPI_USER1_REG(FLASH_SPI_NUM), 0);
+    REG_SET_FIELD(SPI_USER1_REG(FLASH_SPI_NUM), SPI_USR_ADDR_BITLEN, 23);
+    REG_SET_FIELD(SPI_USER1_REG(FLASH_SPI_NUM), SPI_USR_DUMMY_CYCLELEN, 7);
+
+    g_rom_spiflash_dummy_len_plus[FLASH_SPI_NUM] = 0;
 }
 
 void stub_target_flash_init(void *state, stub_lib_flash_attach_policy_t attach_policy)
 {
-    (void)state;
-    uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();
+    if (state) {
+        stub_target_flash_state_save(state);
+    }
 
     if (attach_policy == STUB_LIB_FLASH_ATTACH_ALWAYS || stub_target_flash_needs_attach()) {
+        uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();
         stub_target_flash_attach(spiconfig, 0);
-        /*
-         * Command phase is always set in download mode.
-         * But in reset-run case, it seems to be not set.
-         * So we need to set it here before sending any command.
-         */
-        REG_SET_BIT(SPI_USER_REG(1), SPI_USR_COMMAND);
+    } else {
+        stub_target_spi_init();
     }
+
+    /*
+     * Command phase is always set in download mode.
+     * But in reset-run case, it seems to be not set.
+     * So we need to set it here before sending any command.
+     */
+    REG_SET_BIT(SPI_USER_REG(FLASH_SPI_NUM), SPI_USR_COMMAND);
 }

--- a/src/target/esp32s2/src/flash.c
+++ b/src/target/esp32s2/src/flash.c
@@ -15,10 +15,26 @@
 
 #include <soc/spi_mem_compat.h>
 
-#define SPI_INTERNAL 0
-
 extern esp_rom_spiflash_chip_t g_rom_flashchip;
 extern uint32_t esp_rom_efuse_get_flash_gpio_info(void);
+extern void spi_cache_mode_switch(uint32_t modebit);
+extern void spi_common_set_flash_cs_timing(void);
+
+enum {
+    SPI_USER_REG_ID = 0,
+    SPI_CLOCK_REG_ID,
+    SPI_CTRL_REG_ID,
+    SPI_REGS_NUM,
+};
+
+typedef struct {
+    uint32_t spi_regs[SPI_REGS_NUM];
+} stub_esp32s2_flash_state_t;
+
+size_t stub_target_flash_state_size(void)
+{
+    return sizeof(stub_esp32s2_flash_state_t);
+}
 
 uint32_t stub_target_flash_get_spiconfig_efuse(void)
 {
@@ -36,13 +52,82 @@ void stub_target_spi_wait_ready(void)
         /* busy wait */
     }
 
-    /* There is no HW arbiter on SPI0, so we need to wait for it to be ready */
-    while ((REG_READ(SPI_MEM_FSM_REG(SPI_INTERNAL)) & SPI_MEM_ST)) {
+    /* There is no HW arbiter on internal SPI, so we need to wait for it to be ready */
+    while ((REG_READ(SPI_MEM_FSM_REG(FLASH_SPI_NUM_INT)) & SPI_MEM_ST)) {
         /* busy wait */
     }
 }
 
 bool stub_target_flash_needs_attach(void)
 {
-    return (READ_PERI_REG(SPI_MEM_CACHE_FCTRL_REG(0)) & SPI_MEM_CACHE_FLASH_USR_CMD) == 0;
+    return (READ_PERI_REG(SPI_MEM_CACHE_FCTRL_REG(FLASH_SPI_NUM_INT)) & SPI_MEM_CACHE_FLASH_USR_CMD) == 0;
+}
+
+void stub_target_flash_state_save(void *state)
+{
+    if (!state) {
+        return;
+    }
+
+    stub_esp32s2_flash_state_t *s = state;
+    s->spi_regs[SPI_USER_REG_ID] = READ_PERI_REG(SPI_MEM_USER_REG(FLASH_SPI_NUM));
+    s->spi_regs[SPI_CLOCK_REG_ID] = READ_PERI_REG(SPI_MEM_CLOCK_REG(FLASH_SPI_NUM));
+    s->spi_regs[SPI_CTRL_REG_ID] = READ_PERI_REG(SPI_MEM_CTRL_REG(FLASH_SPI_NUM));
+}
+
+void stub_target_flash_state_restore(const void *state)
+{
+    if (!state) {
+        return;
+    }
+
+    const stub_esp32s2_flash_state_t *s = state;
+
+    WRITE_PERI_REG(SPI_MEM_CLOCK_REG(FLASH_SPI_NUM), s->spi_regs[SPI_CLOCK_REG_ID]);
+    WRITE_PERI_REG(SPI_MEM_CTRL_REG(FLASH_SPI_NUM), s->spi_regs[SPI_CTRL_REG_ID]);
+    WRITE_PERI_REG(SPI_MEM_USER_REG(FLASH_SPI_NUM), s->spi_regs[SPI_USER_REG_ID]);
+}
+
+static void stub_target_spi_init(void)
+{
+    const uint32_t freqbits = 0x30103; /* precalculated for SPI_CLK_DIV(4) */
+
+    /* Trimmed version of ROM SPI_init(SLOWRD_MODE, 4).
+     * We skip the module reset to avoid breaking communication with PSRAM. */
+    REG_CLR_BIT(SPI_MEM_MISC_REG(FLASH_SPI_NUM_INT), SPI_MEM_CS0_DIS);
+    REG_SET_BIT(SPI_MEM_MISC_REG(FLASH_SPI_NUM_INT), SPI_MEM_CS1_DIS);
+
+    spi_common_set_flash_cs_timing();
+
+    WRITE_PERI_REG(SPI_MEM_CLOCK_REG(FLASH_SPI_NUM), freqbits);
+    WRITE_PERI_REG(SPI_MEM_CLOCK_REG(FLASH_SPI_NUM_INT), freqbits);
+
+    WRITE_PERI_REG(SPI_MEM_CTRL_REG(FLASH_SPI_NUM), SPI_MEM_WP_REG | SPI_MEM_RESANDRES);
+    WRITE_PERI_REG(SPI_MEM_CTRL_REG(FLASH_SPI_NUM_INT), SPI_MEM_WP_REG);
+
+    REG_SET_FIELD(SPI_MEM_MISO_DLEN_REG(FLASH_SPI_NUM_INT), SPI_MEM_USR_MISO_DBITLEN, 0xff);
+    REG_SET_FIELD(SPI_MEM_MOSI_DLEN_REG(FLASH_SPI_NUM_INT), SPI_MEM_USR_MOSI_DBITLEN, 0xff);
+    REG_SET_FIELD(SPI_MEM_USER2_REG(FLASH_SPI_NUM_INT), SPI_MEM_USR_COMMAND_BITLEN, 0x7);
+    REG_SET_BIT(SPI_MEM_CACHE_FCTRL_REG(FLASH_SPI_NUM_INT), SPI_MEM_CACHE_REQ_EN);
+
+    WRITE_PERI_REG(SPI_MEM_DDR_REG(FLASH_SPI_NUM_INT), 0);
+    WRITE_PERI_REG(SPI_MEM_DDR_REG(FLASH_SPI_NUM), 0);
+    spi_cache_mode_switch(0);
+    REG_SET_BIT(SPI_MEM_CACHE_FCTRL_REG(FLASH_SPI_NUM_INT), SPI_MEM_CACHE_FLASH_USR_CMD);
+}
+
+void stub_target_flash_init(void *state, stub_lib_flash_attach_policy_t attach_policy)
+{
+    if (state) {
+        stub_target_flash_state_save(state);
+    }
+
+    if (attach_policy == STUB_LIB_FLASH_ATTACH_ALWAYS || stub_target_flash_needs_attach()) {
+        uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();
+        stub_target_flash_attach(spiconfig, 0);
+    } else {
+        stub_target_spi_init();
+    }
+
+    REG_SET_BIT(SPI_MEM_USER_REG(FLASH_SPI_NUM), SPI_MEM_USR_COMMAND);
 }

--- a/src/target/esp32s3/src/flash.c
+++ b/src/target/esp32s3/src/flash.c
@@ -19,8 +19,9 @@
 #include <soc/io_mux_reg.h>
 #include <soc/spi_mem_compat.h>
 
-#define SPI_INTERNAL 0
-
+extern void spi_cache_mode_switch(uint32_t modebit);
+extern void spi_common_set_flash_cs_timing(void);
+extern void esp_rom_opiflash_mode_reset(int spi_num);
 extern uint32_t ets_efuse_get_spiconfig(void);
 extern esp_rom_spiflash_legacy_funcs_t *rom_spiflash_legacy_funcs;
 extern uint32_t esp_rom_efuse_get_flash_gpio_info(void);
@@ -38,6 +39,24 @@ extern void esp_rom_opiflash_exec_cmd(int spi_num,
                                       uint32_t cs_mask,
                                       bool is_write_erase_operation);
 
+enum {
+    SPI_USER_REG_ID = 0,
+    SPI_CTRL_REG_ID,
+    SPI_CTRL2_REG_ID,
+    SPI_CLOCK_REG_ID,
+    SPI_DDR_REG_ID,
+    SPI_REGS_NUM,
+};
+
+typedef struct {
+    uint32_t spi_regs[SPI_REGS_NUM];
+} stub_esp32s3_flash_state_t;
+
+size_t stub_target_flash_state_size(void)
+{
+    return sizeof(stub_esp32s3_flash_state_t);
+}
+
 uint32_t stub_target_flash_get_spiconfig_efuse(void)
 {
     return esp_rom_efuse_get_flash_gpio_info();
@@ -54,25 +73,6 @@ static void stub_target_flash_init_funcs(void)
         .write_sub_len = 32,
     };
     rom_spiflash_legacy_funcs = &funcs;
-}
-
-bool stub_target_flash_needs_attach(void)
-{
-    return (READ_PERI_REG(SPI_MEM_CACHE_FCTRL_REG(0)) & SPI_MEM_CACHE_FLASH_USR_CMD) == 0;
-}
-
-void stub_target_flash_init(void *state, stub_lib_flash_attach_policy_t attach_policy)
-{
-    (void)state;
-    uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();
-
-    if (attach_policy == STUB_LIB_FLASH_ATTACH_ALWAYS || stub_target_flash_needs_attach()) {
-        stub_target_flash_attach(spiconfig, 0);
-        if (ets_efuse_flash_octal_mode()) {
-            STUB_LOGD("octal mode is on\n");
-            stub_target_flash_init_funcs();
-        }
-    }
 }
 
 void stub_target_opiflash_exec_cmd(const opiflash_cmd_params_t *params)
@@ -97,8 +97,8 @@ void stub_target_spi_wait_ready(void)
     while (REG_GET_FIELD(SPI_MEM_FSM_REG(FLASH_SPI_NUM), SPI_MEM_ST)) {
         /* busy wait */
     }
-    /* There is no HW arbiter on SPI_INTERNAL, so we need to wait for it to be ready */
-    while ((REG_READ(SPI_MEM_FSM_REG(SPI_INTERNAL)) & SPI_MEM_ST)) {
+    /* There is no HW arbiter on internal SPI, so we need to wait for it to be ready */
+    while ((REG_READ(SPI_MEM_FSM_REG(FLASH_SPI_NUM_INT)) & SPI_MEM_ST)) {
         /* busy wait */
     }
 }
@@ -107,4 +107,92 @@ uint32_t stub_target_get_max_supported_flash_size(void)
 {
     /* ESP32-S3 supports up to 1GB with 4-byte addressing */
     return GIB(1);
+}
+
+bool stub_target_flash_needs_attach(void)
+{
+    return (READ_PERI_REG(SPI_MEM_CACHE_FCTRL_REG(FLASH_SPI_NUM_INT)) & SPI_MEM_CACHE_FLASH_USR_CMD) == 0;
+}
+
+void stub_target_flash_state_save(void *state)
+{
+    if (!state) {
+        return;
+    }
+
+    stub_esp32s3_flash_state_t *s = state;
+    s->spi_regs[SPI_USER_REG_ID] = READ_PERI_REG(SPI_MEM_USER_REG(FLASH_SPI_NUM));
+    s->spi_regs[SPI_CTRL_REG_ID] = READ_PERI_REG(SPI_MEM_CTRL_REG(FLASH_SPI_NUM));
+    s->spi_regs[SPI_CTRL2_REG_ID] = READ_PERI_REG(SPI_MEM_CTRL2_REG(FLASH_SPI_NUM));
+    s->spi_regs[SPI_CLOCK_REG_ID] = READ_PERI_REG(SPI_MEM_CLOCK_REG(FLASH_SPI_NUM));
+    s->spi_regs[SPI_DDR_REG_ID] = READ_PERI_REG(SPI_MEM_DDR_REG(FLASH_SPI_NUM));
+}
+
+void stub_target_flash_state_restore(const void *state)
+{
+    if (!state)
+        return;
+
+    const stub_esp32s3_flash_state_t *s = state;
+    WRITE_PERI_REG(SPI_MEM_CTRL_REG(FLASH_SPI_NUM), s->spi_regs[SPI_CTRL_REG_ID]);
+    WRITE_PERI_REG(SPI_MEM_CTRL2_REG(FLASH_SPI_NUM), s->spi_regs[SPI_CTRL2_REG_ID]);
+    WRITE_PERI_REG(SPI_MEM_CLOCK_REG(FLASH_SPI_NUM), s->spi_regs[SPI_CLOCK_REG_ID]);
+    WRITE_PERI_REG(SPI_MEM_DDR_REG(FLASH_SPI_NUM), s->spi_regs[SPI_DDR_REG_ID]);
+    WRITE_PERI_REG(SPI_MEM_USER_REG(FLASH_SPI_NUM), s->spi_regs[SPI_USER_REG_ID]);
+}
+
+static void stub_target_spi_init(void)
+{
+    const uint32_t freqbits = 0x30103; /* precalculated for SPI_CLK_DIV(4) */
+
+    /*
+     * Trimmed version of ROM SPI_init(SLOWRD_MODE, 4).
+     * We skip the module reset to avoid breaking communication with PSRAM.
+     */
+    REG_CLR_BIT(SPI_MEM_MISC_REG(FLASH_SPI_NUM_INT), SPI_MEM_CS0_DIS);
+    REG_SET_BIT(SPI_MEM_MISC_REG(FLASH_SPI_NUM_INT), SPI_MEM_CS1_DIS);
+
+    spi_common_set_flash_cs_timing();
+
+    WRITE_PERI_REG(SPI_MEM_CLOCK_REG(FLASH_SPI_NUM), freqbits);
+    WRITE_PERI_REG(SPI_MEM_CLOCK_REG(FLASH_SPI_NUM_INT), freqbits);
+
+    WRITE_PERI_REG(SPI_MEM_CTRL_REG(FLASH_SPI_NUM), SPI_MEM_WP_REG | SPI_MEM_RESANDRES);
+    WRITE_PERI_REG(SPI_MEM_CTRL_REG(FLASH_SPI_NUM_INT), SPI_MEM_WP_REG);
+
+    REG_SET_FIELD(SPI_MEM_MISO_DLEN_REG(FLASH_SPI_NUM_INT), SPI_MEM_USR_MISO_DBITLEN, 0xff);
+    REG_SET_FIELD(SPI_MEM_MOSI_DLEN_REG(FLASH_SPI_NUM_INT), SPI_MEM_USR_MOSI_DBITLEN, 0xff);
+    REG_SET_FIELD(SPI_MEM_USER2_REG(FLASH_SPI_NUM_INT), SPI_MEM_USR_COMMAND_BITLEN, 0x7);
+    REG_SET_BIT(SPI_MEM_CACHE_FCTRL_REG(FLASH_SPI_NUM_INT), SPI_MEM_CACHE_REQ_EN);
+
+    WRITE_PERI_REG(SPI_MEM_DDR_REG(FLASH_SPI_NUM_INT), 0);
+    WRITE_PERI_REG(SPI_MEM_DDR_REG(FLASH_SPI_NUM), 0);
+    spi_cache_mode_switch(0);
+    REG_SET_BIT(SPI_MEM_CACHE_FCTRL_REG(FLASH_SPI_NUM_INT), SPI_MEM_CACHE_FLASH_USR_CMD);
+}
+
+void stub_target_flash_init(void *state, stub_lib_flash_attach_policy_t attach_policy)
+{
+    bool octal_mode = ets_efuse_flash_octal_mode();
+
+    if (state) {
+        stub_target_flash_state_save(state);
+    }
+
+    if (attach_policy == STUB_LIB_FLASH_ATTACH_ALWAYS || stub_target_flash_needs_attach()) {
+        uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();
+        stub_target_flash_attach(spiconfig, 0);
+    } else {
+        stub_target_spi_init();
+        if (octal_mode) {
+            esp_rom_opiflash_mode_reset(FLASH_SPI_NUM);
+        }
+    }
+
+    REG_SET_BIT(SPI_MEM_USER_REG(FLASH_SPI_NUM), SPI_MEM_USR_COMMAND);
+
+    if (octal_mode) {
+        STUB_LOGD("octal mode is on\n");
+        stub_target_flash_init_funcs();
+    }
 }


### PR DESCRIPTION
Add target-specific flash state save/restore support.

The goal is to preserve the relevant flash controller state when the stub uses the non-attach path and then restore it before returning.


