### PR TITLE
fix: handle USB full-packet flush termination

### DIFF
--- a/src/usb_otg.c
+++ b/src/usb_otg.c
@@ -42,7 +42,7 @@ typedef struct {
 // State
 static int s_usb_int_num = 0;
 static void (*s_rx_callback)(uint8_t) = NULL;
-static char s_cdcacm_txbuf[ACM_BYTES_PER_TX];
+static uint8_t s_cdcacm_txbuf[ACM_BYTES_PER_TX];
 static int s_cdcacm_txpos = 0;
 static uint32_t s_cdcacm_old_rts = 0;
 static volatile bool s_reset_requested = false;
@@ -113,10 +113,8 @@ uint8_t stub_lib_usb_otg_tx_one_char(uint8_t c)
 
 void stub_lib_usb_otg_tx_flush(void)
 {
-    if (s_cdcacm_txpos > 0) {
-        esp_rom_cdc_acm_fifo_fill(uart_acm_dev, (const uint8_t *)s_cdcacm_txbuf, s_cdcacm_txpos);
-        s_cdcacm_txpos = 0;
-    }
+    esp_rom_cdc_acm_fifo_fill(uart_acm_dev, s_cdcacm_txbuf, s_cdcacm_txpos);
+    s_cdcacm_txpos = 0;
 }
 
 void stub_lib_usb_otg_rx_async_enable(bool enable)

--- a/src/usb_serial_jtag.c
+++ b/src/usb_serial_jtag.c
@@ -113,6 +113,13 @@ uint8_t stub_lib_usb_serial_jtag_tx_one_char(uint8_t c)
 void stub_lib_usb_serial_jtag_tx_flush(void)
 {
 #if (ESP_ROM_USB_SERIAL_DEVICE_NUM >= 0)
+    /*
+     * USB-Serial-JTAG auto-flushes a full 64-byte FIFO. Per ESP-IDF's HAL,
+     * an immediate WR_DONE after that is a no-op; wait until the FIFO is
+     * writable so WR_DONE either commits pending bytes or sends the ZLP.
+     */
+    uint64_t timeout_us = 50000;
+    stub_target_wait_reg_bit_set(USB_SERIAL_JTAG_EP1_CONF_REG, USB_SERIAL_JTAG_SERIAL_IN_EP_DATA_FREE, &timeout_us);
     SET_PERI_REG_MASK(USB_SERIAL_JTAG_EP1_CONF_REG, USB_SERIAL_JTAG_WR_DONE);
 #endif
 }


### PR DESCRIPTION
## Summary
- Allow USB-OTG flush to call the ROM CDC ACM FIFO fill path with zero bytes so full-size USB packets can be terminated with a ZLP.
- Wait for USB-Serial-JTAG TX FIFO availability before asserting WR_DONE, matching the required full-packet termination behavior.

Fixes https://github.com/espressif/esp-flasher-stub/issues/90