### PR TITLE
feat(uart): expose ROM baudrate getter

### DIFF
--- a/include/esp-stub-lib/uart.h
+++ b/include/esp-stub-lib/uart.h
@@ -55,6 +55,13 @@ void stub_lib_uart_wait_idle(uart_port_t uart_num);
 void stub_lib_uart_init(uart_port_t uart_num);
 
 /**
+ * @brief Get UART baud rate from the ROM download-mode UART device
+ *
+ * @return Baud rate, or 0 if ROM does not report a valid baud rate
+ */
+uint32_t stub_lib_uart_rominit_get_baudrate(void);
+
+/**
  * @brief Set UART baud rate
  *
  * @param uart_num UART port number

--- a/src/uart.c
+++ b/src/uart.c
@@ -20,6 +20,14 @@ extern void esp_rom_isr_unmask(int int_num);
 extern uint8_t esp_rom_uart_tx_one_char(uint8_t ch);
 extern uint8_t esp_rom_uart_rx_one_char(void);
 
+typedef struct {
+    // ROM type is UartBautRate, but the field stores the actual integer baud.
+    int baud_rate;
+    // ... following fields not needed
+} uart_device_t;
+
+extern uart_device_t *esp_rom_get_uart_device(void);
+
 void stub_lib_uart_wait_idle(uart_port_t uart_num)
 {
     stub_target_uart_wait_idle(uart_num);
@@ -28,6 +36,15 @@ void stub_lib_uart_wait_idle(uart_port_t uart_num)
 void stub_lib_uart_init(uart_port_t uart_num)
 {
     stub_target_uart_init(uart_num);
+}
+
+uint32_t stub_lib_uart_rominit_get_baudrate(void)
+{
+    uart_device_t *uart = esp_rom_get_uart_device();
+    if (uart == NULL || uart->baud_rate <= 0) {
+        return 0;
+    }
+    return (uint32_t)uart->baud_rate;
 }
 
 void stub_lib_uart_rominit_set_baudrate(uart_port_t uart_num, uint32_t baudrate)


### PR DESCRIPTION
## Summary

- Add `stub_lib_uart_rominit_get_baudrate()` to expose the baud rate tracked by the ROM download-mode UART device.
- Use the ROM `GetUartDevice` state through a local private declaration in `src/uart.c`, keeping ROM details out of public headers.

## Motivation

`esp-flasher-stub` needs to preserve the active ROM UART link baud when changing clocks during stub startup. Assuming a fixed 115200 baud can break hosts that connected at a different initial baud rate.

## Test Plan

- `cmake -G Ninja -B example/build-esp32 -S example -DESP_TARGET=esp32 --fresh -Wno-dev && ninja -C example/build-esp32`