### PR TITLE
feat(uart): handle UART RX FIFO full and timeout per SoC

### DIFF
--- a/example/stub_main.c
+++ b/example/stub_main.c
@@ -117,6 +117,7 @@ static int __attribute__((unused)) handle_test_uart(void)
 
     stub_lib_uart_init(UART_NUM_0);
     stub_lib_uart_set_rx_timeout(UART_NUM_0, 10);
+    stub_lib_uart_set_rxfifo_full_threshold(UART_NUM_0, 10);
     (void)stub_lib_uart_get_rxfifo_count(UART_NUM_0);
     (void)stub_lib_uart_clear_intr_flags(UART_NUM_0);
     (void)stub_lib_uart_read_rxfifo_byte(UART_NUM_0);

--- a/include/esp-stub-lib/uart.h
+++ b/include/esp-stub-lib/uart.h
@@ -109,13 +109,24 @@ uint32_t stub_lib_uart_get_rxfifo_count(uart_port_t uart_num);
 uint8_t stub_lib_uart_read_rxfifo_byte(uart_port_t uart_num);
 
 /**
- * @brief Configure RX timeout threshold
+ * @brief Configure RX timeout threshold and enable
  *
  * @param uart_num UART port number
- * @param timeout Timeout value in bit times (1-126, 0 to disable)
- * timeout mean the multiple of UART packets (~11 bytes) that can be received before timeout
+ * @param timeout Threshold for RX timeout (masked with chip `UART_RX_TOUT_THRHD_V`); 0 disables.
+ *                Use `UART_RX_TOUT_THRHD_V` for the widest value the current SoC allows.
+ *
+ * @note The UART block stores threshold and enable in different registers on some SoCs;
+ *       this function applies the correct sequence for the current target headers.
  */
 void stub_lib_uart_set_rx_timeout(uart_port_t uart_num, uint8_t timeout);
+
+/**
+ * @brief Configure RX FIFO full interrupt threshold
+ *
+ * @param uart_num UART port number
+ * @param threshold Number of bytes in RX FIFO needed to trigger RXFIFO_FULL interrupt
+ */
+void stub_lib_uart_set_rxfifo_full_threshold(uart_port_t uart_num, uint16_t threshold);
 
 /**
  * @brief Transmit a single byte over UART.

--- a/src/target/base/include/target/uart.h
+++ b/src/target/base/include/target/uart.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -34,6 +34,17 @@ void stub_target_uart_rominit_set_baudrate(uint8_t uart_num, uint32_t baudrate);
  * @brief Flush any buffered transmit data.
  */
 void stub_target_uart_tx_flush(uint8_t uart_no);
+
+/**
+ * @brief Configure UART RX timeout threshold and enable (SoC-specific layout).
+ *
+ * Default (weak): UART_TOUT_CONF_SYNC_REG + UART_REG_UPDATE_REG where present.
+ * Override on targets that use MEM_CONF / CONF1 only layouts.
+ *
+ * @param uart_num UART port number
+ * @param timeout Threshold (masked per SoC); 0 disables RX timeout.
+ */
+void stub_target_uart_set_rx_timeout(uint8_t uart_num, uint8_t timeout);
 
 /**
  * @brief Wrapper for esp_rom_uart_attach

--- a/src/target/common/src/uart.c
+++ b/src/target/common/src/uart.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
@@ -8,9 +8,13 @@
 #include <stdint.h>
 
 #include <esp-stub-lib/rom_wrappers.h>
+#include <esp-stub-lib/soc_utils.h>
 
 #include <target/clock.h>
 #include <target/uart.h>
+
+#include <soc/soc_caps.h>
+#include <soc/uart_reg.h>
 
 extern void esp_rom_uart_set_as_console(uint8_t uart_no);
 extern void esp_rom_uart_tx_wait_idle(uint8_t uart_num);
@@ -44,4 +48,23 @@ void __attribute__((weak)) stub_target_uart_rominit_set_baudrate(uint8_t uart_nu
 void __attribute__((weak)) stub_target_uart_tx_flush(uint8_t uart_no)
 {
     esp_rom_uart_flush_tx(uart_no);
+}
+
+void __attribute__((weak)) stub_target_uart_set_rx_timeout(uint8_t uart_num, uint8_t timeout)
+{
+#if defined(SOC_UART_HAS_SYNC_REG_UPDATE) && SOC_UART_HAS_SYNC_REG_UPDATE
+    if (timeout > 0U) {
+        SET_PERI_REG_BITS(UART_TOUT_CONF_SYNC_REG(uart_num), UART_RX_TOUT_THRHD_V, timeout, UART_RX_TOUT_THRHD_S);
+        SET_PERI_REG_BITS(UART_TOUT_CONF_SYNC_REG(uart_num), UART_RX_TOUT_EN_V, 1U, UART_RX_TOUT_EN_S);
+    } else {
+        SET_PERI_REG_BITS(UART_TOUT_CONF_SYNC_REG(uart_num), UART_RX_TOUT_EN_V, 0U, UART_RX_TOUT_EN_S);
+    }
+
+    WRITE_PERI_REG(UART_REG_UPDATE_REG(uart_num), UART_REG_UPDATE);
+    while ((READ_PERI_REG(UART_REG_UPDATE_REG(uart_num)) & UART_REG_UPDATE) != 0U) {
+    }
+#else
+    (void)uart_num;
+    (void)timeout;
+#endif
 }

--- a/src/target/esp32/src/uart.c
+++ b/src/target/esp32/src/uart.c
@@ -100,3 +100,13 @@ void stub_target_uart_rominit_set_baudrate(uint8_t uart_num, uint32_t baudrate)
 
     stub_lib_delay_us(5 * 1000);
 }
+
+void stub_target_uart_set_rx_timeout(uint8_t uart_num, uint8_t timeout)
+{
+    if (timeout > 0U) {
+        SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RX_TOUT_THRHD_V, timeout, UART_RX_TOUT_THRHD_S);
+        SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RX_TOUT_EN_V, 1U, UART_RX_TOUT_EN_S);
+    } else {
+        SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RX_TOUT_EN_V, 0U, UART_RX_TOUT_EN_S);
+    }
+}

--- a/src/target/esp32c2/src/uart.c
+++ b/src/target/esp32c2/src/uart.c
@@ -55,3 +55,13 @@ void stub_target_uart_rominit_set_baudrate(uint8_t uart_num, uint32_t baudrate)
 
     stub_lib_delay_us(5 * 1000);
 }
+
+void stub_target_uart_set_rx_timeout(uint8_t uart_num, uint8_t timeout)
+{
+    if (timeout > 0U) {
+        SET_PERI_REG_BITS(UART_MEM_CONF_REG(uart_num), UART_RX_TOUT_THRHD_V, timeout, UART_RX_TOUT_THRHD_S);
+        SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RX_TOUT_EN_V, 1U, UART_RX_TOUT_EN_S);
+    } else {
+        SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RX_TOUT_EN_V, 0U, UART_RX_TOUT_EN_S);
+    }
+}

--- a/src/target/esp32c3/src/uart.c
+++ b/src/target/esp32c3/src/uart.c
@@ -57,3 +57,13 @@ void stub_target_uart_rominit_set_baudrate(uint8_t uart_num, uint32_t baudrate)
 
     stub_lib_delay_us(5 * 1000);
 }
+
+void stub_target_uart_set_rx_timeout(uint8_t uart_num, uint8_t timeout)
+{
+    if (timeout > 0U) {
+        SET_PERI_REG_BITS(UART_MEM_CONF_REG(uart_num), UART_RX_TOUT_THRHD_V, timeout, UART_RX_TOUT_THRHD_S);
+        SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RX_TOUT_EN_V, 1U, UART_RX_TOUT_EN_S);
+    } else {
+        SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RX_TOUT_EN_V, 0U, UART_RX_TOUT_EN_S);
+    }
+}

--- a/src/target/esp32c5/include/soc/soc_caps.h
+++ b/src/target/esp32c5/include/soc/soc_caps.h
@@ -8,6 +8,7 @@
 
 /*-------------------------- COMMON CAPS ---------------------------------------*/
 #define SOC_UART_HP_NUM             (2)     /*!< HP UART number */
+#define SOC_UART_HAS_SYNC_REG_UPDATE 1
 
 // Memory Caps
 #define SOC_RTC_FAST_MEM_SUPPORTED  1

--- a/src/target/esp32c6/include/soc/soc_caps.h
+++ b/src/target/esp32c6/include/soc/soc_caps.h
@@ -8,6 +8,7 @@
 
 /*-------------------------- COMMON CAPS ---------------------------------------*/
 #define SOC_UART_HP_NUM             (2)     /*!< HP UART number */
+#define SOC_UART_HAS_SYNC_REG_UPDATE 1
 
 // Memory Caps
 #define SOC_RTC_FAST_MEM_SUPPORTED  1

--- a/src/target/esp32c61/include/soc/soc_caps.h
+++ b/src/target/esp32c61/include/soc/soc_caps.h
@@ -8,3 +8,4 @@
 
 /*-------------------------- COMMON CAPS ---------------------------------------*/
 #define SOC_UART_HP_NUM             (2)     /*!< HP UART number */
+#define SOC_UART_HAS_SYNC_REG_UPDATE 1

--- a/src/target/esp32h2/include/soc/soc_caps.h
+++ b/src/target/esp32h2/include/soc/soc_caps.h
@@ -8,6 +8,7 @@
 
 /*-------------------------- COMMON CAPS ---------------------------------------*/
 #define SOC_UART_HP_NUM             (2)     /*!< HP UART number */
+#define SOC_UART_HAS_SYNC_REG_UPDATE 1
 
 // Memory Caps
 #define SOC_RTC_FAST_MEM_SUPPORTED  1

--- a/src/target/esp32h21/include/soc/soc_caps.h
+++ b/src/target/esp32h21/include/soc/soc_caps.h
@@ -8,6 +8,7 @@
 
 /*-------------------------- COMMON CAPS ---------------------------------------*/
 #define SOC_UART_HP_NUM             (2)     /*!< HP UART number */
+#define SOC_UART_HAS_SYNC_REG_UPDATE 1
 
 // Memory Caps
 #define SOC_RTC_FAST_MEM_SUPPORTED  1

--- a/src/target/esp32h4/include/soc/soc_caps.h
+++ b/src/target/esp32h4/include/soc/soc_caps.h
@@ -8,3 +8,4 @@
 
 /*-------------------------- COMMON CAPS ---------------------------------------*/
 #define SOC_UART_HP_NUM             (2)     /*!< HP UART number */
+#define SOC_UART_HAS_SYNC_REG_UPDATE 1

--- a/src/target/esp32p4/include/soc/soc_caps.h
+++ b/src/target/esp32p4/include/soc/soc_caps.h
@@ -8,6 +8,7 @@
 
 /*-------------------------- COMMON CAPS ---------------------------------------*/
 #define SOC_UART_HP_NUM             (5)     /*!< HP UART number */
+#define SOC_UART_HAS_SYNC_REG_UPDATE 1
 
 // Memory Caps
 #define SOC_RTC_FAST_MEM_SUPPORTED  1

--- a/src/target/esp32s2/src/uart.c
+++ b/src/target/esp32s2/src/uart.c
@@ -51,3 +51,13 @@ void stub_target_uart_rominit_set_baudrate(uint8_t uart_num, uint32_t baudrate)
 
     stub_lib_delay_us(5 * 1000);
 }
+
+void stub_target_uart_set_rx_timeout(uint8_t uart_num, uint8_t timeout)
+{
+    if (timeout > 0U) {
+        SET_PERI_REG_BITS(UART_MEM_CONF_REG(uart_num), UART_RX_TOUT_THRHD_V, timeout, UART_RX_TOUT_THRHD_S);
+        SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RX_TOUT_EN_V, 1U, UART_RX_TOUT_EN_S);
+    } else {
+        SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RX_TOUT_EN_V, 0U, UART_RX_TOUT_EN_S);
+    }
+}

--- a/src/target/esp32s3/src/uart.c
+++ b/src/target/esp32s3/src/uart.c
@@ -54,3 +54,13 @@ void stub_target_uart_rominit_set_baudrate(uint8_t uart_num, uint32_t baudrate)
 
     stub_lib_delay_us(5 * 1000);
 }
+
+void stub_target_uart_set_rx_timeout(uint8_t uart_num, uint8_t timeout)
+{
+    if (timeout > 0U) {
+        SET_PERI_REG_BITS(UART_MEM_CONF_REG(uart_num), UART_RX_TOUT_THRHD_V, timeout, UART_RX_TOUT_THRHD_S);
+        SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RX_TOUT_EN_V, 1U, UART_RX_TOUT_EN_S);
+    } else {
+        SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RX_TOUT_EN_V, 0U, UART_RX_TOUT_EN_S);
+    }
+}

--- a/src/target/esp32s31/include/soc/soc_caps.h
+++ b/src/target/esp32s31/include/soc/soc_caps.h
@@ -7,4 +7,5 @@
 #pragma once
 
 /*-------------------------- COMMON CAPS ---------------------------------------*/
-#define SOC_UART_HP_NUM         (4)    /*!< HP UART number */
+#define SOC_UART_HP_NUM             (4)    /*!< HP UART number */
+#define SOC_UART_HAS_SYNC_REG_UPDATE 1

--- a/src/target/esp8266/include/soc/uart_reg.h
+++ b/src/target/esp8266/include/soc/uart_reg.h
@@ -149,6 +149,8 @@ extern "C" {
 #define UART_CONF1_REG(i)                   (REG_UART_BASE(i) + 0x24)
 #define UART_RX_TOUT_EN                     (BIT(31))
 #define UART_RX_TOUT_EN_M                   (BIT(31))
+#define UART_RX_TOUT_EN_V                   0x1
+#define UART_RX_TOUT_EN_S                   31
 #define UART_RX_TOUT_THRHD_M                (UART_RX_TOUT_THRHD_V << UART_RX_TOUT_THRHD_S)
 #define UART_RX_TOUT_THRHD_V                0x0000007F
 #define UART_RX_TOUT_THRHD_S                24

--- a/src/target/esp8266/src/uart.c
+++ b/src/target/esp8266/src/uart.c
@@ -76,3 +76,13 @@ void stub_target_uart_tx_flush(uint8_t uart_no)
         // wait for TX fifo to be empty, ROM code works the same way
     }
 }
+
+void stub_target_uart_set_rx_timeout(uint8_t uart_num, uint8_t timeout)
+{
+    if (timeout > 0U) {
+        SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RX_TOUT_THRHD_V, timeout, UART_RX_TOUT_THRHD_S);
+        SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RX_TOUT_EN_V, 1U, UART_RX_TOUT_EN_S);
+    } else {
+        SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RX_TOUT_EN_V, 0U, UART_RX_TOUT_EN_S);
+    }
+}

--- a/src/uart.c
+++ b/src/uart.c
@@ -75,14 +75,12 @@ uint8_t stub_lib_uart_read_rxfifo_byte(uart_port_t uart_num)
 
 void stub_lib_uart_set_rx_timeout(uart_port_t uart_num, uint8_t timeout)
 {
-    uint32_t conf1 = READ_PERI_REG(UART_CONF1_REG(uart_num));
-    conf1 &= ~(UART_RX_TOUT_THRHD_M | UART_RX_TOUT_EN_M);
+    stub_target_uart_set_rx_timeout(uart_num, timeout);
+}
 
-    if (timeout > 0U) {
-        conf1 |= (((uint32_t)timeout & UART_RX_TOUT_THRHD_V) << UART_RX_TOUT_THRHD_S) | UART_RX_TOUT_EN;
-    }
-
-    WRITE_PERI_REG(UART_CONF1_REG(uart_num), conf1);
+void stub_lib_uart_set_rxfifo_full_threshold(uart_port_t uart_num, uint16_t threshold)
+{
+    SET_PERI_REG_BITS(UART_CONF1_REG(uart_num), UART_RXFIFO_FULL_THRHD_V, threshold, UART_RXFIFO_FULL_THRHD_S);
 }
 
 uint8_t stub_lib_uart_tx_one_char(uint8_t c)


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description
This pull request adds correct UART RX timeout handling for each SoC, because the registers that set the threshold and enable the timeout differ by some chips.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing
There are three groups of SoCs that handles RX timeout differently 
1. UART_TOUT_CONF_SYNC_REG register is used to set value and enable RX timeout and UART_REG_UPDATE_REG register to update register settings
    - esp32c5 and esp32c6 tested
2. UART_MEM_CONF_REG register is used to set the value and UART_CONF1_REG to enable the timeout
    - esp32s3 and esp32c3 tested
3. UART_CONF1_REG register is used to set the value and enable the timeout
    - esp32 tested

The testing was done using esptool with stub via the UART. 
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
