### PR TITLE
feat(flash): Add padding for not aligned write

### DIFF
--- a/include/esp-stub-lib/flash.h
+++ b/include/esp-stub-lib/flash.h
@@ -117,9 +117,11 @@ int stub_lib_flash_read_buff(uint32_t addr, void *buffer, uint32_t size);
 /**
  * @brief Write data to SPI flash from a buffer.
  *
- * @param addr Address to write to. Should be 4 bytes aligned.
+ * @param addr Address to write to. Unencrypted writes may use any offset; partial words use 0xFF padding. Encrypted
+ *             writes require a 16-byte aligned address.
  * @param buffer Source buffer
- * @param size Number of bytes to write. Should be 4 bytes aligned.
+ * @param size Number of bytes to write. Unencrypted writes may use any length; the tail is padded to a word with 0xFF.
+ *             Encrypted writes require a 16-byte aligned size.
  * @param encrypt Whether to use encrypted write
  *
  * @return Result:

--- a/src/flash.c
+++ b/src/flash.c
@@ -18,10 +18,29 @@
 #include <private/rom_flash.h>
 #include <private/rom_flash_config.h>
 
+extern void *memcpy(void *dest, const void *src, size_t n);
+
 // For flash size > 16MB, we use 4-byte addressing, only some targets support this.
 static bool large_flash_mode = false;
 
 #define STUB_FLASH_ERASE_TIMEOUT_US 1000000U
+
+static int flash_write_buff(uint32_t addr, const void *buffer, uint32_t size, bool encrypt)
+{
+    if (large_flash_mode) {
+        return stub_target_flash_4byte_write(FLASH_SPI_NUM, addr, (const uint8_t *)buffer, size, encrypt);
+    }
+    return stub_target_flash_write_buff(addr, buffer, size, encrypt);
+}
+
+static int flash_write_partial_word(uint32_t word_addr, const uint8_t *src, uint32_t size, uint32_t offset)
+{
+    uint8_t word[4] = { 0xFFU, 0xFFU, 0xFFU, 0xFFU };
+
+    memcpy(word + offset, src, size);
+
+    return flash_write_buff(word_addr, word, sizeof(word), false);
+}
 
 int stub_lib_flash_update_config(stub_lib_flash_config_t *config)
 {
@@ -125,16 +144,55 @@ int stub_lib_flash_write_buff(uint32_t addr, const void *buffer, uint32_t size, 
 {
     STUB_LOGV("Flash write: addr: 0x%x, size: %u, large: %d, enc: %d\n", addr, size, large_flash_mode, encrypt);
 
-    if (!IS_ALIGNED(addr, 4) || !IS_ALIGNED(size, 4)) {
-        STUB_LOGE("Flash write unaligned!\n");
-        return STUB_LIB_ERR_FLASH_WRITE_UNALIGNED;
+    if (size == 0) {
+        return STUB_LIB_OK;
     }
 
-    if (large_flash_mode) {
-        return stub_target_flash_4byte_write(FLASH_SPI_NUM, addr, buffer, size, encrypt);
+    if (encrypt) {
+        if (!IS_ALIGNED(addr, 16) || !IS_ALIGNED(size, 16)) {
+            STUB_LOGE("Encrypted flash write requires 16-byte alignment\n");
+            return STUB_LIB_ERR_FLASH_WRITE_UNALIGNED;
+        }
+        return flash_write_buff(addr, buffer, size, true);
     }
 
-    return stub_target_flash_write_buff(addr, buffer, size, encrypt);
+    if (IS_ALIGNED(addr, 4) && IS_ALIGNED(size, 4)) {
+        return flash_write_buff(addr, buffer, size, false);
+    }
+
+    const uint8_t *src = (const uint8_t *)buffer;
+    uint32_t flash_addr = ALIGN_DOWN(addr, 4);
+    uint32_t offset = addr - flash_addr;
+
+    if (offset != 0) {
+        uint32_t head_size = MIN(size, 4 - offset);
+        int res = flash_write_partial_word(flash_addr, src, head_size, offset);
+        if (res != STUB_LIB_OK) {
+            return res;
+        }
+
+        src += head_size;
+        size -= head_size;
+        flash_addr += 4;
+    }
+
+    uint32_t aligned_size = ALIGN_DOWN(size, 4);
+    if (aligned_size > 0) {
+        int res = flash_write_buff(flash_addr, src, aligned_size, false);
+        if (res != STUB_LIB_OK) {
+            return res;
+        }
+
+        src += aligned_size;
+        size -= aligned_size;
+        flash_addr += aligned_size;
+    }
+
+    if (size > 0) {
+        return flash_write_partial_word(flash_addr, src, size, 0);
+    }
+
+    return STUB_LIB_OK;
 }
 
 int stub_lib_flash_erase_chip(void)


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
This PR adds handling for not 4-byte aligned address and data size flash write. 
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing
This feature was so far tested only on ESP32C6, with alligned and non-alligned addresses and different binary sizes (onebyte, a few bytes, sector size, one kB, one MB). 
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
