### PR TITLE
fix(esp32c5): use explicit SDIO TX packet publish

### DIFF
--- a/src/target/esp32c5/include/soc/slc_reg.h
+++ b/src/target/esp32c5/include/soc/slc_reg.h
@@ -30,6 +30,7 @@
 #define SDIO_SLC0TX_LINK_ADDR_REG   (DR_REG_SLC_BASE + 0x48) /* Host→slave first descriptor */
 #define SDIO_SLC0TOKEN1_REG         (DR_REG_SLC_BASE + 0x64) /* Host→slave buffer credits */
 #define SDIO_SLC_RX_DSCR_CONF_REG   (DR_REG_SLC_BASE + 0xA8) /* Slave→host descriptor configuration */
+#define SDIO_SLC0_LEN_CONF_REG      (DR_REG_SLC_BASE + 0xF4)
 
 /* SDIO_SLC0TOKEN1_REG fields */
 #define SDIO_SLC0_TOKEN1_WDATA_MASK 0x0FFFU
@@ -37,6 +38,10 @@
 
 /* SDIO_SLC_RX_DSCR_CONF_REG fields */
 #define SDIO_SLC0_TOKEN_NO_REPLACE  BIT(0)
+
+/* SDIO_SLC0_LEN_CONF_REG fields */
+#define SDIO_SLC0_LEN_WDATA_MASK    0x000FFFFFU
+#define SDIO_SLC0_LEN_WR            BIT(20)
 
 /* SDIO_SLC0RX_LINK_REG control bits (slave→host DMA) */
 #define SDIO_SLC0_RXLINK_STOP       BIT(28)

--- a/src/target/esp32c5/include/soc/slchost_reg.h
+++ b/src/target/esp32c5/include/soc/slchost_reg.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <esp-stub-lib/bit_utils.h>
+
 #include <soc/reg_base.h>
 
 /*
@@ -18,3 +20,8 @@
  * to pull before the next packet starts.
  */
 #define SLCHOST_CONF_W0_REG (DR_REG_SLCHOST_BASE + 0x6C)
+
+/* Host-visible interrupt registers. */
+#define SLCHOST_SLC0HOST_INT_RAW_REG       (DR_REG_SLCHOST_BASE + 0x50)
+
+#define SLCHOST_SLC0_RX_NEW_PACKET_INT BIT(23)

--- a/src/target/esp32c5/src/sdio.c
+++ b/src/target/esp32c5/src/sdio.c
@@ -74,6 +74,7 @@ static sip_t *s_sip;
  * ------------------------------------------------------------------------- */
 extern sip_t *sip_get_ptr(void);
 extern bool sip_download_begin(void);
+extern uint32_t _rom_eco_version;
 
 extern int slc_from_host_chain_fetch(lldesc_t **head, lldesc_t **tail);
 extern void slc_to_host_chain_recycle(lldesc_t **head, lldesc_t **tail);
@@ -205,7 +206,8 @@ bool stub_target_sdio_take_rx_frame(size_t *out_len)
 
 bool stub_target_sdio_is_active(void)
 {
-    return sip_download_begin();
+    /* Eco version below 2 does not support SDIO download. */
+    return _rom_eco_version >= 2 && sip_download_begin();
 }
 
 void stub_target_sdio_init(void)

--- a/src/target/esp32c5/src/sdio.c
+++ b/src/target/esp32c5/src/sdio.c
@@ -76,7 +76,6 @@ extern sip_t *sip_get_ptr(void);
 extern bool sip_download_begin(void);
 
 extern int slc_from_host_chain_fetch(lldesc_t **head, lldesc_t **tail);
-extern void slc_send_to_host_chain(lldesc_t *head, lldesc_t *tail);
 extern void slc_to_host_chain_recycle(lldesc_t **head, lldesc_t **tail);
 
 extern void esp_rom_isr_attach(int int_num, void *handler, void *arg);
@@ -279,7 +278,12 @@ int stub_target_sdio_tx_frame(const void *data, size_t len)
     REG_WRITE(SDIO_SLC0INT_CLR_REG,
               SDIO_SLC0_RX_DONE_INT | SDIO_SLC0_RX_EOF_INT | SDIO_SLC0_RX_DSCR_EMPTY_INT | SDIO_SLC0_RX_DSCR_ERR_INT);
     REG_WRITE(SLCHOST_CONF_W0_REG, (uint32_t)len);
-    slc_send_to_host_chain(&s_tx_desc, &s_tx_desc);
+    s_sip->slc->first_desc[1] = &s_tx_desc;
+    s_sip->slc->last_desc[1] = &s_tx_desc;
+    REG_WRITE(SDIO_SLC0RX_LINK_ADDR_REG, (uint32_t)(uintptr_t)&s_tx_desc);
+    REG_SET_BIT(SDIO_SLC0RX_LINK_REG, SDIO_SLC0_RXLINK_START);
+    REG_WRITE(SDIO_SLC0_LEN_CONF_REG, ((uint32_t)len & SDIO_SLC0_LEN_WDATA_MASK) | SDIO_SLC0_LEN_WR);
+    REG_WRITE(SLCHOST_SLC0HOST_INT_RAW_REG, SLCHOST_SLC0_RX_NEW_PACKET_INT);
 
     bool ok = sdio_wait_tx_done();
 

--- a/src/target/esp32c6/include/soc/slc_reg.h
+++ b/src/target/esp32c6/include/soc/slc_reg.h
@@ -30,6 +30,7 @@
 #define SDIO_SLC0TX_LINK_ADDR_REG   (DR_REG_SLC_BASE + 0x48) /* Host→slave first descriptor */
 #define SDIO_SLC0TOKEN1_REG         (DR_REG_SLC_BASE + 0x64) /* Host→slave buffer credits */
 #define SDIO_SLC_RX_DSCR_CONF_REG   (DR_REG_SLC_BASE + 0xA8) /* Slave→host descriptor configuration */
+#define SDIO_SLC0_LEN_CONF_REG      (DR_REG_SLC_BASE + 0xF4)
 
 /* SDIO_SLC0TOKEN1_REG fields */
 #define SDIO_SLC0_TOKEN1_WDATA_MASK 0x0FFFU
@@ -37,6 +38,10 @@
 
 /* SDIO_SLC_RX_DSCR_CONF_REG fields */
 #define SDIO_SLC0_TOKEN_NO_REPLACE  BIT(0)
+
+/* SDIO_SLC0_LEN_CONF_REG fields */
+#define SDIO_SLC0_LEN_WDATA_MASK    0x000FFFFFU
+#define SDIO_SLC0_LEN_WR            BIT(20)
 
 /* SDIO_SLC0RX_LINK_REG control bits (slave→host DMA) */
 #define SDIO_SLC0_RXLINK_STOP       BIT(28)

--- a/src/target/esp32c6/include/soc/slchost_reg.h
+++ b/src/target/esp32c6/include/soc/slchost_reg.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <esp-stub-lib/bit_utils.h>
+
 #include <soc/reg_base.h>
 
 /*
@@ -18,3 +20,8 @@
  * to pull before the next packet starts.
  */
 #define SLCHOST_CONF_W0_REG (DR_REG_SLCHOST_BASE + 0x6C)
+
+/* Host-visible interrupt registers. */
+#define SLCHOST_SLC0HOST_INT_RAW_REG       (DR_REG_SLCHOST_BASE + 0x50)
+
+#define SLCHOST_SLC0_RX_NEW_PACKET_INT BIT(23)

--- a/src/target/esp32c6/src/sdio.c
+++ b/src/target/esp32c6/src/sdio.c
@@ -75,7 +75,6 @@ extern sip_t *sip_get_ptr(void);
 extern bool sip_download_begin(void);
 
 extern int slc_from_host_chain_fetch(lldesc_t **head, lldesc_t **tail);
-extern void slc_send_to_host_chain(lldesc_t *head, lldesc_t *tail);
 extern void slc_to_host_chain_recycle(lldesc_t **head, lldesc_t **tail);
 
 extern void esp_rom_isr_attach(int int_num, void *handler, void *arg);
@@ -277,7 +276,12 @@ int stub_target_sdio_tx_frame(const void *data, size_t len)
     REG_WRITE(SDIO_SLC0INT_CLR_REG,
               SDIO_SLC0_RX_DONE_INT | SDIO_SLC0_RX_EOF_INT | SDIO_SLC0_RX_DSCR_EMPTY_INT | SDIO_SLC0_RX_DSCR_ERR_INT);
     REG_WRITE(SLCHOST_CONF_W0_REG, (uint32_t)len);
-    slc_send_to_host_chain(&s_tx_desc, &s_tx_desc);
+    s_sip->slc->first_desc[1] = &s_tx_desc;
+    s_sip->slc->last_desc[1] = &s_tx_desc;
+    REG_WRITE(SDIO_SLC0RX_LINK_ADDR_REG, (uint32_t)(uintptr_t)&s_tx_desc);
+    REG_SET_BIT(SDIO_SLC0RX_LINK_REG, SDIO_SLC0_RXLINK_START);
+    REG_WRITE(SDIO_SLC0_LEN_CONF_REG, ((uint32_t)len & SDIO_SLC0_LEN_WDATA_MASK) | SDIO_SLC0_LEN_WR);
+    REG_WRITE(SLCHOST_SLC0HOST_INT_RAW_REG, SLCHOST_SLC0_RX_NEW_PACKET_INT);
 
     bool ok = sdio_wait_tx_done();
 


### PR DESCRIPTION
Sorry, C5 slc_send_to_host_chain has some weird behavior.

## Summary
- Replace the ROM SDIO send helper with an explicit IDF-style TX publish sequence on ESP32-C5.
- Apply the same TX path to ESP32-C6 for consistency.
- Gate ESP32-C5 SDIO stub activation on ECO2 and newer ROMs.

## Test plan
- Built `esp32c5` and `esp32c6` stubs and tested.
- Verified ESP32-C5 SDIO stub upload/OHAI path on hardware.