### PR TITLE
feat(sdio): Add support for SDIO slave interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(srcs
     src/rom_wrappers.c
     src/security.c
     src/sha256.c
+    src/sdio.c
     src/uart.c
     src/usb_serial_jtag.c
     src/usb_otg.c

--- a/example/stub_main.c
+++ b/example/stub_main.c
@@ -16,6 +16,7 @@
 #include <esp-stub-lib/md5.h>
 #include <esp-stub-lib/mem_utils.h>
 #include <esp-stub-lib/miniz.h>
+#include <esp-stub-lib/sdio.h>
 #include <esp-stub-lib/security.h>
 #include <esp-stub-lib/sha256.h>
 #include <esp-stub-lib/uart.h>
@@ -93,6 +94,18 @@ static void __attribute__((unused)) test_usb_serial_jtag(void)
     (void)stub_lib_usb_serial_jtag_read_rxfifo_byte();
     (void)stub_lib_usb_serial_jtag_tx_one_char('A');
     (void)stub_lib_usb_serial_jtag_tx_flush();
+}
+
+static void __attribute__((unused)) test_sdio(void)
+{
+    uint8_t rx_buf[512] __attribute__((aligned(4)));
+    size_t rx_len;
+
+    (void)stub_lib_sdio_is_active();
+    stub_lib_sdio_init();
+    (void)stub_lib_sdio_take_rx_frame(&rx_len);
+    (void)stub_lib_sdio_rearm(rx_buf, sizeof(rx_buf));
+    (void)stub_lib_sdio_tx_frame(rx_buf, sizeof(rx_buf));
 }
 
 static __attribute__((unused)) void test_md5(void)
@@ -210,6 +223,7 @@ static __attribute__((unused)) int handle_test2(va_list ap)
     test_sha256();
     test_md5();
     test_usb_serial_jtag();
+    test_sdio();
     test_miniz();
     test_clock_init();
 

--- a/include/esp-stub-lib/sdio.h
+++ b/include/esp-stub-lib/sdio.h
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Maximum frame length supported by SDIO DMA descriptor size/length fields. */
+#define SDIO_DMA_DESC_MAX_LEN 0x3FFFU
+
+/**
+ * @brief Check if SDIO is the active download transport.
+ *
+ * Calls ROM sip_download_begin(). Safe to call before stub_lib_sdio_init().
+ *
+ * @return true if SDIO download mode is active
+ */
+bool stub_lib_sdio_is_active(void);
+
+/**
+ * @brief Initialise SDIO transport and register the receive ISR.
+ *
+ * Resets the SLC DMA, initialises credits, and registers the internal SLC0 ISR
+ * using ROM interrupt infrastructure. The CPU interrupt number is chosen
+ * per-target inside the driver. Call stub_lib_sdio_rearm(buf, max_size) to arm
+ * receive DMA.
+ */
+void stub_lib_sdio_init(void);
+
+/**
+ * @brief Claim a completed received frame from the SDIO driver.
+ *
+ * Returns true once per received frame and writes its byte count to @p out_len.
+ * The transport should mark the shared frame buffer complete before calling
+ * stub_lib_sdio_rearm(buf, max_size).
+ */
+bool stub_lib_sdio_take_rx_frame(size_t *out_len);
+
+/**
+ * @brief Arm the receive DMA when it is not already armed.
+ *
+ * If the receive DMA is already armed, this is a no-op. Call after freeing or
+ * claiming a frame buffer to provide the next DMA destination.
+ *
+ * @param buf      Writable 4-byte-aligned receive buffer.
+ * @param max_size Capacity of @p buf in bytes.
+ * @return STUB_LIB_OK on success, STUB_LIB_ERR_* on failure.
+ */
+int stub_lib_sdio_rearm(uint8_t *buf, size_t max_size);
+
+/**
+ * @brief Send one raw SDIO frame.
+ *
+ * Transfers via SLC slave-to-host DMA and waits until the host consumes the
+ * packet, so stack-backed buffers remain valid for the duration.
+ *
+ * @param data Pointer to frame bytes (must be 4-byte aligned).
+ * @param len  Number of frame bytes, up to the DMA descriptor limit (0x3FFF).
+ * @return STUB_LIB_OK on success, STUB_LIB_ERR_* on failure.
+ */
+int stub_lib_sdio_tx_frame(const void *data, size_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/sdio.c
+++ b/src/sdio.c
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <esp-stub-lib/bit_utils.h>
+#include <esp-stub-lib/err.h>
+#include <esp-stub-lib/log.h>
+#include <esp-stub-lib/sdio.h>
+
+#include <target/sdio.h>
+
+#define SDIO_DMA_ALIGN 4U
+
+bool stub_lib_sdio_is_active(void)
+{
+    return stub_target_sdio_is_active();
+}
+
+void stub_lib_sdio_init(void)
+{
+    stub_target_sdio_init();
+}
+
+bool stub_lib_sdio_take_rx_frame(size_t *out_len)
+{
+    return stub_target_sdio_take_rx_frame(out_len);
+}
+
+int stub_lib_sdio_rearm(uint8_t *buf, size_t max_size)
+{
+    if (buf == NULL || max_size == 0 || !IS_ALIGNED((uintptr_t)buf, SDIO_DMA_ALIGN)) {
+        STUB_LOGE("Invalid SDIO RX buffer\n");
+        return STUB_LIB_ERR_INVALID_ARG;
+    }
+    int ret = stub_target_sdio_rearm(buf, max_size);
+    if (ret != STUB_LIB_OK) {
+        STUB_LOGE("Failed to arm SDIO RX\n");
+        return ret;
+    }
+    return STUB_LIB_OK;
+}
+
+int stub_lib_sdio_tx_frame(const void *data, size_t len)
+{
+    if (data == NULL || len == 0 || len > SDIO_DMA_DESC_MAX_LEN || !IS_ALIGNED((uintptr_t)data, SDIO_DMA_ALIGN)) {
+        STUB_LOGE("Invalid SDIO TX frame\n");
+        return STUB_LIB_ERR_INVALID_ARG;
+    }
+    int ret = stub_target_sdio_tx_frame(data, len);
+    if (ret != STUB_LIB_OK) {
+        STUB_LOGE("Failed to send SDIO frame\n");
+        return ret;
+    }
+    return STUB_LIB_OK;
+}

--- a/src/target/base/include/private/rom_sdio_types.h
+++ b/src/target/base/include/private/rom_sdio_types.h
@@ -1,0 +1,128 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * Type definitions for the ROM SLC/SIP layer used by SDIO.
+ *
+ * The struct layouts here must match the ROM's internal structures exactly.
+ * Layout is derived from static analysis of the ESP32-C6 ROM and confirmed
+ * to match ESP32-C5 (same SIP/SLC ROM API, same struct layout).
+ *   - lldesc_t: standard ESP DMA linked-list descriptor (12 bytes)
+ *   - sip_t:    ROM SIP control block (~88 bytes)
+ *
+ * STAILQ_HEAD is assumed to be the standard BSD two-pointer form (8 bytes on
+ * a 32-bit system). enum/sip_state_t is int-sized (4 bytes).
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* -------------------------------------------------------------------------
+ * DMA linked-list descriptor
+ * ------------------------------------------------------------------------- */
+
+typedef struct lldesc_s {
+    volatile uint32_t size : 14;   /* buffer capacity in bytes */
+    volatile uint32_t length : 14; /* valid bytes (set by HW on RX, SW on TX) */
+    volatile uint32_t offset : 1;
+    volatile uint32_t sosf : 1;  /* start-of-sub-frame */
+    volatile uint32_t eof : 1;   /* last descriptor in packet */
+    volatile uint32_t owner : 1; /* 0 = CPU, 1 = DMA */
+    volatile uint8_t *buf;       /* pointer to payload buffer */
+    union {
+        volatile uint32_t empty;
+        struct {
+            struct lldesc_s *stqe_next;
+        } qe; /* next descriptor */
+    };
+} lldesc_t;
+
+#define STAILQ_NEXT(elm, field) ((elm)->field.stqe_next)
+
+/* -------------------------------------------------------------------------
+ * SIP control structure (ROM-owned, accessed via sip_get_ptr())
+ *
+ * Offsets (32-bit pointers):
+ *   0  blksz_evt (2)
+ *   2  blksz_cmd (2)
+ *   4  blksz_from_host_data (2)
+ *   6  blksz_to_host_data (2)
+ *   8  free_evtq [STAILQ_HEAD = 2 x ptr = 8 bytes]
+ *  16  flags (4)
+ *  20  first_to_host_free (4)
+ *  24  last_to_host_free (4)
+ *  28  first_from_host (4)
+ *  32  last_from_host (4)
+ *  36  from_host_seq (4)
+ *  40  to_host_seq (4)
+ *  44  state (4, int-sized enum)
+ *  48  slc (4)
+ *  52  ext (4)
+ *  56  first_to_host_pend (4)
+ *  60  last_to_host_pend (4)
+ *  64  to_host_length (4)
+ *  68  sending_to_host (1) + pad (3)
+ *  72  to_host_data_done_cb fn ptr (4)
+ *  76  to_host_ampduEntryBlock_done_cb fn ptr (4)
+ *  80  to_host_done_process fn ptr (4)
+ *  84  from_host_process fn ptr (4)
+ *  88  get_send_length fn ptr (4)
+ *  92  write_memory (4)
+ * ------------------------------------------------------------------------- */
+
+/* Minimal ROM SLC control block prefix.
+ * The ROM recycle helper uses first_desc[0] / last_desc[0] for FROM_HOST. */
+typedef struct slc_ctrl_s {
+    uint16_t blksz_cmd;
+    uint16_t _pad0;
+    lldesc_t *first_desc[2];
+    lldesc_t *last_desc[2];
+} slc_ctrl_t;
+
+/* Free event descriptor queue head - STAILQ_HEAD(sip_qh, lldesc_s) */
+struct sip_evtq_head {
+    lldesc_t *stqh_first;
+    lldesc_t **stqh_last;
+};
+
+typedef uint32_t sip_state_t;
+
+typedef struct sip_s {
+    uint16_t blksz_evt;
+    uint16_t blksz_cmd;
+    uint16_t blksz_from_host_data;
+    uint16_t blksz_to_host_data;
+    struct sip_evtq_head free_evtq; /* 8 bytes */
+    uint32_t flags;
+    lldesc_t *first_to_host_free;
+    lldesc_t *last_to_host_free;
+    lldesc_t *first_from_host;
+    lldesc_t *last_from_host;
+    uint32_t from_host_seq;
+    uint32_t to_host_seq;
+    sip_state_t state;
+    slc_ctrl_t *slc;
+    void *ext;
+    lldesc_t *first_to_host_pend;
+    lldesc_t *last_to_host_pend;
+    uint32_t to_host_length;
+    bool sending_to_host;
+    uint8_t _pad[3];
+    void (*to_host_data_done_cb)(lldesc_t *head, lldesc_t *tail, uint16_t num);
+    void (*to_host_ampduEntryBlock_done_cb)(lldesc_t *head, lldesc_t *tail, uint16_t num);
+    void (*to_host_done_process)(uint32_t par);
+    void (*from_host_process)(uint32_t par);
+    uint32_t (*get_send_length)(lldesc_t *head, lldesc_t **res);
+    uint32_t write_memory;
+} sip_t;
+
+/* Field accessor macros */
+#define SIP_FIRST_FREE_TO_HOST_DS(sip) ((sip)->first_to_host_free)
+#define SIP_LAST_FREE_TO_HOST_DS(sip)  ((sip)->last_to_host_free)
+#define SIP_FIRST_FROM_HOST_DS(sip)    ((sip)->first_from_host)
+#define SIP_LAST_FROM_HOST_DS(sip)     ((sip)->last_from_host)
+#define SIP_FIRST_PEND_TO_HOST_DS(sip) ((sip)->first_to_host_pend)
+#define SIP_LAST_PEND_TO_HOST_DS(sip)  ((sip)->last_to_host_pend)

--- a/src/target/base/include/target/sdio.h
+++ b/src/target/base/include/target/sdio.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool stub_target_sdio_is_active(void);
+
+void stub_target_sdio_init(void);
+
+bool stub_target_sdio_take_rx_frame(size_t *out_len);
+
+int stub_target_sdio_rearm(uint8_t *buf, size_t max_size);
+
+int stub_target_sdio_tx_frame(const void *data, size_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/target/common/CMakeLists.txt
+++ b/src/target/common/CMakeLists.txt
@@ -8,6 +8,7 @@ set(common_srcs
     src/mem_utils.c
     src/security.c
     src/sha256.c
+    src/sdio.c
     src/uart.c
     src/usb_serial_jtag.c
     src/usb_otg.c

--- a/src/target/common/src/sdio.c
+++ b/src/target/common/src/sdio.c
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <esp-stub-lib/err.h>
+
+#include <target/sdio.h>
+
+bool __attribute__((weak)) stub_target_sdio_is_active(void)
+{
+    return false;
+}
+
+void __attribute__((weak)) stub_target_sdio_init(void)
+{
+}
+
+bool __attribute__((weak)) stub_target_sdio_take_rx_frame(size_t *out_len)
+{
+    (void)out_len;
+    return false;
+}
+
+int __attribute__((weak)) stub_target_sdio_rearm(uint8_t *buf, size_t max_size)
+{
+    (void)buf;
+    (void)max_size;
+    return STUB_LIB_ERR_NOT_SUPPORTED;
+}
+
+int __attribute__((weak)) stub_target_sdio_tx_frame(const void *data, size_t len)
+{
+    (void)data;
+    (void)len;
+    return STUB_LIB_ERR_NOT_SUPPORTED;
+}

--- a/src/target/esp32c5/CMakeLists.txt
+++ b/src/target/esp32c5/CMakeLists.txt
@@ -6,6 +6,7 @@ set(srcs
     src/uart.c
     src/usb_serial_jtag.c
     src/clock.c
+    src/sdio.c
 )
 
 add_library(${ESP_TARGET_LIB} STATIC ${srcs})

--- a/src/target/esp32c5/include/soc/reg_base.h
+++ b/src/target/esp32c5/include/soc/reg_base.h
@@ -32,8 +32,12 @@
 #define DR_REG_SOC_ETM_BASE                       0x60013000
 #define DR_REG_MCPWM_BASE                         0x60014000
 #define DR_REG_PARL_IO_BASE                       0x60015000
+#define DR_REG_HINF_BASE                          0x60016000
+#define DR_REG_SLC_BASE                           0x60017000
+#define DR_REG_SLCHOST_BASE                       0x60018000
 #define DR_REG_PVT_MONITOR_BASE                   0x60019000
 #define DR_REG_PSRAM_MEM_MONITOR_BASE             0x6001A000
+#define DR_REG_PVT_BASE                           DR_REG_PVT_MONITOR_BASE
 
 /**
  * @brief Peripheral 1 Modules
@@ -65,6 +69,7 @@
 #define DR_REG_TEE_BASE                           0x60098000
 #define DR_REG_HP_APM_BASE                        0x60099000
 #define DR_REG_LP_APM0_BASE                       0x60099800
+#define DR_REG_CPU_APM_BASE                       0x6009A000
 #define DR_REG_MISC_BASE                          0x6009F000
 
 /**
@@ -77,7 +82,6 @@
 #define DR_REG_MODEM_PWR1_BASE                    0x600AF000
 
 #define PWDET_CONF_REG                            0x600A0810
-#define DR_REG_I2C_ANA_MST_BASE                   0x600AF800
 #define IEEE802154_REG_BASE                       0x600A3000
 
 /**
@@ -107,7 +111,7 @@
  *
  */
 #define DR_REG_TRACE_BASE                         0x600C0000
-#define DR_REG_ASSIST_DEBUG_BASE                  0x600C2000
+#define DR_REG_BUS_MONITOR_BASE                   0x600C2000
 #define DR_REG_INTPRI_BASE                        0x600C5000
 #define DR_REG_CACHE_BASE                         0x600C8000  // CACHE_CONFIG/EXTMEM
 #define DR_REG_CLINT_M_BASE                       0x20000000

--- a/src/target/esp32c5/include/soc/slc_reg.h
+++ b/src/target/esp32c5/include/soc/slc_reg.h
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * SLC (Serial Link Controller) register definitions for ESP32-C5.
+ * Base address: DR_REG_SLC_BASE = 0x60017000  (same as ESP32-C6)
+ *
+ * Naming note: SLC uses "TX" for host→slave and "RX" for slave→host,
+ * which is the opposite of application-level terminology.
+ */
+
+#pragma once
+
+#include <esp-stub-lib/bit_utils.h>
+
+#include <soc/reg_base.h>
+
+/* Register addresses */
+#define SDIO_SLCCONF0_REG           (DR_REG_SLC_BASE + 0x00)
+#define SDIO_SLC0INT_RAW_REG        (DR_REG_SLC_BASE + 0x04)
+#define SDIO_SLC0INT_ST_REG         (DR_REG_SLC_BASE + 0x08)
+#define SDIO_SLC0INT_ENA_REG        (DR_REG_SLC_BASE + 0x0C)
+#define SDIO_SLC0INT_CLR_REG        (DR_REG_SLC_BASE + 0x10)
+
+/* DMA link registers */
+#define SDIO_SLC0RX_LINK_REG        (DR_REG_SLC_BASE + 0x3C) /* Slave→host DMA control */
+#define SDIO_SLC0RX_LINK_ADDR_REG   (DR_REG_SLC_BASE + 0x40) /* Slave→host first descriptor */
+#define SDIO_SLC0TX_LINK_REG        (DR_REG_SLC_BASE + 0x44) /* Host→slave DMA control */
+#define SDIO_SLC0TX_LINK_ADDR_REG   (DR_REG_SLC_BASE + 0x48) /* Host→slave first descriptor */
+#define SDIO_SLC0TOKEN1_REG         (DR_REG_SLC_BASE + 0x64) /* Host→slave buffer credits */
+#define SDIO_SLC_RX_DSCR_CONF_REG   (DR_REG_SLC_BASE + 0xA8) /* Slave→host descriptor configuration */
+
+/* SDIO_SLC0TOKEN1_REG fields */
+#define SDIO_SLC0_TOKEN1_WDATA_MASK 0x0FFFU
+#define SDIO_SLC0_TOKEN1_WR         BIT(12)
+
+/* SDIO_SLC_RX_DSCR_CONF_REG fields */
+#define SDIO_SLC0_TOKEN_NO_REPLACE  BIT(0)
+
+/* SDIO_SLC0RX_LINK_REG control bits (slave→host DMA) */
+#define SDIO_SLC0_RXLINK_STOP       BIT(28)
+#define SDIO_SLC0_RXLINK_START      BIT(29)
+
+/* SDIO_SLC0TX_LINK_REG control bits (host→slave DMA) */
+#define SDIO_SLC0_TXLINK_STOP       BIT(28)
+#define SDIO_SLC0_TXLINK_START      BIT(29)
+#define SDIO_SLC0_TXLINK_RESTART    BIT(30)
+#define SDIO_SLC0_TXLINK_PARK       BIT(31)
+
+/* SDIO_SLCCONF0_REG bits — DMA reset */
+#define SDIO_SLC0_TX_RST            BIT(0) /* Reset host→slave DMA */
+#define SDIO_SLC0_RX_RST            BIT(1) /* Reset slave→host DMA */
+
+/*
+ * Interrupt bits — same bit position in RAW / ST / ENA / CLR registers.
+ *
+ * Bit 15: TX_SUC_EOF     — host finished writing a packet (host→slave data ready)
+ * Bit 16: RX_DONE        — slave→host DMA descriptor processed (owner reclaimed)
+ * Bit 17: RX_EOF         — slave→host DMA transfer completed (eof descriptor sent)
+ * Bit 18: RX_DSCR_EMPTY  — slave→host descriptor chain exhausted; must be cleared
+ *                           before restarting RXLINK_START or the new DMA is ignored
+ * Bit 19: TX_DSCR_ERR    — TX descriptor error (fatal)
+ * Bit 20: RX_DSCR_ERR    — RX descriptor error (fatal)
+ * Bit 21: TX_DSCR_EMPTY  — TX descriptor chain exhausted (fatal)
+ */
+#define SDIO_SLC0_TX_SUC_EOF_INT    BIT(15)
+#define SDIO_SLC0_RX_DONE_INT       BIT(16)
+#define SDIO_SLC0_RX_EOF_INT        BIT(17)
+#define SDIO_SLC0_RX_DSCR_EMPTY_INT BIT(18)
+#define SDIO_SLC0_TX_DSCR_ERR_INT   BIT(19)
+#define SDIO_SLC0_RX_DSCR_ERR_INT   BIT(20)
+#define SDIO_SLC0_TX_DSCR_EMPTY_INT BIT(21)

--- a/src/target/esp32c5/include/soc/slchost_reg.h
+++ b/src/target/esp32c5/include/soc/slchost_reg.h
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * SLCHOST register definitions for ESP32-C5.
+ * Base address: DR_REG_SLCHOST_BASE = 0x60018000  (same as ESP32-C6)
+ */
+
+#pragma once
+
+#include <soc/reg_base.h>
+
+/*
+ * SLCHOST_CONF_W0_REG (+0x6C):
+ * Written by the slave before sending a packet to advertise the total
+ * transfer length. The host reads this via CMD53 to know how many bytes
+ * to pull before the next packet starts.
+ */
+#define SLCHOST_CONF_W0_REG (DR_REG_SLCHOST_BASE + 0x6C)

--- a/src/target/esp32c5/ld/esp32c5.rom.ld
+++ b/src/target/esp32c5/ld/esp32c5.rom.ld
@@ -424,3 +424,50 @@ usb_serial_device_rx_one_char = 0x40000ab8;
 usb_serial_device_rx_one_char_block = 0x40000abc;
 usb_serial_device_tx_flush = 0x40000ac0;
 usb_serial_device_tx_one_char = 0x40000ac4;
+
+/***************************************
+ Group lldesc_eco2
+ ***************************************/
+
+/* Functions */
+lldesc_build_chain = 0x4000154c;
+
+
+/***************************************
+ Group sip_eco2
+ ***************************************/
+
+/* Functions */
+sip_after_tx_complete = 0x40001550;
+sip_alloc_to_host_evt = 0x40001554;
+sip_download_begin = 0x40001558;
+sip_get_ptr = 0x4000155c;
+sip_get_state = 0x40001560;
+sip_init_attach = 0x40001564;
+sip_install_rx_ctrl_cb = 0x40001568;
+sip_install_rx_data_cb = 0x4000156c;
+sip_is_active = 0x40001570;
+sip_post_init = 0x40001574;
+sip_reclaim_from_host_cmd = 0x40001578;
+sip_reclaim_tx_data_pkt = 0x4000157c;
+sip_send = 0x40001580;
+sip_to_host_chain_append = 0x40001584;
+sip_to_host_evt_send_done = 0x40001588;
+
+
+/***************************************
+ Group slc_eco2
+ ***************************************/
+
+/* Functions */
+slc_add_credits = 0x4000158c;
+slc_enable = 0x40001590;
+slc_from_host_chain_fetch = 0x40001594;
+slc_from_host_chain_recycle = 0x40001598;
+slc_has_pkt_to_host = 0x4000159c;
+slc_init_attach = 0x400015a0;
+slc_init_credit = 0x400015a4;
+slc_reattach = 0x400015a8;
+slc_send_to_host_chain = 0x400015ac;
+slc_set_host_io_max_window = 0x400015b0;
+slc_to_host_chain_recycle = 0x400015b4;

--- a/src/target/esp32c5/src/sdio.c
+++ b/src/target/esp32c5/src/sdio.c
@@ -1,0 +1,290 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * SDIO transport for ESP32-C5 flasher stub.
+ *
+ * The ROM already completed SDIO enumeration before jumping to the stub.
+ * The host→slave SLC TX DMA is NOT pre-armed for the stub (SLC0TX_LINK_ADDR
+ * reads 0 at startup).  We build our own static descriptor chain of
+ * SDIO_RX_NUM_DESC × SDIO_RX_BLKSZ bytes and arm the DMA with it.
+ *
+ * Receive path (interrupt-driven):
+ *   Caller provides a receive buffer via stub_target_sdio_rearm().
+ *   sdio_slc_isr() fires on TX_SUC_EOF_INT, calls slc_from_host_chain_fetch()
+ *   and sdio_process_from_host(), then latches the received length for
+ *   stub_target_sdio_take_rx_frame().
+ *   Payload length is taken from the DMA descriptor length. No SLIP decoding.
+ *
+ * Transmit path (synchronous):
+ *   stub_target_sdio_tx_frame() sends one aligned raw response frame with SLC RX
+ *   DMA and waits until the host consumes it, so caller-owned stack buffers are
+ *   safe.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <esp-stub-lib/err.h>
+#include <esp-stub-lib/rom_wrappers.h>
+#include <esp-stub-lib/sdio.h>
+#include <esp-stub-lib/soc_utils.h>
+
+#include <target/sdio.h>
+
+#include <private/helpers.h>
+#include <private/rom_sdio_types.h>
+
+#include <soc/clic_reg.h>
+#include <soc/interrupt_matrix_reg.h>
+#include <soc/slc_reg.h>
+#include <soc/slchost_reg.h>
+
+/* -------------------------------------------------------------------------
+ * TX buffer — stub→host (raw payload, no SIP header)
+ * ------------------------------------------------------------------------- */
+#define SDIO_SLC_INT_CLR_ALL   0xFFFFFFFFU
+#define SDIO_TX_TIMEOUT_US     1000000U
+#define SDIO_SLC_INTERRUPT_NUM 18U
+
+static lldesc_t s_tx_desc;
+
+/* -------------------------------------------------------------------------
+ * RX descriptor — host→stub (SLC TX DMA in hardware terms).
+ *
+ * Each DMA arm exposes a full descriptor chain over the active SLIP raw receive
+ * buffer. slc_from_host_chain_fetch() returns one complete host FIFO write,
+ * which can span multiple 512-byte descriptors.
+ * ------------------------------------------------------------------------- */
+#define SDIO_RX_BLKSZ    512U
+#define SDIO_RX_NUM_DESC 33U
+
+static lldesc_t s_rx_desc[SDIO_RX_NUM_DESC];
+static volatile bool s_rx_armed;
+static volatile bool s_rx_frame_ready;
+static volatile size_t s_rx_received_len;
+
+static sip_t *s_sip;
+
+/* -------------------------------------------------------------------------
+ * ROM function declarations
+ * All symbols are resolved via esp32c5.rom.ld / esp32c5.rom.api.ld.
+ * ------------------------------------------------------------------------- */
+extern sip_t *sip_get_ptr(void);
+extern bool sip_download_begin(void);
+
+extern int slc_from_host_chain_fetch(lldesc_t **head, lldesc_t **tail);
+extern void slc_send_to_host_chain(lldesc_t *head, lldesc_t *tail);
+extern void slc_to_host_chain_recycle(lldesc_t **head, lldesc_t **tail);
+
+extern void esp_rom_isr_attach(int int_num, void *handler, void *arg);
+extern void esp_rom_isr_unmask(int int_num);
+extern void esp_rom_esprv_intc_int_set_priority(int int_num, int priority);
+
+static void sdio_set_rx_credits(uint32_t credits)
+{
+    REG_WRITE(SDIO_SLC0TOKEN1_REG, SDIO_SLC0_TOKEN1_WR | (credits & SDIO_SLC0_TOKEN1_WDATA_MASK));
+}
+
+static void sdio_reset_from_host_window(void)
+{
+    REG_SET_BIT(SDIO_SLCCONF0_REG, SDIO_SLC0_TX_RST);
+    REG_CLR_BIT(SDIO_SLCCONF0_REG, SDIO_SLC0_TX_RST);
+    REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC0_TX_SUC_EOF_INT | SDIO_SLC0_TX_DSCR_ERR_INT | SDIO_SLC0_TX_DSCR_EMPTY_INT);
+    s_sip->slc->first_desc[0] = NULL;
+    s_sip->slc->last_desc[0] = NULL;
+    s_rx_armed = false;
+}
+
+int stub_target_sdio_rearm(uint8_t *buf, size_t max_size)
+{
+    if (s_rx_armed) {
+        return STUB_LIB_OK;
+    }
+
+    if (s_rx_frame_ready) {
+        return STUB_LIB_FAIL;
+    }
+
+    size_t rx_desc_count = max_size / SDIO_RX_BLKSZ;
+    if (rx_desc_count > SDIO_RX_NUM_DESC) {
+        rx_desc_count = SDIO_RX_NUM_DESC;
+    }
+    if (rx_desc_count == 0) {
+        return STUB_LIB_ERR_INVALID_ARG;
+    }
+
+    size_t desc_offset = 0;
+
+    for (size_t i = 0; i < rx_desc_count; i++) {
+        lldesc_t *desc = &s_rx_desc[i];
+        desc->size = SDIO_RX_BLKSZ;
+        desc->length = 0;
+        desc->offset = 0;
+        desc->sosf = 0;
+        desc->eof = 0;
+        desc->owner = 1;
+        desc->buf = buf + desc_offset;
+        STAILQ_NEXT(desc, qe) = i + 1U < rx_desc_count ? &s_rx_desc[i + 1U] : NULL;
+
+        desc_offset += SDIO_RX_BLKSZ;
+    }
+
+    REG_WRITE(SDIO_SLC0TX_LINK_ADDR_REG, (uint32_t)(uintptr_t)&s_rx_desc[0]);
+    REG_SET_BIT(SDIO_SLC0TX_LINK_REG, SDIO_SLC0_TXLINK_START);
+    sdio_set_rx_credits(rx_desc_count);
+
+    s_rx_armed = true;
+    return STUB_LIB_OK;
+}
+
+/* -------------------------------------------------------------------------
+ * Process one received raw packet. head and known_tail come directly from
+ * slc_from_host_chain_fetch(), which returns the complete host FIFO write.
+ * ------------------------------------------------------------------------- */
+static void sdio_process_from_host(lldesc_t *head, lldesc_t *known_tail)
+{
+    s_rx_received_len = 0;
+    for (lldesc_t *cur = head; cur != NULL; cur = STAILQ_NEXT(cur, qe)) {
+        size_t chunk_len = cur->length;
+
+        s_rx_received_len += chunk_len;
+        if (cur == known_tail) {
+            break;
+        }
+    }
+
+    s_rx_frame_ready = true;
+    sdio_reset_from_host_window();
+}
+
+/* -------------------------------------------------------------------------
+ * SLC0 interrupt service routine — handles all host→stub DMA events.
+ * ------------------------------------------------------------------------- */
+static void sdio_slc_isr(void)
+{
+    uint32_t raw = REG_READ(SDIO_SLC0INT_RAW_REG);
+
+    if (raw & SDIO_SLC0_TX_SUC_EOF_INT) {
+        REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC0_TX_SUC_EOF_INT);
+
+        lldesc_t *head, *tail;
+        slc_from_host_chain_fetch(&head, &tail);
+        if (head == NULL) {
+            s_rx_armed = false;
+        } else {
+            tail->eof = 0;
+            sdio_process_from_host(head, tail);
+        }
+    }
+
+    if (raw & SDIO_SLC0_TX_DSCR_ERR_INT) {
+        REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC0_TX_DSCR_ERR_INT);
+    }
+    if (raw & SDIO_SLC0_RX_DSCR_ERR_INT) {
+        REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC0_RX_DSCR_ERR_INT);
+    }
+    if (raw & SDIO_SLC0_TX_DSCR_EMPTY_INT) {
+        REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC0_TX_DSCR_EMPTY_INT);
+        sdio_reset_from_host_window();
+    }
+}
+
+bool stub_target_sdio_take_rx_frame(size_t *out_len)
+{
+    if (!s_rx_frame_ready) {
+        return false;
+    }
+    if (out_len) {
+        *out_len = s_rx_received_len;
+    }
+    s_rx_frame_ready = false;
+    return true;
+}
+
+bool stub_target_sdio_is_active(void)
+{
+    return sip_download_begin();
+}
+
+void stub_target_sdio_init(void)
+{
+    /* Reset only the host→slave DMA (our receive path, bit 0).
+     * Do NOT reset the slave→host DMA (bit 1): sip_download_begin() already
+     * configured it with the correct SDIO block-size and mode registers; a
+     * reset would destroy that state and break subsequent RXLINK_START calls. */
+    s_sip = sip_get_ptr();
+
+    sdio_reset_from_host_window();
+    REG_SET_BIT(SDIO_SLC_RX_DSCR_CONF_REG, SDIO_SLC0_TOKEN_NO_REPLACE);
+    sdio_set_rx_credits(0);
+
+    s_rx_armed = false;
+    s_rx_frame_ready = false;
+    s_rx_received_len = 0;
+
+    /* Disable SLC interrupts before re-arming DMA so no interrupt fires
+     * into an unregistered handler during the setup sequence. */
+    REG_WRITE(SDIO_SLC0INT_ENA_REG, 0);
+
+    REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC_INT_CLR_ALL);
+
+    /* ESP32-C5 uses CLIC: the map register takes (cpu_intr_num + CLIC_EXT_INTR_NUM_OFFSET). */
+    WRITE_PERI_REG(INTERRUPT_CORE0_SLC0_INTR_MAP_REG, SDIO_SLC_INTERRUPT_NUM + CLIC_EXT_INTR_NUM_OFFSET);
+    esp_rom_esprv_intc_int_set_priority(SDIO_SLC_INTERRUPT_NUM, 1);
+    esp_rom_isr_attach(SDIO_SLC_INTERRUPT_NUM, (void *)sdio_slc_isr, NULL);
+    esp_rom_isr_unmask(BIT(SDIO_SLC_INTERRUPT_NUM));
+
+    REG_WRITE(SDIO_SLC0INT_ENA_REG, SDIO_SLC0_TX_SUC_EOF_INT | SDIO_SLC0_TX_DSCR_ERR_INT | SDIO_SLC0_TX_DSCR_EMPTY_INT);
+}
+
+static bool sdio_wait_tx_done(void)
+{
+    uint64_t remaining_us = SDIO_TX_TIMEOUT_US;
+    int wait_res = stub_target_wait_reg_bit_set(SDIO_SLC0INT_RAW_REG,
+                                                SDIO_SLC0_RX_EOF_INT | SDIO_SLC0_RX_DSCR_ERR_INT,
+                                                &remaining_us);
+    if (wait_res != STUB_LIB_OK) {
+        return false;
+    }
+
+    uint32_t raw = REG_READ(SDIO_SLC0INT_RAW_REG);
+    if (raw & SDIO_SLC0_RX_EOF_INT) {
+        REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC0_RX_DONE_INT | SDIO_SLC0_RX_EOF_INT | SDIO_SLC0_RX_DSCR_EMPTY_INT);
+        lldesc_t *head, *tail;
+        slc_to_host_chain_recycle(&head, &tail);
+        return true;
+    }
+    if (raw & SDIO_SLC0_RX_DSCR_ERR_INT) {
+        REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC0_RX_DSCR_ERR_INT);
+    }
+
+    return false;
+}
+
+int stub_target_sdio_tx_frame(const void *data, size_t len)
+{
+    /* DMA descriptor size/length fields are 14-bit bitfields. */
+    s_tx_desc.size = (uint32_t)len & SDIO_DMA_DESC_MAX_LEN;
+    s_tx_desc.length = (uint32_t)len & SDIO_DMA_DESC_MAX_LEN;
+    s_tx_desc.offset = 0;
+    s_tx_desc.sosf = 0;
+    s_tx_desc.eof = 1;
+    s_tx_desc.owner = 1;
+    s_tx_desc.buf = (uint8_t *)data;
+    STAILQ_NEXT(&s_tx_desc, qe) = NULL;
+
+    REG_WRITE(SDIO_SLC0INT_CLR_REG,
+              SDIO_SLC0_RX_DONE_INT | SDIO_SLC0_RX_EOF_INT | SDIO_SLC0_RX_DSCR_EMPTY_INT | SDIO_SLC0_RX_DSCR_ERR_INT);
+    REG_WRITE(SLCHOST_CONF_W0_REG, (uint32_t)len);
+    slc_send_to_host_chain(&s_tx_desc, &s_tx_desc);
+
+    bool ok = sdio_wait_tx_done();
+
+    /* Our descriptors are static, not ROM-owned SIP buffers. */
+    SIP_FIRST_FREE_TO_HOST_DS(s_sip) = NULL;
+    SIP_LAST_FREE_TO_HOST_DS(s_sip) = NULL;
+    return ok ? STUB_LIB_OK : STUB_LIB_FAIL;
+}

--- a/src/target/esp32c6/CMakeLists.txt
+++ b/src/target/esp32c6/CMakeLists.txt
@@ -5,6 +5,7 @@ set(srcs
     src/uart.c
     src/usb_serial_jtag.c
     src/mmu.c
+    src/sdio.c
 )
 
 add_library(${ESP_TARGET_LIB} STATIC ${srcs})

--- a/src/target/esp32c6/include/soc/slc_reg.h
+++ b/src/target/esp32c6/include/soc/slc_reg.h
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * SLC (Serial Link Controller) register definitions for ESP32-C6.
+ * Base address: DR_REG_SLC_BASE = 0x60017000
+ *
+ * Naming note: SLC uses "TX" for host→slave and "RX" for slave→host,
+ * which is the opposite of application-level terminology.
+ */
+
+#pragma once
+
+#include <esp-stub-lib/bit_utils.h>
+
+#include <soc/reg_base.h>
+
+/* Register addresses */
+#define SDIO_SLCCONF0_REG           (DR_REG_SLC_BASE + 0x00)
+#define SDIO_SLC0INT_RAW_REG        (DR_REG_SLC_BASE + 0x04)
+#define SDIO_SLC0INT_ST_REG         (DR_REG_SLC_BASE + 0x08)
+#define SDIO_SLC0INT_ENA_REG        (DR_REG_SLC_BASE + 0x0C)
+#define SDIO_SLC0INT_CLR_REG        (DR_REG_SLC_BASE + 0x10)
+
+/* DMA link registers */
+#define SDIO_SLC0RX_LINK_REG        (DR_REG_SLC_BASE + 0x3C) /* Slave→host DMA control */
+#define SDIO_SLC0RX_LINK_ADDR_REG   (DR_REG_SLC_BASE + 0x40) /* Slave→host first descriptor */
+#define SDIO_SLC0TX_LINK_REG        (DR_REG_SLC_BASE + 0x44) /* Host→slave DMA control */
+#define SDIO_SLC0TX_LINK_ADDR_REG   (DR_REG_SLC_BASE + 0x48) /* Host→slave first descriptor */
+#define SDIO_SLC0TOKEN1_REG         (DR_REG_SLC_BASE + 0x64) /* Host→slave buffer credits */
+#define SDIO_SLC_RX_DSCR_CONF_REG   (DR_REG_SLC_BASE + 0xA8) /* Slave→host descriptor configuration */
+
+/* SDIO_SLC0TOKEN1_REG fields */
+#define SDIO_SLC0_TOKEN1_WDATA_MASK 0x0FFFU
+#define SDIO_SLC0_TOKEN1_WR         BIT(12)
+
+/* SDIO_SLC_RX_DSCR_CONF_REG fields */
+#define SDIO_SLC0_TOKEN_NO_REPLACE  BIT(0)
+
+/* SDIO_SLC0RX_LINK_REG control bits (slave→host DMA) */
+#define SDIO_SLC0_RXLINK_STOP       BIT(28)
+#define SDIO_SLC0_RXLINK_START      BIT(29)
+
+/* SDIO_SLC0TX_LINK_REG control bits (host→slave DMA) */
+#define SDIO_SLC0_TXLINK_STOP       BIT(28)
+#define SDIO_SLC0_TXLINK_START      BIT(29)
+#define SDIO_SLC0_TXLINK_RESTART    BIT(30)
+#define SDIO_SLC0_TXLINK_PARK       BIT(31)
+
+/* SDIO_SLCCONF0_REG bits — DMA reset */
+#define SDIO_SLC0_TX_RST            BIT(0) /* Reset host→slave DMA */
+#define SDIO_SLC0_RX_RST            BIT(1) /* Reset slave→host DMA */
+
+/*
+ * Interrupt bits — same bit position in RAW / ST / ENA / CLR registers.
+ *
+ * Bit 15: TX_SUC_EOF     — host finished writing a packet (host→slave data ready)
+ * Bit 16: RX_DONE        — slave→host DMA descriptor processed (owner reclaimed)
+ * Bit 17: RX_EOF         — slave→host DMA transfer completed (eof descriptor sent)
+ * Bit 18: RX_DSCR_EMPTY  — slave→host descriptor chain exhausted; must be cleared
+ *                           before restarting RXLINK_START or the new DMA is ignored
+ * Bit 19: TX_DSCR_ERR    — TX descriptor error (fatal)
+ * Bit 20: RX_DSCR_ERR    — RX descriptor error (fatal)
+ * Bit 21: TX_DSCR_EMPTY  — TX descriptor chain exhausted (fatal)
+ */
+#define SDIO_SLC0_TX_SUC_EOF_INT    BIT(15)
+#define SDIO_SLC0_RX_DONE_INT       BIT(16)
+#define SDIO_SLC0_RX_EOF_INT        BIT(17)
+#define SDIO_SLC0_RX_DSCR_EMPTY_INT BIT(18)
+#define SDIO_SLC0_TX_DSCR_ERR_INT   BIT(19)
+#define SDIO_SLC0_RX_DSCR_ERR_INT   BIT(20)
+#define SDIO_SLC0_TX_DSCR_EMPTY_INT BIT(21)

--- a/src/target/esp32c6/include/soc/slchost_reg.h
+++ b/src/target/esp32c6/include/soc/slchost_reg.h
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * SLCHOST register definitions for ESP32-C6.
+ * Base address: DR_REG_SLCHOST_BASE = 0x60018000
+ */
+
+#pragma once
+
+#include <soc/reg_base.h>
+
+/*
+ * SLCHOST_CONF_W0_REG (+0x6C):
+ * Written by the slave before sending a packet to advertise the total
+ * transfer length. The host reads this via CMD53 to know how many bytes
+ * to pull before the next packet starts.
+ */
+#define SLCHOST_CONF_W0_REG (DR_REG_SLCHOST_BASE + 0x6C)

--- a/src/target/esp32c6/src/sdio.c
+++ b/src/target/esp32c6/src/sdio.c
@@ -1,0 +1,288 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * SDIO transport for ESP32-C6 flasher stub.
+ *
+ * The ROM already completed SDIO enumeration before jumping to the stub.
+ * The host→slave SLC TX DMA is NOT pre-armed for the stub (SLC0TX_LINK_ADDR
+ * reads 0 at startup).  We build our own static descriptor chain of
+ * SDIO_RX_NUM_DESC × SDIO_RX_BLKSZ bytes and arm the DMA with it.
+ *
+ * Receive path (interrupt-driven):
+ *   Caller provides a receive buffer via stub_target_sdio_rearm().
+ *   sdio_slc_isr() fires on TX_SUC_EOF_INT, calls slc_from_host_chain_fetch()
+ *   and sdio_process_from_host(), then latches the received length for
+ *   stub_target_sdio_take_rx_frame().
+ *   Payload length is taken from the DMA descriptor length. No SLIP decoding.
+ *
+ * Transmit path (synchronous):
+ *   stub_target_sdio_tx_frame() sends one aligned raw response frame with SLC RX
+ *   DMA and waits until the host consumes it, so caller-owned stack buffers are
+ *   safe.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <esp-stub-lib/err.h>
+#include <esp-stub-lib/rom_wrappers.h>
+#include <esp-stub-lib/sdio.h>
+#include <esp-stub-lib/soc_utils.h>
+
+#include <target/sdio.h>
+
+#include <private/helpers.h>
+#include <private/rom_sdio_types.h>
+
+#include <soc/interrupt_matrix_reg.h>
+#include <soc/slc_reg.h>
+#include <soc/slchost_reg.h>
+
+/* -------------------------------------------------------------------------
+ * TX buffer — stub→host (raw payload, no SIP header)
+ * ------------------------------------------------------------------------- */
+#define SDIO_SLC_INT_CLR_ALL   0xFFFFFFFFU
+#define SDIO_TX_TIMEOUT_US     1000000U
+#define SDIO_SLC_INTERRUPT_NUM 18U
+
+static lldesc_t s_tx_desc;
+
+/* -------------------------------------------------------------------------
+ * RX descriptor — host→stub (SLC TX DMA in hardware terms).
+ *
+ * Each DMA arm exposes a full descriptor chain over the active SLIP raw receive
+ * buffer. slc_from_host_chain_fetch() returns one complete host FIFO write,
+ * which can span multiple 512-byte descriptors.
+ * ------------------------------------------------------------------------- */
+#define SDIO_RX_BLKSZ    512U
+#define SDIO_RX_NUM_DESC 33U
+
+static lldesc_t s_rx_desc[SDIO_RX_NUM_DESC];
+static volatile bool s_rx_armed;
+static volatile bool s_rx_frame_ready;
+static volatile size_t s_rx_received_len;
+
+static sip_t *s_sip;
+
+/* -------------------------------------------------------------------------
+ * ROM function declarations
+ * All symbols are resolved via esp32c6.rom.ld / esp32c6.rom.api.ld.
+ * ------------------------------------------------------------------------- */
+extern sip_t *sip_get_ptr(void);
+extern bool sip_download_begin(void);
+
+extern int slc_from_host_chain_fetch(lldesc_t **head, lldesc_t **tail);
+extern void slc_send_to_host_chain(lldesc_t *head, lldesc_t *tail);
+extern void slc_to_host_chain_recycle(lldesc_t **head, lldesc_t **tail);
+
+extern void esp_rom_isr_attach(int int_num, void *handler, void *arg);
+extern void esp_rom_isr_unmask(int int_num);
+extern void esp_rom_esprv_intc_int_set_priority(int int_num, int priority);
+
+static void sdio_set_rx_credits(uint32_t credits)
+{
+    REG_WRITE(SDIO_SLC0TOKEN1_REG, SDIO_SLC0_TOKEN1_WR | (credits & SDIO_SLC0_TOKEN1_WDATA_MASK));
+}
+
+static void sdio_reset_from_host_window(void)
+{
+    REG_SET_BIT(SDIO_SLCCONF0_REG, SDIO_SLC0_TX_RST);
+    REG_CLR_BIT(SDIO_SLCCONF0_REG, SDIO_SLC0_TX_RST);
+    REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC0_TX_SUC_EOF_INT | SDIO_SLC0_TX_DSCR_ERR_INT | SDIO_SLC0_TX_DSCR_EMPTY_INT);
+    s_sip->slc->first_desc[0] = NULL;
+    s_sip->slc->last_desc[0] = NULL;
+    s_rx_armed = false;
+}
+
+int stub_target_sdio_rearm(uint8_t *buf, size_t max_size)
+{
+    if (s_rx_armed) {
+        return STUB_LIB_OK;
+    }
+
+    if (s_rx_frame_ready) {
+        return STUB_LIB_FAIL;
+    }
+
+    size_t rx_desc_count = max_size / SDIO_RX_BLKSZ;
+    if (rx_desc_count > SDIO_RX_NUM_DESC) {
+        rx_desc_count = SDIO_RX_NUM_DESC;
+    }
+    if (rx_desc_count == 0) {
+        return STUB_LIB_ERR_INVALID_ARG;
+    }
+
+    size_t desc_offset = 0;
+
+    for (size_t i = 0; i < rx_desc_count; i++) {
+        lldesc_t *desc = &s_rx_desc[i];
+        desc->size = SDIO_RX_BLKSZ;
+        desc->length = 0;
+        desc->offset = 0;
+        desc->sosf = 0;
+        desc->eof = 0;
+        desc->owner = 1;
+        desc->buf = buf + desc_offset;
+        STAILQ_NEXT(desc, qe) = i + 1U < rx_desc_count ? &s_rx_desc[i + 1U] : NULL;
+
+        desc_offset += SDIO_RX_BLKSZ;
+    }
+
+    REG_WRITE(SDIO_SLC0TX_LINK_ADDR_REG, (uint32_t)(uintptr_t)&s_rx_desc[0]);
+    REG_SET_BIT(SDIO_SLC0TX_LINK_REG, SDIO_SLC0_TXLINK_START);
+    sdio_set_rx_credits(rx_desc_count);
+
+    s_rx_armed = true;
+    return STUB_LIB_OK;
+}
+
+/* -------------------------------------------------------------------------
+ * Process one received raw packet. head and known_tail come directly from
+ * slc_from_host_chain_fetch(), which returns the complete host FIFO write.
+ * ------------------------------------------------------------------------- */
+static void sdio_process_from_host(lldesc_t *head, lldesc_t *known_tail)
+{
+    s_rx_received_len = 0;
+    for (lldesc_t *cur = head; cur != NULL; cur = STAILQ_NEXT(cur, qe)) {
+        size_t chunk_len = cur->length;
+
+        s_rx_received_len += chunk_len;
+        if (cur == known_tail) {
+            break;
+        }
+    }
+
+    s_rx_frame_ready = true;
+    sdio_reset_from_host_window();
+}
+
+/* -------------------------------------------------------------------------
+ * SLC0 interrupt service routine — handles all host→stub DMA events.
+ * ------------------------------------------------------------------------- */
+static void sdio_slc_isr(void)
+{
+    uint32_t raw = REG_READ(SDIO_SLC0INT_RAW_REG);
+
+    if (raw & SDIO_SLC0_TX_SUC_EOF_INT) {
+        REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC0_TX_SUC_EOF_INT);
+
+        lldesc_t *head, *tail;
+        slc_from_host_chain_fetch(&head, &tail);
+        if (head == NULL) {
+            s_rx_armed = false;
+        } else {
+            tail->eof = 0;
+            sdio_process_from_host(head, tail);
+        }
+    }
+
+    if (raw & SDIO_SLC0_TX_DSCR_ERR_INT) {
+        REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC0_TX_DSCR_ERR_INT);
+    }
+    if (raw & SDIO_SLC0_RX_DSCR_ERR_INT) {
+        REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC0_RX_DSCR_ERR_INT);
+    }
+    if (raw & SDIO_SLC0_TX_DSCR_EMPTY_INT) {
+        REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC0_TX_DSCR_EMPTY_INT);
+        sdio_reset_from_host_window();
+    }
+}
+
+bool stub_target_sdio_take_rx_frame(size_t *out_len)
+{
+    if (!s_rx_frame_ready) {
+        return false;
+    }
+    if (out_len) {
+        *out_len = s_rx_received_len;
+    }
+    s_rx_frame_ready = false;
+    return true;
+}
+
+bool stub_target_sdio_is_active(void)
+{
+    return sip_download_begin();
+}
+
+void stub_target_sdio_init(void)
+{
+    /* Reset only the host→slave DMA (our receive path, bit 0).
+     * Do NOT reset the slave→host DMA (bit 1): sip_download_begin() already
+     * configured it with the correct SDIO block-size and mode registers; a
+     * reset would destroy that state and break subsequent RXLINK_START calls. */
+    s_sip = sip_get_ptr();
+
+    sdio_reset_from_host_window();
+    REG_SET_BIT(SDIO_SLC_RX_DSCR_CONF_REG, SDIO_SLC0_TOKEN_NO_REPLACE);
+    sdio_set_rx_credits(0);
+
+    s_rx_armed = false;
+    s_rx_frame_ready = false;
+    s_rx_received_len = 0;
+
+    /* Disable SLC interrupts before re-arming DMA so no interrupt fires
+     * into an unregistered handler during the setup sequence. */
+    REG_WRITE(SDIO_SLC0INT_ENA_REG, 0);
+
+    REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC_INT_CLR_ALL);
+
+    WRITE_PERI_REG(INTMTX_CORE0_SLC0_INTR_MAP_REG, SDIO_SLC_INTERRUPT_NUM);
+    esp_rom_esprv_intc_int_set_priority(SDIO_SLC_INTERRUPT_NUM, 1);
+    esp_rom_isr_attach(SDIO_SLC_INTERRUPT_NUM, (void *)sdio_slc_isr, NULL);
+    esp_rom_isr_unmask(BIT(SDIO_SLC_INTERRUPT_NUM));
+
+    REG_WRITE(SDIO_SLC0INT_ENA_REG, SDIO_SLC0_TX_SUC_EOF_INT | SDIO_SLC0_TX_DSCR_ERR_INT | SDIO_SLC0_TX_DSCR_EMPTY_INT);
+}
+
+static bool sdio_wait_tx_done(void)
+{
+    uint64_t remaining_us = SDIO_TX_TIMEOUT_US;
+    int wait_res = stub_target_wait_reg_bit_set(SDIO_SLC0INT_RAW_REG,
+                                                SDIO_SLC0_RX_EOF_INT | SDIO_SLC0_RX_DSCR_ERR_INT,
+                                                &remaining_us);
+    if (wait_res != STUB_LIB_OK) {
+        return false;
+    }
+
+    uint32_t raw = REG_READ(SDIO_SLC0INT_RAW_REG);
+    if (raw & SDIO_SLC0_RX_EOF_INT) {
+        REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC0_RX_DONE_INT | SDIO_SLC0_RX_EOF_INT | SDIO_SLC0_RX_DSCR_EMPTY_INT);
+        lldesc_t *head, *tail;
+        slc_to_host_chain_recycle(&head, &tail);
+        return true;
+    }
+    if (raw & SDIO_SLC0_RX_DSCR_ERR_INT) {
+        REG_WRITE(SDIO_SLC0INT_CLR_REG, SDIO_SLC0_RX_DSCR_ERR_INT);
+    }
+
+    return false;
+}
+
+int stub_target_sdio_tx_frame(const void *data, size_t len)
+{
+    /* DMA descriptor size/length fields are 14-bit bitfields. */
+    s_tx_desc.size = (uint32_t)len & SDIO_DMA_DESC_MAX_LEN;
+    s_tx_desc.length = (uint32_t)len & SDIO_DMA_DESC_MAX_LEN;
+    s_tx_desc.offset = 0;
+    s_tx_desc.sosf = 0;
+    s_tx_desc.eof = 1;
+    s_tx_desc.owner = 1;
+    s_tx_desc.buf = (uint8_t *)data;
+    STAILQ_NEXT(&s_tx_desc, qe) = NULL;
+
+    REG_WRITE(SDIO_SLC0INT_CLR_REG,
+              SDIO_SLC0_RX_DONE_INT | SDIO_SLC0_RX_EOF_INT | SDIO_SLC0_RX_DSCR_EMPTY_INT | SDIO_SLC0_RX_DSCR_ERR_INT);
+    REG_WRITE(SLCHOST_CONF_W0_REG, (uint32_t)len);
+    slc_send_to_host_chain(&s_tx_desc, &s_tx_desc);
+
+    bool ok = sdio_wait_tx_done();
+
+    /* Our descriptors are static, not ROM-owned SIP buffers. */
+    SIP_FIRST_FREE_TO_HOST_DS(s_sip) = NULL;
+    SIP_LAST_FREE_TO_HOST_DS(s_sip) = NULL;
+    return ok ? STUB_LIB_OK : STUB_LIB_FAIL;
+}


### PR DESCRIPTION
## Summary

This MR adds the initial SDIO support in `esp-stub-lib`.

- Add a public SDIO API in `esp-stub-lib/include/esp-stub-lib/sdio.h`.
- Add common weak SDIO target hooks under `esp-stub-lib/src/target/common/`.
- Add target-backed SDIO implementations for supported chips under `esp-stub-lib/src/target/`.
- Use ROM SIP/SLC setup and DMA descriptors for raw SDIO RX/TX frames.
- Keep non-SDIO targets building through the weak fallback implementation.

## How It Works

The SDIO implementation reuses the ROM SIP/SLC initialization path, then exposes a small target-backed API to the stub. Host-to-stub frames are received through SLC DMA descriptors supplied by the caller. The caller is expected to provide a 4-byte aligned receive buffer because the transfer is DMA-backed.

After each received frame, the implementation resets the receive descriptor window so the next host write starts from the beginning of the supplied buffer. When a frame arrives, the target implementation reports the completed length and re-arms the receive window for the next frame.

Stub-to-host frames are sent by preparing a DMA descriptor for the caller-provided buffer, publishing the transfer length to the SDIO host register, and waiting for the SLC completion interrupt. The implementation also configures the SLC descriptor path so raw payload bytes are transferred as-is.

## Testing

- Built the affected `esp-stub-lib` targets.
- Tested the initial SDIO implementation on real hardware.
