### PR TITLE
fix(esp32s3): preserve OPI flash state across stub partial-init

### DIFF
--- a/src/target/esp32s3/src/flash.c
+++ b/src/target/esp32s3/src/flash.c
@@ -10,21 +10,22 @@
 #include <esp-stub-lib/bit_utils.h>
 #include <esp-stub-lib/cache.h>
 #include <esp-stub-lib/log.h>
+#include <esp-stub-lib/rom_wrappers.h>
 #include <esp-stub-lib/soc_utils.h>
 
 #include <target/flash.h>
 
+#include <private/flash_commands.h>
 #include <private/rom_flash.h>
 #include <private/rom_flash_config.h>
 
-#include <soc/io_mux_reg.h>
 #include <soc/spi_mem_compat.h>
 
 extern void spi_cache_mode_switch(uint32_t modebit);
 extern void spi_common_set_flash_cs_timing(void);
 extern void esp_rom_opiflash_mode_reset(int spi_num);
-extern uint32_t ets_efuse_get_spiconfig(void);
 extern esp_rom_spiflash_legacy_funcs_t *rom_spiflash_legacy_funcs;
+extern esp_rom_spiflash_legacy_data_t *rom_spiflash_legacy_data;
 extern uint32_t esp_rom_efuse_get_flash_gpio_info(void);
 extern void esp_rom_opiflash_exec_cmd(int spi_num,
                                       spi_flash_mode_t mode,
@@ -49,17 +50,44 @@ typedef struct {
 } esp_rom_opiflash_spi0rd_t;
 extern void esp_rom_opiflash_cache_mode_config(spi_flash_mode_t mode, const esp_rom_opiflash_spi0rd_t *cache);
 
+/* MXIC OPI mode-switch: WRCR2[0] = 0x01 (STR OPI) or 0x02 (DTR OPI). */
+#define MXIC_CMD_WRCR2_SPI    0x72
+#define MXIC_CR2_MODE_OPI_STR 0x01
+#define MXIC_CR2_MODE_OPI_DTR 0x02
+
 enum {
     SPI_USER_REG_ID = 0,
     SPI_CTRL_REG_ID,
     SPI_CTRL2_REG_ID,
     SPI_CLOCK_REG_ID,
     SPI_DDR_REG_ID,
+    SPI_TIMING_CALI_REG_ID,
     SPI_REGS_NUM,
+};
+
+enum {
+    SPI0_USER_REG_ID = 0,
+    SPI0_USER1_REG_ID,
+    SPI0_USER2_REG_ID,
+    SPI0_CTRL_REG_ID,
+    SPI0_CTRL2_REG_ID,
+    SPI0_CACHE_FCTRL_REG_ID,
+    SPI0_DDR_REG_ID,
+    SPI0_TIMING_CALI_REG_ID,
+    SPI0_CLOCK_REG_ID,
+    SPI0_MISC_REG_ID,
+    SPI0_MISO_DLEN_REG_ID,
+    SPI0_MOSI_DLEN_REG_ID,
+    SPI0_REGS_NUM,
 };
 
 typedef struct {
     uint32_t spi_regs[SPI_REGS_NUM];
+    uint32_t spi0_regs[SPI0_REGS_NUM];
+    uint8_t dummy_len_plus;
+    uint8_t spi0_dummy_len_plus;
+    uint8_t target_cr2;
+    bool octal_active;
 } stub_esp32s3_flash_state_t;
 
 size_t stub_target_flash_state_size(void)
@@ -136,6 +164,8 @@ void stub_target_flash_state_save(void *state)
     s->spi_regs[SPI_CTRL2_REG_ID] = READ_PERI_REG(SPI_MEM_CTRL2_REG(FLASH_SPI_NUM));
     s->spi_regs[SPI_CLOCK_REG_ID] = READ_PERI_REG(SPI_MEM_CLOCK_REG(FLASH_SPI_NUM));
     s->spi_regs[SPI_DDR_REG_ID] = READ_PERI_REG(SPI_MEM_DDR_REG(FLASH_SPI_NUM));
+    s->spi_regs[SPI_TIMING_CALI_REG_ID] = READ_PERI_REG(SPI_MEM_TIMING_CALI_REG(FLASH_SPI_NUM));
+    s->dummy_len_plus = rom_spiflash_legacy_data->dummy_len_plus[FLASH_SPI_NUM];
 }
 
 void stub_target_flash_state_restore(const void *state)
@@ -149,6 +179,8 @@ void stub_target_flash_state_restore(const void *state)
     WRITE_PERI_REG(SPI_MEM_CLOCK_REG(FLASH_SPI_NUM), s->spi_regs[SPI_CLOCK_REG_ID]);
     WRITE_PERI_REG(SPI_MEM_DDR_REG(FLASH_SPI_NUM), s->spi_regs[SPI_DDR_REG_ID]);
     WRITE_PERI_REG(SPI_MEM_USER_REG(FLASH_SPI_NUM), s->spi_regs[SPI_USER_REG_ID]);
+    WRITE_PERI_REG(SPI_MEM_TIMING_CALI_REG(FLASH_SPI_NUM), s->spi_regs[SPI_TIMING_CALI_REG_ID]);
+    rom_spiflash_legacy_data->dummy_len_plus[FLASH_SPI_NUM] = s->dummy_len_plus;
 }
 
 static void stub_target_spi_init(void)
@@ -179,6 +211,12 @@ static void stub_target_spi_init(void)
     WRITE_PERI_REG(SPI_MEM_DDR_REG(FLASH_SPI_NUM), 0);
     spi_cache_mode_switch(0);
     REG_SET_BIT(SPI_MEM_CACHE_FCTRL_REG(FLASH_SPI_NUM_INT), SPI_MEM_CACHE_FLASH_USR_CMD);
+
+    /* Clear IDF's extra-dummy tuning on SPI1; otherwise it shifts JEDEC ID
+     * readback. SPI0 left alone (cache/PSRAM). Restored by flash_state_*(). */
+    rom_spiflash_legacy_data->dummy_len_plus[FLASH_SPI_NUM] = 0;
+    CLEAR_PERI_REG_MASK(SPI_MEM_TIMING_CALI_REG(FLASH_SPI_NUM), SPI_MEM_TIMING_CALI_M);
+    REG_SET_FIELD(SPI_MEM_TIMING_CALI_REG(FLASH_SPI_NUM), SPI_MEM_EXTRA_DUMMY_CYCLELEN, 0);
 }
 
 static struct {
@@ -188,7 +226,81 @@ static struct {
     uint32_t saved_user2;
     uint32_t saved_cache_fctrl;
     uint32_t saved_ctrl;
+    uint32_t saved_timing_cali;
+    uint8_t saved_dummy_len_plus;
 } s_addr32_state;
+
+static void octal_save_spi0_state(stub_esp32s3_flash_state_t *s)
+{
+    s->spi0_regs[SPI0_USER_REG_ID] = REG_READ(SPI_MEM_USER_REG(FLASH_SPI_NUM_INT));
+    s->spi0_regs[SPI0_USER1_REG_ID] = REG_READ(SPI_MEM_USER1_REG(FLASH_SPI_NUM_INT));
+    s->spi0_regs[SPI0_USER2_REG_ID] = REG_READ(SPI_MEM_USER2_REG(FLASH_SPI_NUM_INT));
+    s->spi0_regs[SPI0_CTRL_REG_ID] = REG_READ(SPI_MEM_CTRL_REG(FLASH_SPI_NUM_INT));
+    s->spi0_regs[SPI0_CTRL2_REG_ID] = REG_READ(SPI_MEM_CTRL2_REG(FLASH_SPI_NUM_INT));
+    s->spi0_regs[SPI0_CACHE_FCTRL_REG_ID] = REG_READ(SPI_MEM_CACHE_FCTRL_REG(FLASH_SPI_NUM_INT));
+    s->spi0_regs[SPI0_DDR_REG_ID] = REG_READ(SPI_MEM_DDR_REG(FLASH_SPI_NUM_INT));
+    s->spi0_regs[SPI0_TIMING_CALI_REG_ID] = REG_READ(SPI_MEM_TIMING_CALI_REG(FLASH_SPI_NUM_INT));
+    s->spi0_regs[SPI0_CLOCK_REG_ID] = REG_READ(SPI_MEM_CLOCK_REG(FLASH_SPI_NUM_INT));
+    s->spi0_regs[SPI0_MISC_REG_ID] = REG_READ(SPI_MEM_MISC_REG(FLASH_SPI_NUM_INT));
+    s->spi0_regs[SPI0_MISO_DLEN_REG_ID] = REG_READ(SPI_MEM_MISO_DLEN_REG(FLASH_SPI_NUM_INT));
+    s->spi0_regs[SPI0_MOSI_DLEN_REG_ID] = REG_READ(SPI_MEM_MOSI_DLEN_REG(FLASH_SPI_NUM_INT));
+    s->spi0_dummy_len_plus = rom_spiflash_legacy_data->dummy_len_plus[FLASH_SPI_NUM_INT];
+    s->target_cr2 =
+        (s->spi0_regs[SPI0_DDR_REG_ID] & SPI_MEM_SPI_FMEM_DDR_EN) ? MXIC_CR2_MODE_OPI_DTR : MXIC_CR2_MODE_OPI_STR;
+    s->octal_active = true;
+}
+
+static void octal_restore_chip_mode(uint8_t target_cr2)
+{
+    esp_rom_opiflash_exec_cmd(FLASH_SPI_NUM,
+                              SPI_FLASH_FASTRD_MODE,
+                              CMD_WREN,
+                              8,
+                              0,
+                              0,
+                              0,
+                              NULL,
+                              0,
+                              NULL,
+                              0,
+                              ESP_ROM_OPIFLASH_SEL_CS0,
+                              false);
+
+    stub_lib_delay_us(10);
+
+    esp_rom_opiflash_exec_cmd(FLASH_SPI_NUM,
+                              SPI_FLASH_FASTRD_MODE,
+                              MXIC_CMD_WRCR2_SPI,
+                              8,
+                              0,
+                              32,
+                              0,
+                              &target_cr2,
+                              8,
+                              NULL,
+                              0,
+                              ESP_ROM_OPIFLASH_SEL_CS0,
+                              false);
+
+    stub_lib_delay_us(40);
+}
+
+static void octal_restore_spi0_state(const stub_esp32s3_flash_state_t *s)
+{
+    REG_WRITE(SPI_MEM_CLOCK_REG(FLASH_SPI_NUM_INT), s->spi0_regs[SPI0_CLOCK_REG_ID]);
+    REG_WRITE(SPI_MEM_USER_REG(FLASH_SPI_NUM_INT), s->spi0_regs[SPI0_USER_REG_ID]);
+    REG_WRITE(SPI_MEM_USER1_REG(FLASH_SPI_NUM_INT), s->spi0_regs[SPI0_USER1_REG_ID]);
+    REG_WRITE(SPI_MEM_USER2_REG(FLASH_SPI_NUM_INT), s->spi0_regs[SPI0_USER2_REG_ID]);
+    REG_WRITE(SPI_MEM_CTRL_REG(FLASH_SPI_NUM_INT), s->spi0_regs[SPI0_CTRL_REG_ID]);
+    REG_WRITE(SPI_MEM_CTRL2_REG(FLASH_SPI_NUM_INT), s->spi0_regs[SPI0_CTRL2_REG_ID]);
+    REG_WRITE(SPI_MEM_CACHE_FCTRL_REG(FLASH_SPI_NUM_INT), s->spi0_regs[SPI0_CACHE_FCTRL_REG_ID]);
+    REG_WRITE(SPI_MEM_DDR_REG(FLASH_SPI_NUM_INT), s->spi0_regs[SPI0_DDR_REG_ID]);
+    REG_WRITE(SPI_MEM_TIMING_CALI_REG(FLASH_SPI_NUM_INT), s->spi0_regs[SPI0_TIMING_CALI_REG_ID]);
+    REG_WRITE(SPI_MEM_MISC_REG(FLASH_SPI_NUM_INT), s->spi0_regs[SPI0_MISC_REG_ID]);
+    REG_WRITE(SPI_MEM_MISO_DLEN_REG(FLASH_SPI_NUM_INT), s->spi0_regs[SPI0_MISO_DLEN_REG_ID]);
+    REG_WRITE(SPI_MEM_MOSI_DLEN_REG(FLASH_SPI_NUM_INT), s->spi0_regs[SPI0_MOSI_DLEN_REG_ID]);
+    rom_spiflash_legacy_data->dummy_len_plus[FLASH_SPI_NUM_INT] = s->spi0_dummy_len_plus;
+}
 
 static void enable_4byte_cache_mode(void)
 {
@@ -200,11 +312,21 @@ static void enable_4byte_cache_mode(void)
     s_addr32_state.saved_user2 = REG_READ(SPI_MEM_USER2_REG(FLASH_SPI_NUM_INT));
     s_addr32_state.saved_cache_fctrl = REG_READ(SPI_MEM_CACHE_FCTRL_REG(FLASH_SPI_NUM_INT));
     s_addr32_state.saved_ctrl = REG_READ(SPI_MEM_CTRL_REG(FLASH_SPI_NUM_INT));
+    s_addr32_state.saved_timing_cali = REG_READ(SPI_MEM_TIMING_CALI_REG(FLASH_SPI_NUM_INT));
+    s_addr32_state.saved_dummy_len_plus = rom_spiflash_legacy_data->dummy_len_plus[FLASH_SPI_NUM_INT];
 
+    /* Clear IDF's extra-dummy tuning on SPI0; otherwise it stacks on top of
+     * the dummy count we pass to cache_mode_config() and mis-times reads. */
+    CLEAR_PERI_REG_MASK(SPI_MEM_TIMING_CALI_REG(FLASH_SPI_NUM_INT), SPI_MEM_TIMING_CALI_M);
+    REG_SET_FIELD(SPI_MEM_TIMING_CALI_REG(FLASH_SPI_NUM_INT), SPI_MEM_EXTRA_DUMMY_CYCLELEN, 0);
+    rom_spiflash_legacy_data->dummy_len_plus[FLASH_SPI_NUM_INT] = 0;
+
+    /* Use FAST_READ_4B + 8 dummy; SLOWRD/0x13/0-dummy comes back bit-shifted
+     * through SPI0 cache at typical flash clocks. Matches IDF. */
     const esp_rom_opiflash_spi0rd_t cache_rd = {
         .addr_bit_len = 32,
-        .dummy_bit_len = 0,
-        .cmd = 0x13,
+        .dummy_bit_len = 8,
+        .cmd = CMD_FSTRD4B,
         .cmd_bit_len = 8,
         .var_dummy_en = 0,
     };
@@ -212,11 +334,7 @@ static void enable_4byte_cache_mode(void)
     STUB_LOGD("Switching SPI0 cache to 32-bit addr (cmd=0x%x, dummy=%u)\n", cache_rd.cmd, cache_rd.dummy_bit_len);
 
     stub_lib_cache_stop();
-    esp_rom_opiflash_cache_mode_config(SPI_FLASH_SLOWRD_MODE, &cache_rd);
-    /* Workaround: ROM esp_rom_opiflash_cache_mode_config sets SPI_MEM_USR_DUMMY
-     * unconditionally; clear it when no dummy phase is required. */
-    if (cache_rd.dummy_bit_len == 0)
-        REG_CLR_BIT(SPI_MEM_USER_REG(FLASH_SPI_NUM_INT), SPI_MEM_USR_DUMMY);
+    esp_rom_opiflash_cache_mode_config(SPI_FLASH_FASTRD_MODE, &cache_rd);
     stub_lib_cache_start();
 
     s_addr32_state.applied = true;
@@ -233,6 +351,8 @@ static void disable_4byte_cache_mode(void)
     REG_WRITE(SPI_MEM_USER2_REG(FLASH_SPI_NUM_INT), s_addr32_state.saved_user2);
     REG_WRITE(SPI_MEM_CACHE_FCTRL_REG(FLASH_SPI_NUM_INT), s_addr32_state.saved_cache_fctrl);
     REG_WRITE(SPI_MEM_CTRL_REG(FLASH_SPI_NUM_INT), s_addr32_state.saved_ctrl);
+    REG_WRITE(SPI_MEM_TIMING_CALI_REG(FLASH_SPI_NUM_INT), s_addr32_state.saved_timing_cali);
+    rom_spiflash_legacy_data->dummy_len_plus[FLASH_SPI_NUM_INT] = s_addr32_state.saved_dummy_len_plus;
     stub_lib_cache_start();
 
     s_addr32_state.applied = false;
@@ -249,15 +369,27 @@ void stub_target_flash_set_4byte_cache_mode(bool enable)
 void stub_target_flash_init(void *state, stub_lib_flash_attach_policy_t attach_policy)
 {
     bool octal_mode = ets_efuse_flash_octal_mode();
+    bool needs_attach = (attach_policy == STUB_LIB_FLASH_ATTACH_ALWAYS) || stub_target_flash_needs_attach();
+    stub_esp32s3_flash_state_t *s = state;
 
-    if (state) {
-        stub_target_flash_state_save(state);
+    if (s) {
+        stub_target_flash_state_save(s);
+        /* Buffer is allocated by the client and may be uninitialized. */
+        s->octal_active = false;
+        s->target_cr2 = 0;
     }
 
-    if (attach_policy == STUB_LIB_FLASH_ATTACH_ALWAYS || stub_target_flash_needs_attach()) {
+    if (needs_attach) {
         uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();
         stub_target_flash_attach(spiconfig, 0);
     } else {
+        /* Partial init: full SPI module reset would break IDF's cache config
+         * and PSRAM on the same bus. For octal, snapshot SPI0 first --
+         * stub_target_spi_init() clobbers it, and deinit needs the original
+         * to put the chip back into OPI. NULL state opts out of OPI restore. */
+        if (octal_mode && s) {
+            octal_save_spi0_state(s);
+        }
         stub_target_spi_init();
         if (octal_mode) {
             esp_rom_opiflash_mode_reset(FLASH_SPI_NUM);
@@ -267,7 +399,23 @@ void stub_target_flash_init(void *state, stub_lib_flash_attach_policy_t attach_p
     REG_SET_BIT(SPI_MEM_USER_REG(FLASH_SPI_NUM), SPI_MEM_USR_COMMAND);
 
     if (octal_mode) {
-        STUB_LOGD("octal mode is on\n");
+        STUB_LOGD("octal mode is on (cr2_restore=0x%x)\n", s ? s->target_cr2 : 0);
         stub_target_flash_init_funcs();
     }
+}
+
+/* Restore chip + SPI0 to IDF's OPI mode; otherwise a chip-in-SPI /
+ * controller-in-OPI mismatch crashes the app on the next cache fetch.
+ * Opt-in via state buffer: NULL skips the restore. */
+void stub_target_flash_deinit(const void *state)
+{
+    const stub_esp32s3_flash_state_t *s = state;
+
+    if (s && s->octal_active) {
+        stub_lib_cache_stop();
+        octal_restore_chip_mode(s->target_cr2);
+        octal_restore_spi0_state(s);
+        stub_lib_cache_start();
+    }
+    stub_target_flash_state_restore(state);
 }


### PR DESCRIPTION
On S3 with octal (OPI) flash configured by IDF, the stub's partial-init path puts SPI1 and the chip into single-SPI so it can use legacy ROM helpers (RDID/RDSR/WREN/erase/program). `esp_rom_opiflash_mode_reset()` leaves the chip in single-SPI, and `stub_target_spi_init()` clobbers SPI0's OPI cache config as a side effect.
