### PR TITLE
fix(esp32p4): select CPLL root mux after CPU divider setup

### DIFF
--- a/src/target/esp32p4/src/clock.c
+++ b/src/target/esp32p4/src/clock.c
@@ -150,9 +150,9 @@ static void stub_target_apply_cpu_cpll_div2(void)
 
     /*
      * Upscale from ROM download ~100 MHz (CPLL/4) to 200 MHz (CPLL/2).
-     * Match IDF rtc_clk_cpu_freq_to_cpll_mhz(200) upscale order:
-     * APB -> SYS -> MEM -> CPU. Do not retouch LP_CLKRST_HP_ROOT_CLK_SRC_SEL
-     * or recalibrate CPLL — ROM already selected CPLL @ 400 MHz.
+     * Match IDF rtc_clk_cpu_freq_to_cpll_mhz(200): APB -> SYS -> MEM -> CPU,
+     * then switch root mux to CPLL last (ROM may still be on XTAL). Do not
+     * recalibrate CPLL.
      *
      * Divider register fields store (divider - 1), same as clk_ll_*_set_divider().
      */
@@ -171,6 +171,8 @@ static void stub_target_apply_cpu_cpll_div2(void)
     ctrl0 |= (1U << HP_SYS_CLKRST_REG_CPU_CLK_DIV_NUM_S);
     WRITE_PERI_REG(HP_SYS_CLKRST_ROOT_CLK_CTRL0_REG, ctrl0);
     stub_target_bus_update();
+
+    REG_SET_FIELD(LP_CLKRST_HP_CLK_CTRL_REG, LP_CLKRST_HP_ROOT_CLK_SRC_SEL, 1);
 }
 
 void stub_target_clock_init(void)


### PR DESCRIPTION
## Summary
- After hard reset, ROM download often leaves the HP root clock on XTAL; the stub previously assumed CPLL was already selected and only programmed CPLL/2 dividers.
- Select `HP_ROOT_CLK_SRC_SEL` to CPLL **after** APB→SYS→MEM→CPU divider updates, matching ESP-IDF `rtc_clk_cpu_freq_to_cpll_mhz()` / `clk_ll_cpu_set_src()`.
- Restores USJ flash throughput (~1600 kbit/s) that regressed when the mux switch was omitted.

## Test plan
- [ ] Hard-reset ESP32-P4 (USJ), flash with installed stub, confirm ~1600 kbit/s class throughput
- [ ] Confirm stub starts reliably after cold reset (OHAI / write-flash)
- [ ] Optional: dump `LP_CLKRST_HP_CLK_CTRL` / root dividers after stub start and verify src=CPLL, CPU÷2