### PR TITLE
feat(spi): Add support for SPI slave interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(srcs
     src/security.c
     src/sha256.c
     src/sdio.c
+    src/spi.c
     src/uart.c
     src/usb_serial_jtag.c
     src/usb_otg.c

--- a/example/stub_main.c
+++ b/example/stub_main.c
@@ -19,6 +19,7 @@
 #include <esp-stub-lib/sdio.h>
 #include <esp-stub-lib/security.h>
 #include <esp-stub-lib/sha256.h>
+#include <esp-stub-lib/spi.h>
 #include <esp-stub-lib/uart.h>
 #include <esp-stub-lib/usb_serial_jtag.h>
 
@@ -106,6 +107,18 @@ static void __attribute__((unused)) test_sdio(void)
     (void)stub_lib_sdio_take_rx_frame(&rx_len);
     (void)stub_lib_sdio_rearm(rx_buf, sizeof(rx_buf));
     (void)stub_lib_sdio_tx_frame(rx_buf, sizeof(rx_buf));
+}
+
+static void __attribute__((unused)) test_spi(void)
+{
+    uint8_t rx_buf[512] __attribute__((aligned(4)));
+    size_t rx_len;
+
+    (void)stub_lib_spi_is_active();
+    stub_lib_spi_init();
+    (void)stub_lib_spi_take_rx_frame(&rx_len);
+    (void)stub_lib_spi_rearm(rx_buf, sizeof(rx_buf));
+    (void)stub_lib_spi_tx_frame(rx_buf, sizeof(rx_buf));
 }
 
 static __attribute__((unused)) void test_md5(void)
@@ -225,6 +238,7 @@ static __attribute__((unused)) int handle_test2(va_list ap)
     test_md5();
     test_usb_serial_jtag();
     test_sdio();
+    test_spi();
     test_miniz();
     test_clock_init();
 

--- a/include/esp-stub-lib/spi.h
+++ b/include/esp-stub-lib/spi.h
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Maximum frame length for a single SPI slave-HD DMA transfer.
+ *  The ROM DMA loaders (spi_slave_rom_txdma_load / _rxdma_load) reject any
+ *  length above LLDESC_SPI_MAX_BUFFER_SIZE (4096 - 4), so this is the true
+ *  single-descriptor limit, not the 12-bit descriptor field max (0xFFF). */
+#define SPI_DMA_DESC_MAX_LEN (4096U - 4U)
+
+/**
+ * @brief Check whether the SPI (download boot) transport is active.
+ *
+ * @return true if the ROM left GP-SPI2 in slave mode with a valid download
+ *         handshake, i.e. this stub was loaded over SPI.
+ */
+bool stub_lib_spi_is_active(void);
+
+/**
+ * @brief Initialize the SPI (download boot) transport.
+ * Resets the SPI DMA, initialises credits, and registers the internal SPI2 ISR
+ * using ROM interrupt infrastructure. The CPU interrupt number is chosen
+ * per-target inside the driver. Call stub_lib_spi_rearm(buf, max_size) to arm
+ * receive DMA.
+ */
+void stub_lib_spi_init(void);
+
+/**
+ * @brief Claim a completed received frame from the SPI driver.
+ *
+ * Returns true once per received frame and writes its byte count to @p out_len.
+ * The transport should mark the shared frame buffer complete before calling
+ * stub_lib_spi_rearm(buf, max_size).
+ */
+bool stub_lib_spi_take_rx_frame(size_t *out_len);
+
+/**
+ * @brief Arm the receive DMA when it is not already armed.
+ *
+ * If the receive DMA is already armed, this is a no-op. Call after freeing or
+ * claiming a frame buffer to provide the next DMA destination.
+ *
+ * @param buf      Writable 4-byte-aligned receive buffer.
+ * @param max_size Capacity of @p buf in bytes.
+ * @return STUB_LIB_OK on success, STUB_LIB_ERR_* on failure.
+ */
+int stub_lib_spi_rearm(uint8_t *buf, size_t max_size);
+
+/**
+ * @brief Send one raw SPI frame.
+ *
+ * Transfers via the SPI slave HD TX DMA path and waits until the host reads
+ * the frame, so stack-backed buffers remain valid for the duration.
+ *
+ * @param data Pointer to frame bytes (must be 4-byte aligned).
+ * @param len  Number of frame bytes, up to the DMA descriptor limit (4092).
+ * @return STUB_LIB_OK on success, STUB_LIB_ERR_* on failure.
+ */
+int stub_lib_spi_tx_frame(const void *data, size_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/spi.c
+++ b/src/spi.c
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <esp-stub-lib/bit_utils.h>
+#include <esp-stub-lib/err.h>
+#include <esp-stub-lib/log.h>
+#include <esp-stub-lib/spi.h>
+
+#include <target/spi.h>
+
+#define SPI_DMA_ALIGN 4U
+
+bool stub_lib_spi_is_active(void)
+{
+    return stub_target_spi_is_active();
+}
+
+void stub_lib_spi_init(void)
+{
+    stub_target_spi_init();
+}
+
+bool stub_lib_spi_take_rx_frame(size_t *out_len)
+{
+    return stub_target_spi_take_rx_frame(out_len);
+}
+
+int stub_lib_spi_rearm(uint8_t *buf, size_t max_size)
+{
+    if (buf == NULL || max_size == 0 || !IS_ALIGNED((uintptr_t)buf, SPI_DMA_ALIGN)) {
+        STUB_LOGE("Invalid SPI RX buffer\n");
+        return STUB_LIB_ERR_INVALID_ARG;
+    }
+    int ret = stub_target_spi_rearm(buf, max_size);
+    if (ret != STUB_LIB_OK) {
+        STUB_LOGE("Failed to arm SPI RX\n");
+        return ret;
+    }
+    return STUB_LIB_OK;
+}
+
+int stub_lib_spi_tx_frame(const void *data, size_t len)
+{
+    if (data == NULL || len == 0 || len > SPI_DMA_DESC_MAX_LEN || !IS_ALIGNED((uintptr_t)data, SPI_DMA_ALIGN)) {
+        STUB_LOGE("Invalid SPI TX frame\n");
+        return STUB_LIB_ERR_INVALID_ARG;
+    }
+    int ret = stub_target_spi_tx_frame(data, len);
+    if (ret != STUB_LIB_OK) {
+        STUB_LOGE("Failed to send SPI frame\n");
+        return ret;
+    }
+    return STUB_LIB_OK;
+}

--- a/src/target/base/include/private/spi_slave_protocol.h
+++ b/src/target/base/include/private/spi_slave_protocol.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * Shared-register SPI slave download-boot protocol constants.
+ *
+ * These values are defined by the ESP mask ROM (see esp-rom spi_rom_reg.h) and
+ * must stay in lockstep with the host-side driver in
+ * esp-serial-flasher/src/protocol_spi.c. All SPI transport targets use the
+ * same W0..W3 handshake layout (VER / RXSTA / TXSTA / CMD).
+ */
+#pragma once
+
+#include <stdint.h>
+
+#include <esp-stub-lib/bit_utils.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* RXSTA / TXSTA status word layout */
+#define SPI_SLV_STA_TOGGLE    BIT(0)
+#define SPI_SLV_STA_INIT      BIT(1)
+#define SPI_SLV_STA_LEN_SHIFT 2
+#define SPI_SLV_STATE_INIT    (SPI_SLV_STA_TOGGLE | SPI_SLV_STA_INIT)
+
+/* CMD register (W3) handshake bytes */
+#define SPI_SLV_CMD_IDLE      0xAAU /* slave -> host: idle, no download selected yet */
+#define SPI_SLV_CMD_READY     0xA5U /* host -> slave (echoed back): connected        */
+#define SPI_SLV_CMD_REBOOT    0xFEU /* host -> slave: reboot                         */
+#define SPI_SLV_CMD_DONE      0x55U /* slave -> host: prior SPI download completed   */
+
+#define SPI_SLV_VERSION_VALUE 0x20200618U /* mirrors the ROM's VERSION_VALUE */
+
+/* Bounded wait for the host to read a TX frame out over RDDMA. */
+#define SPI_SLV_TX_TIMEOUT_US 1000000U
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/target/base/include/target/spi.h
+++ b/src/target/base/include/target/spi.h
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool stub_target_spi_is_active(void);
+void stub_target_spi_init(void);
+
+bool stub_target_spi_take_rx_frame(size_t *out_len);
+int stub_target_spi_rearm(uint8_t *buf, size_t max_size);
+int stub_target_spi_tx_frame(const void *data, size_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/target/common/CMakeLists.txt
+++ b/src/target/common/CMakeLists.txt
@@ -9,6 +9,7 @@ set(common_srcs
     src/security.c
     src/sha256.c
     src/sdio.c
+    src/spi.c
     src/uart.c
     src/usb_serial_jtag.c
     src/usb_otg.c

--- a/src/target/common/src/spi.c
+++ b/src/target/common/src/spi.c
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <esp-stub-lib/err.h>
+
+#include <target/spi.h>
+
+bool __attribute__((weak)) stub_target_spi_is_active(void)
+{
+    return false;
+}
+
+void __attribute__((weak)) stub_target_spi_init(void)
+{
+    return;
+}
+
+bool __attribute__((weak)) stub_target_spi_take_rx_frame(size_t *out_len)
+{
+    (void)out_len;
+    return false;
+}
+
+int __attribute__((weak)) stub_target_spi_rearm(uint8_t *buf, size_t max_size)
+{
+    (void)buf;
+    (void)max_size;
+    return STUB_LIB_ERR_NOT_SUPPORTED;
+}
+
+int __attribute__((weak)) stub_target_spi_tx_frame(const void *data, size_t len)
+{
+    (void)data;
+    (void)len;
+    return STUB_LIB_ERR_NOT_SUPPORTED;
+}

--- a/src/target/esp32c2/CMakeLists.txt
+++ b/src/target/esp32c2/CMakeLists.txt
@@ -5,6 +5,7 @@ set(srcs
     src/uart.c
     src/clock.c
     src/md5.c
+    src/spi.c
 )
 
 add_library(${ESP_TARGET_LIB} STATIC ${srcs})
@@ -12,6 +13,7 @@ add_library(${ESP_TARGET_LIB} STATIC ${srcs})
 target_link_options(${ESP_TARGET_LIB}
     PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c2.rom.ld
     PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c2.rom.api.ld
+    PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c2.rom.extra.ld
     PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c2.rom.libc.ld
     PUBLIC -T${CMAKE_CURRENT_LIST_DIR}/ld/esp32c2.rom.libgcc.ld
 )

--- a/src/target/esp32c2/include/soc/spi_reg.h
+++ b/src/target/esp32c2/include/soc/spi_reg.h
@@ -1,0 +1,1755 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include <esp-stub-lib/bit_utils.h>
+#include <esp-stub-lib/soc_utils.h>
+#include <soc/reg_base.h>
+
+#include <soc/soc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* C2 has a single GP-SPI peripheral (SPI2); its soc.h does not define the
+ * indexed REG_SPI_BASE() helper the register macros below use, so provide it
+ * here. Only i == 2 is meaningful. */
+#ifndef REG_SPI_BASE
+#define REG_SPI_BASE(i) (DR_REG_SPI2_BASE + ((i) - 2) * 0x1000)
+#endif
+
+#define SPI_CMD_REG(i)          (REG_SPI_BASE(i) + 0x0)
+/* SPI_USR : R/W/SC ;bitpos:[24] ;default: 1'b0 ; */
+/*description: User define command enable.  An operation will be triggered when the bit is set.
+ The bit will be cleared once the operation done.1: enable 0: disable. Can not b
+e changed by CONF_buf..*/
+#define SPI_USR    (BIT(24))
+#define SPI_USR_M  (BIT(24))
+#define SPI_USR_V  0x1
+#define SPI_USR_S  24
+/* SPI_UPDATE : WT ;bitpos:[23] ;default: 1'b0 ; */
+/*description: Set this bit to synchronize SPI registers from APB clock domain into SPI module
+clock domain, which is only used in SPI master mode..*/
+#define SPI_UPDATE    (BIT(23))
+#define SPI_UPDATE_M  (BIT(23))
+#define SPI_UPDATE_V  0x1
+#define SPI_UPDATE_S  23
+/* SPI_CONF_BITLEN : R/W ;bitpos:[17:0] ;default: 18'd0 ; */
+/*description: Define the APB cycles of  SPI_CONF state. Can be configured in CONF state..*/
+#define SPI_CONF_BITLEN    0x0003FFFF
+#define SPI_CONF_BITLEN_M  ((SPI_CONF_BITLEN_V)<<(SPI_CONF_BITLEN_S))
+#define SPI_CONF_BITLEN_V  0x3FFFF
+#define SPI_CONF_BITLEN_S  0
+
+#define SPI_ADDR_REG(i)          (REG_SPI_BASE(i) + 0x4)
+/* SPI_USR_ADDR_VALUE : R/W ;bitpos:[31:0] ;default: 32'b0 ; */
+/*description: Address to slave. Can be configured in CONF state..*/
+#define SPI_USR_ADDR_VALUE    0xFFFFFFFF
+#define SPI_USR_ADDR_VALUE_M  ((SPI_USR_ADDR_VALUE_V)<<(SPI_USR_ADDR_VALUE_S))
+#define SPI_USR_ADDR_VALUE_V  0xFFFFFFFF
+#define SPI_USR_ADDR_VALUE_S  0
+
+#define SPI_CTRL_REG(i)          (REG_SPI_BASE(i) + 0x8)
+/* SPI_WR_BIT_ORDER : R/W ;bitpos:[26:25] ;default: 2'b0 ; */
+/*description: In command address write-data (MOSI) phases 1: LSB first 0: MSB first. Can be con
+figured in CONF state..*/
+#define SPI_WR_BIT_ORDER    0x00000003
+#define SPI_WR_BIT_ORDER_M  ((SPI_WR_BIT_ORDER_V)<<(SPI_WR_BIT_ORDER_S))
+#define SPI_WR_BIT_ORDER_V  0x3
+#define SPI_WR_BIT_ORDER_S  25
+/* SPI_RD_BIT_ORDER : R/W ;bitpos:[24:23] ;default: 2'b0 ; */
+/*description: In read-data (MISO) phase 1: LSB first 0: MSB first. Can be configured in CONF s
+tate..*/
+#define SPI_RD_BIT_ORDER    0x00000003
+#define SPI_RD_BIT_ORDER_M  ((SPI_RD_BIT_ORDER_V)<<(SPI_RD_BIT_ORDER_S))
+#define SPI_RD_BIT_ORDER_V  0x3
+#define SPI_RD_BIT_ORDER_S  23
+/* SPI_WP_POL : R/W ;bitpos:[21] ;default: 1'b1 ; */
+/*description: Write protect signal output when SPI is idle.  1: output high, 0: output low.  C
+an be configured in CONF state..*/
+#define SPI_WP_POL    (BIT(21))
+#define SPI_WP_POL_M  (BIT(21))
+#define SPI_WP_POL_V  0x1
+#define SPI_WP_POL_S  21
+/* SPI_HOLD_POL : R/W ;bitpos:[20] ;default: 1'b1 ; */
+/*description: SPI_HOLD output value when SPI is idle. 1: output high, 0: output low. Can be co
+nfigured in CONF state..*/
+#define SPI_HOLD_POL    (BIT(20))
+#define SPI_HOLD_POL_M  (BIT(20))
+#define SPI_HOLD_POL_V  0x1
+#define SPI_HOLD_POL_S  20
+/* SPI_D_POL : R/W ;bitpos:[19] ;default: 1'b1 ; */
+/*description: The bit is used to set MOSI line polarity, 1: high 0, low. Can be configured in
+CONF state..*/
+#define SPI_D_POL    (BIT(19))
+#define SPI_D_POL_M  (BIT(19))
+#define SPI_D_POL_V  0x1
+#define SPI_D_POL_S  19
+/* SPI_Q_POL : R/W ;bitpos:[18] ;default: 1'b1 ; */
+/*description: The bit is used to set MISO line polarity, 1: high 0, low. Can be configured in
+CONF state..*/
+#define SPI_Q_POL    (BIT(18))
+#define SPI_Q_POL_M  (BIT(18))
+#define SPI_Q_POL_V  0x1
+#define SPI_Q_POL_S  18
+/* SPI_FREAD_OCT : R/W ;bitpos:[16] ;default: 1'b0 ; */
+/*description: In the read operations read-data phase apply 8 signals. 1: enable 0: disable.  C
+an be configured in CONF state..*/
+#define SPI_FREAD_OCT    (BIT(16))
+#define SPI_FREAD_OCT_M  (BIT(16))
+#define SPI_FREAD_OCT_V  0x1
+#define SPI_FREAD_OCT_S  16
+/* SPI_FREAD_QUAD : R/W ;bitpos:[15] ;default: 1'b0 ; */
+/*description: In the read operations read-data phase apply 4 signals. 1: enable 0: disable.  C
+an be configured in CONF state..*/
+#define SPI_FREAD_QUAD    (BIT(15))
+#define SPI_FREAD_QUAD_M  (BIT(15))
+#define SPI_FREAD_QUAD_V  0x1
+#define SPI_FREAD_QUAD_S  15
+/* SPI_FREAD_DUAL : R/W ;bitpos:[14] ;default: 1'b0 ; */
+/*description: In the read operations, read-data phase apply 2 signals. 1: enable 0: disable. C
+an be configured in CONF state..*/
+#define SPI_FREAD_DUAL    (BIT(14))
+#define SPI_FREAD_DUAL_M  (BIT(14))
+#define SPI_FREAD_DUAL_V  0x1
+#define SPI_FREAD_DUAL_S  14
+/* SPI_FCMD_OCT : R/W ;bitpos:[10] ;default: 1'b0 ; */
+/*description: Apply 8 signals during command phase 1:enable 0: disable. Can be configured in C
+ONF state..*/
+#define SPI_FCMD_OCT    (BIT(10))
+#define SPI_FCMD_OCT_M  (BIT(10))
+#define SPI_FCMD_OCT_V  0x1
+#define SPI_FCMD_OCT_S  10
+/* SPI_FCMD_QUAD : R/W ;bitpos:[9] ;default: 1'b0 ; */
+/*description: Apply 4 signals during command phase 1:enable 0: disable. Can be configured in C
+ONF state..*/
+#define SPI_FCMD_QUAD    (BIT(9))
+#define SPI_FCMD_QUAD_M  (BIT(9))
+#define SPI_FCMD_QUAD_V  0x1
+#define SPI_FCMD_QUAD_S  9
+/* SPI_FCMD_DUAL : R/W ;bitpos:[8] ;default: 1'b0 ; */
+/*description: Apply 2 signals during command phase 1:enable 0: disable. Can be configured in C
+ONF state..*/
+#define SPI_FCMD_DUAL    (BIT(8))
+#define SPI_FCMD_DUAL_M  (BIT(8))
+#define SPI_FCMD_DUAL_V  0x1
+#define SPI_FCMD_DUAL_S  8
+/* SPI_FADDR_OCT : R/W ;bitpos:[7] ;default: 1'b0 ; */
+/*description: Apply 8 signals during addr phase 1:enable 0: disable. Can be configured in CONF
+ state..*/
+#define SPI_FADDR_OCT    (BIT(7))
+#define SPI_FADDR_OCT_M  (BIT(7))
+#define SPI_FADDR_OCT_V  0x1
+#define SPI_FADDR_OCT_S  7
+/* SPI_FADDR_QUAD : R/W ;bitpos:[6] ;default: 1'b0 ; */
+/*description: Apply 4 signals during addr phase 1:enable 0: disable. Can be configured in CONF
+ state..*/
+#define SPI_FADDR_QUAD    (BIT(6))
+#define SPI_FADDR_QUAD_M  (BIT(6))
+#define SPI_FADDR_QUAD_V  0x1
+#define SPI_FADDR_QUAD_S  6
+/* SPI_FADDR_DUAL : R/W ;bitpos:[5] ;default: 1'b0 ; */
+/*description: Apply 2 signals during addr phase 1:enable 0: disable. Can be configured in CONF
+ state..*/
+#define SPI_FADDR_DUAL    (BIT(5))
+#define SPI_FADDR_DUAL_M  (BIT(5))
+#define SPI_FADDR_DUAL_V  0x1
+#define SPI_FADDR_DUAL_S  5
+/* SPI_DUMMY_OUT : R/W ;bitpos:[3] ;default: 1'b0 ; */
+/*description: 0: In the dummy phase, the FSPI bus signals are not output. 1: In the dummy phas
+e, the FSPI bus signals are output. Can be configured in CONF state..*/
+#define SPI_DUMMY_OUT    (BIT(3))
+#define SPI_DUMMY_OUT_M  (BIT(3))
+#define SPI_DUMMY_OUT_V  0x1
+#define SPI_DUMMY_OUT_S  3
+
+#define SPI_CLOCK_REG(i)          (REG_SPI_BASE(i) + 0xC)
+/* SPI_CLK_EQU_SYSCLK : R/W ;bitpos:[31] ;default: 1'b1 ; */
+/*description: In the master mode 1: spi_clk is equal to system 0: spi_clk is divided from syst
+em clock. Can be configured in CONF state..*/
+#define SPI_CLK_EQU_SYSCLK    (BIT(31))
+#define SPI_CLK_EQU_SYSCLK_M  (BIT(31))
+#define SPI_CLK_EQU_SYSCLK_V  0x1
+#define SPI_CLK_EQU_SYSCLK_S  31
+/* SPI_CLKDIV_PRE : R/W ;bitpos:[21:18] ;default: 4'b0 ; */
+/*description: In the master mode it is pre-divider of spi_clk.  Can be configured in CONF stat
+e..*/
+#define SPI_CLKDIV_PRE    0x0000000F
+#define SPI_CLKDIV_PRE_M  ((SPI_CLKDIV_PRE_V)<<(SPI_CLKDIV_PRE_S))
+#define SPI_CLKDIV_PRE_V  0xF
+#define SPI_CLKDIV_PRE_S  18
+/* SPI_CLKCNT_N : R/W ;bitpos:[17:12] ;default: 6'h3 ; */
+/*description: In the master mode it is the divider of spi_clk. So spi_clk frequency is system/
+(spi_clkdiv_pre+1)/(spi_clkcnt_N+1). Can be configured in CONF state..*/
+#define SPI_CLKCNT_N    0x0000003F
+#define SPI_CLKCNT_N_M  ((SPI_CLKCNT_N_V)<<(SPI_CLKCNT_N_S))
+#define SPI_CLKCNT_N_V  0x3F
+#define SPI_CLKCNT_N_S  12
+/* SPI_CLKCNT_H : R/W ;bitpos:[11:6] ;default: 6'h1 ; */
+/*description: In the master mode it must be floor((spi_clkcnt_N+1)/2-1). In the slave mode it
+must be 0. Can be configured in CONF state..*/
+#define SPI_CLKCNT_H    0x0000003F
+#define SPI_CLKCNT_H_M  ((SPI_CLKCNT_H_V)<<(SPI_CLKCNT_H_S))
+#define SPI_CLKCNT_H_V  0x3F
+#define SPI_CLKCNT_H_S  6
+/* SPI_CLKCNT_L : R/W ;bitpos:[5:0] ;default: 6'h3 ; */
+/*description: In the master mode it must be equal to spi_clkcnt_N. In the slave mode it must b
+e 0. Can be configured in CONF state..*/
+#define SPI_CLKCNT_L    0x0000003F
+#define SPI_CLKCNT_L_M  ((SPI_CLKCNT_L_V)<<(SPI_CLKCNT_L_S))
+#define SPI_CLKCNT_L_V  0x3F
+#define SPI_CLKCNT_L_S  0
+
+#define SPI_USER_REG(i)          (REG_SPI_BASE(i) + 0x10)
+/* SPI_USR_COMMAND : R/W ;bitpos:[31] ;default: 1'b1 ; */
+/*description: This bit enable the command phase of an operation. Can be configured in CONF
+state..*/
+#define SPI_USR_COMMAND    (BIT(31))
+#define SPI_USR_COMMAND_M  (BIT(31))
+#define SPI_USR_COMMAND_V  0x1
+#define SPI_USR_COMMAND_S  31
+/* SPI_USR_ADDR : R/W ;bitpos:[30] ;default: 1'b0 ; */
+/*description: This bit enable the address phase of an operation. Can be configured in CONF
+state..*/
+#define SPI_USR_ADDR    (BIT(30))
+#define SPI_USR_ADDR_M  (BIT(30))
+#define SPI_USR_ADDR_V  0x1
+#define SPI_USR_ADDR_S  30
+/* SPI_USR_DUMMY : R/W ;bitpos:[29] ;default: 1'b0 ; */
+/*description: This bit enable the dummy phase of an operation. Can be configured in CONF state
+..*/
+#define SPI_USR_DUMMY    (BIT(29))
+#define SPI_USR_DUMMY_M  (BIT(29))
+#define SPI_USR_DUMMY_V  0x1
+#define SPI_USR_DUMMY_S  29
+/* SPI_USR_MISO : R/W ;bitpos:[28] ;default: 1'b0 ; */
+/*description: This bit enable the read-data phase of an operation. Can be configured in CONF s
+tate..*/
+#define SPI_USR_MISO    (BIT(28))
+#define SPI_USR_MISO_M  (BIT(28))
+#define SPI_USR_MISO_V  0x1
+#define SPI_USR_MISO_S  28
+/* SPI_USR_MOSI : R/W ;bitpos:[27] ;default: 1'b0 ; */
+/*description: This bit enable the write-data phase of an operation. Can be configured in CONF
+state..*/
+#define SPI_USR_MOSI    (BIT(27))
+#define SPI_USR_MOSI_M  (BIT(27))
+#define SPI_USR_MOSI_V  0x1
+#define SPI_USR_MOSI_S  27
+/* SPI_USR_DUMMY_IDLE : R/W ;bitpos:[26] ;default: 1'b0 ; */
+/*description: spi clock is disable in dummy phase when the bit is enable. Can be configured in
+ CONF state..*/
+#define SPI_USR_DUMMY_IDLE    (BIT(26))
+#define SPI_USR_DUMMY_IDLE_M  (BIT(26))
+#define SPI_USR_DUMMY_IDLE_V  0x1
+#define SPI_USR_DUMMY_IDLE_S  26
+/* SPI_USR_MOSI_HIGHPART : R/W ;bitpos:[25] ;default: 1'b0 ; */
+/*description: write-data phase only access to high-part of the buffer spi_w8~spi_w15. 1: enabl
+e 0: disable.  Can be configured in CONF state..*/
+#define SPI_USR_MOSI_HIGHPART    (BIT(25))
+#define SPI_USR_MOSI_HIGHPART_M  (BIT(25))
+#define SPI_USR_MOSI_HIGHPART_V  0x1
+#define SPI_USR_MOSI_HIGHPART_S  25
+/* SPI_USR_MISO_HIGHPART : R/W ;bitpos:[24] ;default: 1'b0 ; */
+/*description: read-data phase only access to high-part of the buffer spi_w8~spi_w15. 1: enable
+ 0: disable. Can be configured in CONF state..*/
+#define SPI_USR_MISO_HIGHPART    (BIT(24))
+#define SPI_USR_MISO_HIGHPART_M  (BIT(24))
+#define SPI_USR_MISO_HIGHPART_V  0x1
+#define SPI_USR_MISO_HIGHPART_S  24
+/* SPI_SIO : R/W ;bitpos:[17] ;default: 1'b0 ; */
+/*description: Set the bit to enable 3-line half duplex communication mosi and miso signals sha
+re the same pin. 1: enable 0: disable. Can be configured in CONF state..*/
+#define SPI_SIO    (BIT(17))
+#define SPI_SIO_M  (BIT(17))
+#define SPI_SIO_V  0x1
+#define SPI_SIO_S  17
+/* SPI_USR_CONF_NXT : R/W ;bitpos:[15] ;default: 1'b0 ; */
+/*description: 1: Enable the DMA CONF phase of next seg-trans operation, which means seg-trans
+will continue. 0: The seg-trans will end after the current SPI seg-trans or this
+ is not seg-trans mode. Can be configured in CONF state..*/
+#define SPI_USR_CONF_NXT    (BIT(15))
+#define SPI_USR_CONF_NXT_M  (BIT(15))
+#define SPI_USR_CONF_NXT_V  0x1
+#define SPI_USR_CONF_NXT_S  15
+/* SPI_FWRITE_OCT : R/W ;bitpos:[14] ;default: 1'b0 ; */
+/*description: In the write operations read-data phase apply 8 signals. Can be configured in CO
+NF state..*/
+#define SPI_FWRITE_OCT    (BIT(14))
+#define SPI_FWRITE_OCT_M  (BIT(14))
+#define SPI_FWRITE_OCT_V  0x1
+#define SPI_FWRITE_OCT_S  14
+/* SPI_FWRITE_QUAD : R/W ;bitpos:[13] ;default: 1'b0 ; */
+/*description: In the write operations read-data phase apply 4 signals. Can be configured in CO
+NF state..*/
+#define SPI_FWRITE_QUAD    (BIT(13))
+#define SPI_FWRITE_QUAD_M  (BIT(13))
+#define SPI_FWRITE_QUAD_V  0x1
+#define SPI_FWRITE_QUAD_S  13
+/* SPI_FWRITE_DUAL : R/W ;bitpos:[12] ;default: 1'b0 ; */
+/*description: In the write operations read-data phase apply 2 signals. Can be configured in CO
+NF state..*/
+#define SPI_FWRITE_DUAL    (BIT(12))
+#define SPI_FWRITE_DUAL_M  (BIT(12))
+#define SPI_FWRITE_DUAL_V  0x1
+#define SPI_FWRITE_DUAL_S  12
+/* SPI_CK_OUT_EDGE : R/W ;bitpos:[9] ;default: 1'b0 ; */
+/*description: the bit combined with spi_mosi_delay_mode bits to set mosi signal delay mode. Ca
+n be configured in CONF state..*/
+#define SPI_CK_OUT_EDGE    (BIT(9))
+#define SPI_CK_OUT_EDGE_M  (BIT(9))
+#define SPI_CK_OUT_EDGE_V  0x1
+#define SPI_CK_OUT_EDGE_S  9
+/* SPI_RSCK_I_EDGE : R/W ;bitpos:[8] ;default: 1'b0 ; */
+/*description: In the slave mode, this bit can be used to change the polarity of rsck. 0: rsck
+= !spi_ck_i. 1:rsck = spi_ck_i..*/
+#define SPI_RSCK_I_EDGE    (BIT(8))
+#define SPI_RSCK_I_EDGE_M  (BIT(8))
+#define SPI_RSCK_I_EDGE_V  0x1
+#define SPI_RSCK_I_EDGE_S  8
+/* SPI_CS_SETUP : R/W ;bitpos:[7] ;default: 1'b1 ; */
+/*description: spi cs is enable when spi is in  prepare  phase. 1: enable 0: disable. Can be co
+nfigured in CONF state..*/
+#define SPI_CS_SETUP    (BIT(7))
+#define SPI_CS_SETUP_M  (BIT(7))
+#define SPI_CS_SETUP_V  0x1
+#define SPI_CS_SETUP_S  7
+/* SPI_CS_HOLD : R/W ;bitpos:[6] ;default: 1'b1 ; */
+/*description: spi cs keep low when spi is in  done  phase. 1: enable 0: disable. Can be config
+ured in CONF state..*/
+#define SPI_CS_HOLD    (BIT(6))
+#define SPI_CS_HOLD_M  (BIT(6))
+#define SPI_CS_HOLD_V  0x1
+#define SPI_CS_HOLD_S  6
+/* SPI_TSCK_I_EDGE : R/W ;bitpos:[5] ;default: 1'b0 ; */
+/*description: In the slave mode, this bit can be used to change the polarity of tsck. 0: tsck
+= spi_ck_i. 1:tsck = !spi_ck_i..*/
+#define SPI_TSCK_I_EDGE    (BIT(5))
+#define SPI_TSCK_I_EDGE_M  (BIT(5))
+#define SPI_TSCK_I_EDGE_V  0x1
+#define SPI_TSCK_I_EDGE_S  5
+/* SPI_OPI_MODE : R/W ;bitpos:[4] ;default: 1'b0 ; */
+/*description: Just for master mode. 1: spi controller is in OPI mode (all in 8-b-m). 0: others
+. Can be configured in CONF state..*/
+#define SPI_OPI_MODE    (BIT(4))
+#define SPI_OPI_MODE_M  (BIT(4))
+#define SPI_OPI_MODE_V  0x1
+#define SPI_OPI_MODE_S  4
+/* SPI_QPI_MODE : R/W/SS/SC ;bitpos:[3] ;default: 1'b0 ; */
+/*description: Both for master mode and slave mode. 1: spi controller is in QPI mode. 0: others
+. Can be configured in CONF state..*/
+#define SPI_QPI_MODE    (BIT(3))
+#define SPI_QPI_MODE_M  (BIT(3))
+#define SPI_QPI_MODE_V  0x1
+#define SPI_QPI_MODE_S  3
+/* SPI_DOUTDIN : R/W ;bitpos:[0] ;default: 1'b0 ; */
+/*description: Set the bit to enable full duplex communication. 1: enable 0: disable. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUTDIN    (BIT(0))
+#define SPI_DOUTDIN_M  (BIT(0))
+#define SPI_DOUTDIN_V  0x1
+#define SPI_DOUTDIN_S  0
+
+#define SPI_USER1_REG(i)          (REG_SPI_BASE(i) + 0x14)
+/* SPI_USR_ADDR_BITLEN : R/W ;bitpos:[31:27] ;default: 5'd23 ; */
+/*description: The length in bits of address phase. The register value shall be (bit_num-1). Ca
+n be configured in CONF state..*/
+#define SPI_USR_ADDR_BITLEN    0x0000001F
+#define SPI_USR_ADDR_BITLEN_M  ((SPI_USR_ADDR_BITLEN_V)<<(SPI_USR_ADDR_BITLEN_S))
+#define SPI_USR_ADDR_BITLEN_V  0x1F
+#define SPI_USR_ADDR_BITLEN_S  27
+/* SPI_CS_HOLD_TIME : R/W ;bitpos:[26:22] ;default: 5'h1 ; */
+/*description: delay cycles of cs pin by spi clock this bits are combined with spi_cs_hold bit.
+ Can be configured in CONF state..*/
+#define SPI_CS_HOLD_TIME    0x0000001F
+#define SPI_CS_HOLD_TIME_M  ((SPI_CS_HOLD_TIME_V)<<(SPI_CS_HOLD_TIME_S))
+#define SPI_CS_HOLD_TIME_V  0x1F
+#define SPI_CS_HOLD_TIME_S  22
+/* SPI_CS_SETUP_TIME : R/W ;bitpos:[21:17] ;default: 5'b0 ; */
+/*description: (cycles+1) of prepare phase by spi clock this bits are combined with spi_cs_setu
+p bit. Can be configured in CONF state..*/
+#define SPI_CS_SETUP_TIME    0x0000001F
+#define SPI_CS_SETUP_TIME_M  ((SPI_CS_SETUP_TIME_V)<<(SPI_CS_SETUP_TIME_S))
+#define SPI_CS_SETUP_TIME_V  0x1F
+#define SPI_CS_SETUP_TIME_S  17
+/* SPI_MST_WFULL_ERR_END_EN : R/W ;bitpos:[16] ;default: 1'b1 ; */
+/*description: 1: SPI transfer is ended when SPI RX AFIFO wfull error is valid in GP-SPI master
+ FD/HD-mode. 0: SPI transfer is not ended when SPI RX AFIFO wfull error is valid
+ in GP-SPI master FD/HD-mode..*/
+#define SPI_MST_WFULL_ERR_END_EN    (BIT(16))
+#define SPI_MST_WFULL_ERR_END_EN_M  (BIT(16))
+#define SPI_MST_WFULL_ERR_END_EN_V  0x1
+#define SPI_MST_WFULL_ERR_END_EN_S  16
+/* SPI_USR_DUMMY_CYCLELEN : R/W ;bitpos:[7:0] ;default: 8'd7 ; */
+/*description: The length in spi_clk cycles of dummy phase. The register value shall be (cycle_
+num-1). Can be configured in CONF state..*/
+#define SPI_USR_DUMMY_CYCLELEN    0x000000FF
+#define SPI_USR_DUMMY_CYCLELEN_M  ((SPI_USR_DUMMY_CYCLELEN_V)<<(SPI_USR_DUMMY_CYCLELEN_S))
+#define SPI_USR_DUMMY_CYCLELEN_V  0xFF
+#define SPI_USR_DUMMY_CYCLELEN_S  0
+
+#define SPI_USER2_REG(i)          (REG_SPI_BASE(i) + 0x18)
+/* SPI_USR_COMMAND_BITLEN : R/W ;bitpos:[31:28] ;default: 4'd7 ; */
+/*description: The length in bits of command phase. The register value shall be (bit_num-1). Ca
+n be configured in CONF state..*/
+#define SPI_USR_COMMAND_BITLEN    0x0000000F
+#define SPI_USR_COMMAND_BITLEN_M  ((SPI_USR_COMMAND_BITLEN_V)<<(SPI_USR_COMMAND_BITLEN_S))
+#define SPI_USR_COMMAND_BITLEN_V  0xF
+#define SPI_USR_COMMAND_BITLEN_S  28
+/* SPI_MST_REMPTY_ERR_END_EN : R/W ;bitpos:[27] ;default: 1'b1 ; */
+/*description: 1: SPI transfer is ended when SPI TX AFIFO read empty error is valid in GP-SPI m
+aster FD/HD-mode. 0: SPI transfer is not ended when SPI TX AFIFO read empty error
+r is valid in GP-SPI master FD/HD-mode..*/
+#define SPI_MST_REMPTY_ERR_END_EN    (BIT(27))
+#define SPI_MST_REMPTY_ERR_END_EN_M  (BIT(27))
+#define SPI_MST_REMPTY_ERR_END_EN_V  0x1
+#define SPI_MST_REMPTY_ERR_END_EN_S  27
+/* SPI_USR_COMMAND_VALUE : R/W ;bitpos:[15:0] ;default: 16'b0 ; */
+/*description: The value of  command. Can be configured in CONF state..*/
+#define SPI_USR_COMMAND_VALUE    0x0000FFFF
+#define SPI_USR_COMMAND_VALUE_M  ((SPI_USR_COMMAND_VALUE_V)<<(SPI_USR_COMMAND_VALUE_S))
+#define SPI_USR_COMMAND_VALUE_V  0xFFFF
+#define SPI_USR_COMMAND_VALUE_S  0
+
+#define SPI_MS_DLEN_REG(i)          (REG_SPI_BASE(i) + 0x1C)
+/* SPI_MS_DATA_BITLEN : R/W ;bitpos:[17:0] ;default: 18'b0 ; */
+/*description: The value of these bits is the configured SPI transmission data bit length in ma
+ster mode DMA controlled transfer or CPU controlled transfer. The value is also
+the configured bit length in slave mode DMA RX controlled transfer. The register
+ value shall be (bit_num-1). Can be configured in CONF state..*/
+#define SPI_MS_DATA_BITLEN    0x0003FFFF
+#define SPI_MS_DATA_BITLEN_M  ((SPI_MS_DATA_BITLEN_V)<<(SPI_MS_DATA_BITLEN_S))
+#define SPI_MS_DATA_BITLEN_V  0x3FFFF
+#define SPI_MS_DATA_BITLEN_S  0
+
+#define SPI_MISC_REG(i)          (REG_SPI_BASE(i) + 0x20)
+/* SPI_QUAD_DIN_PIN_SWAP : R/W ;bitpos:[31] ;default: 1'b0 ; */
+/*description: 1: SPI quad input swap enable, swap FSPID with FSPIQ, swap FSPIWP with FSPIHD. 0
+:  spi quad input swap disable. Can be configured in CONF state..*/
+#define SPI_QUAD_DIN_PIN_SWAP    (BIT(31))
+#define SPI_QUAD_DIN_PIN_SWAP_M  (BIT(31))
+#define SPI_QUAD_DIN_PIN_SWAP_V  0x1
+#define SPI_QUAD_DIN_PIN_SWAP_S  31
+/* SPI_CS_KEEP_ACTIVE : R/W ;bitpos:[30] ;default: 1'b0 ; */
+/*description: spi cs line keep low when the bit is set. Can be configured in CONF state..*/
+#define SPI_CS_KEEP_ACTIVE    (BIT(30))
+#define SPI_CS_KEEP_ACTIVE_M  (BIT(30))
+#define SPI_CS_KEEP_ACTIVE_V  0x1
+#define SPI_CS_KEEP_ACTIVE_S  30
+/* SPI_CK_IDLE_EDGE : R/W ;bitpos:[29] ;default: 1'b0 ; */
+/*description: 1: spi clk line is high when idle     0: spi clk line is low when idle. Can be c
+onfigured in CONF state..*/
+#define SPI_CK_IDLE_EDGE    (BIT(29))
+#define SPI_CK_IDLE_EDGE_M  (BIT(29))
+#define SPI_CK_IDLE_EDGE_V  0x1
+#define SPI_CK_IDLE_EDGE_S  29
+/* SPI_DQS_IDLE_EDGE : R/W ;bitpos:[24] ;default: 1'b0 ; */
+/*description: The default value of spi_dqs. Can be configured in CONF state..*/
+#define SPI_DQS_IDLE_EDGE    (BIT(24))
+#define SPI_DQS_IDLE_EDGE_M  (BIT(24))
+#define SPI_DQS_IDLE_EDGE_V  0x1
+#define SPI_DQS_IDLE_EDGE_S  24
+/* SPI_SLAVE_CS_POL : R/W ;bitpos:[23] ;default: 1'b0 ; */
+/*description: spi slave input cs polarity select. 1: inv  0: not change. Can be configured in
+CONF state..*/
+#define SPI_SLAVE_CS_POL    (BIT(23))
+#define SPI_SLAVE_CS_POL_M  (BIT(23))
+#define SPI_SLAVE_CS_POL_V  0x1
+#define SPI_SLAVE_CS_POL_S  23
+/* SPI_CMD_DTR_EN : R/W ;bitpos:[19] ;default: 1'b0 ; */
+/*description: 1: SPI clk and data of SPI_SEND_CMD state are in DTR mode, including master 1/2/
+4/8-bm. 0:  SPI clk and data of SPI_SEND_CMD state are in STR mode. Can be confi
+gured in CONF state..*/
+#define SPI_CMD_DTR_EN    (BIT(19))
+#define SPI_CMD_DTR_EN_M  (BIT(19))
+#define SPI_CMD_DTR_EN_V  0x1
+#define SPI_CMD_DTR_EN_S  19
+/* SPI_ADDR_DTR_EN : R/W ;bitpos:[18] ;default: 1'b0 ; */
+/*description: 1: SPI clk and data of SPI_SEND_ADDR state are in DTR mode, including master 1/2
+/4/8-bm.  0:  SPI clk and data of SPI_SEND_ADDR state are in STR mode. Can be co
+nfigured in CONF state..*/
+#define SPI_ADDR_DTR_EN    (BIT(18))
+#define SPI_ADDR_DTR_EN_M  (BIT(18))
+#define SPI_ADDR_DTR_EN_V  0x1
+#define SPI_ADDR_DTR_EN_S  18
+/* SPI_DATA_DTR_EN : R/W ;bitpos:[17] ;default: 1'b0 ; */
+/*description: 1: SPI clk and data of SPI_DOUT and SPI_DIN state are in DTR mode, including mas
+ter 1/2/4/8-bm.  0:  SPI clk and data of SPI_DOUT and SPI_DIN state are in STR m
+ode. Can be configured in CONF state..*/
+#define SPI_DATA_DTR_EN    (BIT(17))
+#define SPI_DATA_DTR_EN_M  (BIT(17))
+#define SPI_DATA_DTR_EN_V  0x1
+#define SPI_DATA_DTR_EN_S  17
+/* SPI_CLK_DATA_DTR_EN : R/W ;bitpos:[16] ;default: 1'b0 ; */
+/*description: 1: SPI master DTR mode is applied to SPI clk, data and spi_dqs.  0: SPI master D
+TR mode is  only applied to spi_dqs. This bit should be used with bit 17/18/19. .*/
+#define SPI_CLK_DATA_DTR_EN    (BIT(16))
+#define SPI_CLK_DATA_DTR_EN_M  (BIT(16))
+#define SPI_CLK_DATA_DTR_EN_V  0x1
+#define SPI_CLK_DATA_DTR_EN_S  16
+/* SPI_MASTER_CS_POL : R/W ;bitpos:[12:7] ;default: 6'b0 ; */
+/*description: In the master mode the bits are the polarity of spi cs line, the value is equiva
+lent to spi_cs ^ spi_master_cs_pol. Can be configured in CONF state..*/
+#define SPI_MASTER_CS_POL    0x0000003F
+#define SPI_MASTER_CS_POL_M  ((SPI_MASTER_CS_POL_V)<<(SPI_MASTER_CS_POL_S))
+#define SPI_MASTER_CS_POL_V  0x3F
+#define SPI_MASTER_CS_POL_S  7
+/* SPI_CK_DIS : R/W ;bitpos:[6] ;default: 1'b0 ; */
+/*description: 1: spi clk out disable,  0: spi clk out enable. Can be configured in CONF state..*/
+#define SPI_CK_DIS    (BIT(6))
+#define SPI_CK_DIS_M  (BIT(6))
+#define SPI_CK_DIS_V  0x1
+#define SPI_CK_DIS_S  6
+/* SPI_CS5_DIS : R/W ;bitpos:[5] ;default: 1'b1 ; */
+/*description: SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Ca
+n be configured in CONF state..*/
+#define SPI_CS5_DIS    (BIT(5))
+#define SPI_CS5_DIS_M  (BIT(5))
+#define SPI_CS5_DIS_V  0x1
+#define SPI_CS5_DIS_S  5
+/* SPI_CS4_DIS : R/W ;bitpos:[4] ;default: 1'b1 ; */
+/*description: SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Ca
+n be configured in CONF state..*/
+#define SPI_CS4_DIS    (BIT(4))
+#define SPI_CS4_DIS_M  (BIT(4))
+#define SPI_CS4_DIS_V  0x1
+#define SPI_CS4_DIS_S  4
+/* SPI_CS3_DIS : R/W ;bitpos:[3] ;default: 1'b1 ; */
+/*description: SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Ca
+n be configured in CONF state..*/
+#define SPI_CS3_DIS    (BIT(3))
+#define SPI_CS3_DIS_M  (BIT(3))
+#define SPI_CS3_DIS_V  0x1
+#define SPI_CS3_DIS_S  3
+/* SPI_CS2_DIS : R/W ;bitpos:[2] ;default: 1'b1 ; */
+/*description: SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Ca
+n be configured in CONF state..*/
+#define SPI_CS2_DIS    (BIT(2))
+#define SPI_CS2_DIS_M  (BIT(2))
+#define SPI_CS2_DIS_V  0x1
+#define SPI_CS2_DIS_S  2
+/* SPI_CS1_DIS : R/W ;bitpos:[1] ;default: 1'b1 ; */
+/*description: SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Ca
+n be configured in CONF state..*/
+#define SPI_CS1_DIS    (BIT(1))
+#define SPI_CS1_DIS_M  (BIT(1))
+#define SPI_CS1_DIS_V  0x1
+#define SPI_CS1_DIS_S  1
+/* SPI_CS0_DIS : R/W ;bitpos:[0] ;default: 1'b0 ; */
+/*description: SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Ca
+n be configured in CONF state..*/
+#define SPI_CS0_DIS    (BIT(0))
+#define SPI_CS0_DIS_M  (BIT(0))
+#define SPI_CS0_DIS_V  0x1
+#define SPI_CS0_DIS_S  0
+
+#define SPI_DIN_MODE_REG(i)          (REG_SPI_BASE(i) + 0x24)
+/* SPI_TIMING_HCLK_ACTIVE : R/W ;bitpos:[16] ;default: 1'b0 ; */
+/*description: 1:enable hclk in SPI input timing module.  0: disable it. Can be configured in C
+ONF state..*/
+#define SPI_TIMING_HCLK_ACTIVE    (BIT(16))
+#define SPI_TIMING_HCLK_ACTIVE_M  (BIT(16))
+#define SPI_TIMING_HCLK_ACTIVE_V  0x1
+#define SPI_TIMING_HCLK_ACTIVE_S  16
+/* SPI_DIN7_MODE : R/W ;bitpos:[15:14] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN7_MODE    0x00000003
+#define SPI_DIN7_MODE_M  ((SPI_DIN7_MODE_V)<<(SPI_DIN7_MODE_S))
+#define SPI_DIN7_MODE_V  0x3
+#define SPI_DIN7_MODE_S  14
+/* SPI_DIN6_MODE : R/W ;bitpos:[13:12] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN6_MODE    0x00000003
+#define SPI_DIN6_MODE_M  ((SPI_DIN6_MODE_V)<<(SPI_DIN6_MODE_S))
+#define SPI_DIN6_MODE_V  0x3
+#define SPI_DIN6_MODE_S  12
+/* SPI_DIN5_MODE : R/W ;bitpos:[11:10] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN5_MODE    0x00000003
+#define SPI_DIN5_MODE_M  ((SPI_DIN5_MODE_V)<<(SPI_DIN5_MODE_S))
+#define SPI_DIN5_MODE_V  0x3
+#define SPI_DIN5_MODE_S  10
+/* SPI_DIN4_MODE : R/W ;bitpos:[9:8] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN4_MODE    0x00000003
+#define SPI_DIN4_MODE_M  ((SPI_DIN4_MODE_V)<<(SPI_DIN4_MODE_S))
+#define SPI_DIN4_MODE_V  0x3
+#define SPI_DIN4_MODE_S  8
+/* SPI_DIN3_MODE : R/W ;bitpos:[7:6] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN3_MODE    0x00000003
+#define SPI_DIN3_MODE_M  ((SPI_DIN3_MODE_V)<<(SPI_DIN3_MODE_S))
+#define SPI_DIN3_MODE_V  0x3
+#define SPI_DIN3_MODE_S  6
+/* SPI_DIN2_MODE : R/W ;bitpos:[5:4] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN2_MODE    0x00000003
+#define SPI_DIN2_MODE_M  ((SPI_DIN2_MODE_V)<<(SPI_DIN2_MODE_S))
+#define SPI_DIN2_MODE_V  0x3
+#define SPI_DIN2_MODE_S  4
+/* SPI_DIN1_MODE : R/W ;bitpos:[3:2] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN1_MODE    0x00000003
+#define SPI_DIN1_MODE_M  ((SPI_DIN1_MODE_V)<<(SPI_DIN1_MODE_S))
+#define SPI_DIN1_MODE_V  0x3
+#define SPI_DIN1_MODE_S  2
+/* SPI_DIN0_MODE : R/W ;bitpos:[1:0] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN0_MODE    0x00000003
+#define SPI_DIN0_MODE_M  ((SPI_DIN0_MODE_V)<<(SPI_DIN0_MODE_S))
+#define SPI_DIN0_MODE_V  0x3
+#define SPI_DIN0_MODE_S  0
+
+#define SPI_DIN_NUM_REG(i)          (REG_SPI_BASE(i) + 0x28)
+/* SPI_DIN7_NUM : R/W ;bitpos:[15:14] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN7_NUM    0x00000003
+#define SPI_DIN7_NUM_M  ((SPI_DIN7_NUM_V)<<(SPI_DIN7_NUM_S))
+#define SPI_DIN7_NUM_V  0x3
+#define SPI_DIN7_NUM_S  14
+/* SPI_DIN6_NUM : R/W ;bitpos:[13:12] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN6_NUM    0x00000003
+#define SPI_DIN6_NUM_M  ((SPI_DIN6_NUM_V)<<(SPI_DIN6_NUM_S))
+#define SPI_DIN6_NUM_V  0x3
+#define SPI_DIN6_NUM_S  12
+/* SPI_DIN5_NUM : R/W ;bitpos:[11:10] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN5_NUM    0x00000003
+#define SPI_DIN5_NUM_M  ((SPI_DIN5_NUM_V)<<(SPI_DIN5_NUM_S))
+#define SPI_DIN5_NUM_V  0x3
+#define SPI_DIN5_NUM_S  10
+/* SPI_DIN4_NUM : R/W ;bitpos:[9:8] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN4_NUM    0x00000003
+#define SPI_DIN4_NUM_M  ((SPI_DIN4_NUM_V)<<(SPI_DIN4_NUM_S))
+#define SPI_DIN4_NUM_V  0x3
+#define SPI_DIN4_NUM_S  8
+/* SPI_DIN3_NUM : R/W ;bitpos:[7:6] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN3_NUM    0x00000003
+#define SPI_DIN3_NUM_M  ((SPI_DIN3_NUM_V)<<(SPI_DIN3_NUM_S))
+#define SPI_DIN3_NUM_V  0x3
+#define SPI_DIN3_NUM_S  6
+/* SPI_DIN2_NUM : R/W ;bitpos:[5:4] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN2_NUM    0x00000003
+#define SPI_DIN2_NUM_M  ((SPI_DIN2_NUM_V)<<(SPI_DIN2_NUM_S))
+#define SPI_DIN2_NUM_V  0x3
+#define SPI_DIN2_NUM_S  4
+/* SPI_DIN1_NUM : R/W ;bitpos:[3:2] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN1_NUM    0x00000003
+#define SPI_DIN1_NUM_M  ((SPI_DIN1_NUM_V)<<(SPI_DIN1_NUM_S))
+#define SPI_DIN1_NUM_V  0x3
+#define SPI_DIN1_NUM_S  2
+/* SPI_DIN0_NUM : R/W ;bitpos:[1:0] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN0_NUM    0x00000003
+#define SPI_DIN0_NUM_M  ((SPI_DIN0_NUM_V)<<(SPI_DIN0_NUM_S))
+#define SPI_DIN0_NUM_V  0x3
+#define SPI_DIN0_NUM_S  0
+
+#define SPI_DOUT_MODE_REG(i)          (REG_SPI_BASE(i) + 0x2C)
+/* SPI_D_DQS_MODE : R/W ;bitpos:[8] ;default: 1'b0 ; */
+/*description: The output signal SPI_DQS is delayed by the SPI module clock, 0: output without
+delayed, 1: output delay for a SPI module clock cycle at its negative edge. Can
+be configured in CONF state..*/
+#define SPI_D_DQS_MODE    (BIT(8))
+#define SPI_D_DQS_MODE_M  (BIT(8))
+#define SPI_D_DQS_MODE_V  0x1
+#define SPI_D_DQS_MODE_S  8
+/* SPI_DOUT7_MODE : R/W ;bitpos:[7] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT7_MODE    (BIT(7))
+#define SPI_DOUT7_MODE_M  (BIT(7))
+#define SPI_DOUT7_MODE_V  0x1
+#define SPI_DOUT7_MODE_S  7
+/* SPI_DOUT6_MODE : R/W ;bitpos:[6] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT6_MODE    (BIT(6))
+#define SPI_DOUT6_MODE_M  (BIT(6))
+#define SPI_DOUT6_MODE_V  0x1
+#define SPI_DOUT6_MODE_S  6
+/* SPI_DOUT5_MODE : R/W ;bitpos:[5] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT5_MODE    (BIT(5))
+#define SPI_DOUT5_MODE_M  (BIT(5))
+#define SPI_DOUT5_MODE_V  0x1
+#define SPI_DOUT5_MODE_S  5
+/* SPI_DOUT4_MODE : R/W ;bitpos:[4] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT4_MODE    (BIT(4))
+#define SPI_DOUT4_MODE_M  (BIT(4))
+#define SPI_DOUT4_MODE_V  0x1
+#define SPI_DOUT4_MODE_S  4
+/* SPI_DOUT3_MODE : R/W ;bitpos:[3] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT3_MODE    (BIT(3))
+#define SPI_DOUT3_MODE_M  (BIT(3))
+#define SPI_DOUT3_MODE_V  0x1
+#define SPI_DOUT3_MODE_S  3
+/* SPI_DOUT2_MODE : R/W ;bitpos:[2] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT2_MODE    (BIT(2))
+#define SPI_DOUT2_MODE_M  (BIT(2))
+#define SPI_DOUT2_MODE_V  0x1
+#define SPI_DOUT2_MODE_S  2
+/* SPI_DOUT1_MODE : R/W ;bitpos:[1] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT1_MODE    (BIT(1))
+#define SPI_DOUT1_MODE_M  (BIT(1))
+#define SPI_DOUT1_MODE_V  0x1
+#define SPI_DOUT1_MODE_S  1
+/* SPI_DOUT0_MODE : R/W ;bitpos:[0] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT0_MODE    (BIT(0))
+#define SPI_DOUT0_MODE_M  (BIT(0))
+#define SPI_DOUT0_MODE_V  0x1
+#define SPI_DOUT0_MODE_S  0
+
+#define SPI_DMA_CONF_REG(i)          (REG_SPI_BASE(i) + 0x30)
+/* SPI_DMA_AFIFO_RST : WT ;bitpos:[31] ;default: 1'b0 ; */
+/*description: Set this bit to reset DMA TX AFIFO, which is used to send data out in SPI slave
+DMA controlled mode transfer..*/
+#define SPI_DMA_AFIFO_RST    (BIT(31))
+#define SPI_DMA_AFIFO_RST_M  (BIT(31))
+#define SPI_DMA_AFIFO_RST_V  0x1
+#define SPI_DMA_AFIFO_RST_S  31
+/* SPI_BUF_AFIFO_RST : WT ;bitpos:[30] ;default: 1'b0 ; */
+/*description: Set this bit to reset BUF TX AFIFO, which is used send data out in SPI slave CPU
+ controlled mode transfer and master mode transfer..*/
+#define SPI_BUF_AFIFO_RST    (BIT(30))
+#define SPI_BUF_AFIFO_RST_M  (BIT(30))
+#define SPI_BUF_AFIFO_RST_V  0x1
+#define SPI_BUF_AFIFO_RST_S  30
+/* SPI_RX_AFIFO_RST : WT ;bitpos:[29] ;default: 1'b0 ; */
+/*description: Set this bit to reset RX AFIFO, which is used to receive data in SPI master and
+slave mode transfer..*/
+#define SPI_RX_AFIFO_RST    (BIT(29))
+#define SPI_RX_AFIFO_RST_M  (BIT(29))
+#define SPI_RX_AFIFO_RST_V  0x1
+#define SPI_RX_AFIFO_RST_S  29
+/* SPI_DMA_TX_ENA : R/W ;bitpos:[28] ;default: 1'b0 ; */
+/*description: Set this bit to enable SPI DMA controlled send data mode..*/
+#define SPI_DMA_TX_ENA    (BIT(28))
+#define SPI_DMA_TX_ENA_M  (BIT(28))
+#define SPI_DMA_TX_ENA_V  0x1
+#define SPI_DMA_TX_ENA_S  28
+/* SPI_DMA_RX_ENA : R/W ;bitpos:[27] ;default: 1'd0 ; */
+/*description: Set this bit to enable SPI DMA controlled receive data mode..*/
+#define SPI_DMA_RX_ENA    (BIT(27))
+#define SPI_DMA_RX_ENA_M  (BIT(27))
+#define SPI_DMA_RX_ENA_V  0x1
+#define SPI_DMA_RX_ENA_S  27
+/* SPI_RX_EOF_EN : R/W ;bitpos:[21] ;default: 1'b0 ; */
+/*description: 1: spi_dma_inlink_eof is set when the number of dma pushed data bytes is equal t
+o the value of spi_slv/mst_dma_rd_bytelen[19:0] in spi dma transition.  0: spi_d
+ma_inlink_eof is set by spi_trans_done in non-seg-trans or spi_dma_seg_trans_don
+e in seg-trans..*/
+#define SPI_RX_EOF_EN    (BIT(21))
+#define SPI_RX_EOF_EN_M  (BIT(21))
+#define SPI_RX_EOF_EN_V  0x1
+#define SPI_RX_EOF_EN_S  21
+/* SPI_SLV_TX_SEG_TRANS_CLR_EN : R/W ;bitpos:[20] ;default: 1'b0 ; */
+/*description: 1: spi_dma_outfifo_empty_vld is cleared by spi slave cmd 6. 0: spi_dma_outfifo_e
+mpty_vld is cleared by spi_trans_done..*/
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN    (BIT(20))
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN_M  (BIT(20))
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN_V  0x1
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN_S  20
+/* SPI_SLV_RX_SEG_TRANS_CLR_EN : R/W ;bitpos:[19] ;default: 1'b0 ; */
+/*description: 1: spi_dma_infifo_full_vld is cleared by spi slave cmd 5. 0: spi_dma_infifo_full
+_vld is cleared by spi_trans_done..*/
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN    (BIT(19))
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN_M  (BIT(19))
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN_V  0x1
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN_S  19
+/* SPI_DMA_SLV_SEG_TRANS_EN : R/W ;bitpos:[18] ;default: 1'b0 ; */
+/*description: Enable dma segment transfer in spi dma half slave mode. 1: enable. 0: disable..*/
+#define SPI_DMA_SLV_SEG_TRANS_EN    (BIT(18))
+#define SPI_DMA_SLV_SEG_TRANS_EN_M  (BIT(18))
+#define SPI_DMA_SLV_SEG_TRANS_EN_V  0x1
+#define SPI_DMA_SLV_SEG_TRANS_EN_S  18
+/* SPI_DMA_INFIFO_FULL : RO ;bitpos:[1] ;default: 1'b1 ; */
+/*description: Records the status of DMA RX FIFO. 1: DMA RX FIFO is not ready for receiving dat
+a. 0: DMA RX FIFO is ready for receiving data..*/
+#define SPI_DMA_INFIFO_FULL    (BIT(1))
+#define SPI_DMA_INFIFO_FULL_M  (BIT(1))
+#define SPI_DMA_INFIFO_FULL_V  0x1
+#define SPI_DMA_INFIFO_FULL_S  1
+/* SPI_DMA_OUTFIFO_EMPTY : RO ;bitpos:[0] ;default: 1'b1 ; */
+/*description: Records the status of DMA TX FIFO. 1: DMA TX FIFO is not ready for sending data.
+ 0: DMA TX FIFO is ready for sending data..*/
+#define SPI_DMA_OUTFIFO_EMPTY    (BIT(0))
+#define SPI_DMA_OUTFIFO_EMPTY_M  (BIT(0))
+#define SPI_DMA_OUTFIFO_EMPTY_V  0x1
+#define SPI_DMA_OUTFIFO_EMPTY_S  0
+
+#define SPI_DMA_INT_ENA_REG(i)          (REG_SPI_BASE(i) + 0x34)
+/* SPI_APP1_INT_ENA : R/W ;bitpos:[20] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_APP1_INT interrupt..*/
+#define SPI_APP1_INT_ENA    (BIT(20))
+#define SPI_APP1_INT_ENA_M  (BIT(20))
+#define SPI_APP1_INT_ENA_V  0x1
+#define SPI_APP1_INT_ENA_S  20
+/* SPI_APP2_INT_ENA : R/W ;bitpos:[19] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_APP2_INT interrupt..*/
+#define SPI_APP2_INT_ENA    (BIT(19))
+#define SPI_APP2_INT_ENA_M  (BIT(19))
+#define SPI_APP2_INT_ENA_V  0x1
+#define SPI_APP2_INT_ENA_S  19
+/* SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA : R/W ;bitpos:[18] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt..*/
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_M  (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_V  0x1
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_S  18
+/* SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA : R/W ;bitpos:[17] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt..*/
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_M  (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_V  0x1
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_S  17
+/* SPI_SLV_CMD_ERR_INT_ENA : R/W ;bitpos:[16] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_SLV_CMD_ERR_INT interrupt..*/
+#define SPI_SLV_CMD_ERR_INT_ENA    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_ENA_M  (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_ENA_V  0x1
+#define SPI_SLV_CMD_ERR_INT_ENA_S  16
+/* SPI_SLV_BUF_ADDR_ERR_INT_ENA : R/W ;bitpos:[15] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt..*/
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA_M  (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA_V  0x1
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA_S  15
+/* SPI_SEG_MAGIC_ERR_INT_ENA : R/W ;bitpos:[14] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_SEG_MAGIC_ERR_INT interrupt..*/
+#define SPI_SEG_MAGIC_ERR_INT_ENA    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_ENA_M  (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_ENA_V  0x1
+#define SPI_SEG_MAGIC_ERR_INT_ENA_S  14
+/* SPI_DMA_SEG_TRANS_DONE_INT_ENA : R/W ;bitpos:[13] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt..*/
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA_M  (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA_V  0x1
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA_S  13
+/* SPI_TRANS_DONE_INT_ENA : R/W ;bitpos:[12] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_TRANS_DONE_INT interrupt..*/
+#define SPI_TRANS_DONE_INT_ENA    (BIT(12))
+#define SPI_TRANS_DONE_INT_ENA_M  (BIT(12))
+#define SPI_TRANS_DONE_INT_ENA_V  0x1
+#define SPI_TRANS_DONE_INT_ENA_S  12
+/* SPI_SLV_WR_BUF_DONE_INT_ENA : R/W ;bitpos:[11] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_SLV_WR_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_WR_BUF_DONE_INT_ENA    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_ENA_M  (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_ENA_V  0x1
+#define SPI_SLV_WR_BUF_DONE_INT_ENA_S  11
+/* SPI_SLV_RD_BUF_DONE_INT_ENA : R/W ;bitpos:[10] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_SLV_RD_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_RD_BUF_DONE_INT_ENA    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_ENA_M  (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_ENA_V  0x1
+#define SPI_SLV_RD_BUF_DONE_INT_ENA_S  10
+/* SPI_SLV_WR_DMA_DONE_INT_ENA : R/W ;bitpos:[9] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_SLV_WR_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_WR_DMA_DONE_INT_ENA    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_ENA_M  (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_ENA_V  0x1
+#define SPI_SLV_WR_DMA_DONE_INT_ENA_S  9
+/* SPI_SLV_RD_DMA_DONE_INT_ENA : R/W ;bitpos:[8] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_SLV_RD_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_RD_DMA_DONE_INT_ENA    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_ENA_M  (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_ENA_V  0x1
+#define SPI_SLV_RD_DMA_DONE_INT_ENA_S  8
+/* SPI_SLV_CMDA_INT_ENA : R/W ;bitpos:[7] ;default: 1'b0 ; */
+/*description: The enable bit for SPI slave CMDA interrupt..*/
+#define SPI_SLV_CMDA_INT_ENA    (BIT(7))
+#define SPI_SLV_CMDA_INT_ENA_M  (BIT(7))
+#define SPI_SLV_CMDA_INT_ENA_V  0x1
+#define SPI_SLV_CMDA_INT_ENA_S  7
+/* SPI_SLV_CMD9_INT_ENA : R/W ;bitpos:[6] ;default: 1'b0 ; */
+/*description: The enable bit for SPI slave CMD9 interrupt..*/
+#define SPI_SLV_CMD9_INT_ENA    (BIT(6))
+#define SPI_SLV_CMD9_INT_ENA_M  (BIT(6))
+#define SPI_SLV_CMD9_INT_ENA_V  0x1
+#define SPI_SLV_CMD9_INT_ENA_S  6
+/* SPI_SLV_CMD8_INT_ENA : R/W ;bitpos:[5] ;default: 1'b0 ; */
+/*description: The enable bit for SPI slave CMD8 interrupt..*/
+#define SPI_SLV_CMD8_INT_ENA    (BIT(5))
+#define SPI_SLV_CMD8_INT_ENA_M  (BIT(5))
+#define SPI_SLV_CMD8_INT_ENA_V  0x1
+#define SPI_SLV_CMD8_INT_ENA_S  5
+/* SPI_SLV_CMD7_INT_ENA : R/W ;bitpos:[4] ;default: 1'b0 ; */
+/*description: The enable bit for SPI slave CMD7 interrupt..*/
+#define SPI_SLV_CMD7_INT_ENA    (BIT(4))
+#define SPI_SLV_CMD7_INT_ENA_M  (BIT(4))
+#define SPI_SLV_CMD7_INT_ENA_V  0x1
+#define SPI_SLV_CMD7_INT_ENA_S  4
+/* SPI_SLV_EN_QPI_INT_ENA : R/W ;bitpos:[3] ;default: 1'b0 ; */
+/*description: The enable bit for SPI slave En_QPI interrupt..*/
+#define SPI_SLV_EN_QPI_INT_ENA    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_ENA_M  (BIT(3))
+#define SPI_SLV_EN_QPI_INT_ENA_V  0x1
+#define SPI_SLV_EN_QPI_INT_ENA_S  3
+/* SPI_SLV_EX_QPI_INT_ENA : R/W ;bitpos:[2] ;default: 1'b0 ; */
+/*description: The enable bit for SPI slave Ex_QPI interrupt..*/
+#define SPI_SLV_EX_QPI_INT_ENA    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_ENA_M  (BIT(2))
+#define SPI_SLV_EX_QPI_INT_ENA_V  0x1
+#define SPI_SLV_EX_QPI_INT_ENA_S  2
+/* SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA : R/W ;bitpos:[1] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt..*/
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_M  (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_V  0x1
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_S  1
+/* SPI_DMA_INFIFO_FULL_ERR_INT_ENA : R/W ;bitpos:[0] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt..*/
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA_M  (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA_V  0x1
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA_S  0
+
+#define SPI_DMA_INT_CLR_REG(i)          (REG_SPI_BASE(i) + 0x38)
+/* SPI_APP1_INT_CLR : WT ;bitpos:[20] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_APP1_INT interrupt..*/
+#define SPI_APP1_INT_CLR    (BIT(20))
+#define SPI_APP1_INT_CLR_M  (BIT(20))
+#define SPI_APP1_INT_CLR_V  0x1
+#define SPI_APP1_INT_CLR_S  20
+/* SPI_APP2_INT_CLR : WT ;bitpos:[19] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_APP2_INT interrupt..*/
+#define SPI_APP2_INT_CLR    (BIT(19))
+#define SPI_APP2_INT_CLR_M  (BIT(19))
+#define SPI_APP2_INT_CLR_V  0x1
+#define SPI_APP2_INT_CLR_S  19
+/* SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR : WT ;bitpos:[18] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt..*/
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_M  (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_V  0x1
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_S  18
+/* SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR : WT ;bitpos:[17] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt..*/
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_M  (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_V  0x1
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_S  17
+/* SPI_SLV_CMD_ERR_INT_CLR : WT ;bitpos:[16] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_SLV_CMD_ERR_INT interrupt..*/
+#define SPI_SLV_CMD_ERR_INT_CLR    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_CLR_M  (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_CLR_V  0x1
+#define SPI_SLV_CMD_ERR_INT_CLR_S  16
+/* SPI_SLV_BUF_ADDR_ERR_INT_CLR : WT ;bitpos:[15] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt..*/
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR_M  (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR_V  0x1
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR_S  15
+/* SPI_SEG_MAGIC_ERR_INT_CLR : WT ;bitpos:[14] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_SEG_MAGIC_ERR_INT interrupt..*/
+#define SPI_SEG_MAGIC_ERR_INT_CLR    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_CLR_M  (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_CLR_V  0x1
+#define SPI_SEG_MAGIC_ERR_INT_CLR_S  14
+/* SPI_DMA_SEG_TRANS_DONE_INT_CLR : WT ;bitpos:[13] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt..*/
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR_M  (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR_V  0x1
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR_S  13
+/* SPI_TRANS_DONE_INT_CLR : WT ;bitpos:[12] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_TRANS_DONE_INT interrupt..*/
+#define SPI_TRANS_DONE_INT_CLR    (BIT(12))
+#define SPI_TRANS_DONE_INT_CLR_M  (BIT(12))
+#define SPI_TRANS_DONE_INT_CLR_V  0x1
+#define SPI_TRANS_DONE_INT_CLR_S  12
+/* SPI_SLV_WR_BUF_DONE_INT_CLR : WT ;bitpos:[11] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_SLV_WR_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_WR_BUF_DONE_INT_CLR    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_CLR_M  (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_CLR_V  0x1
+#define SPI_SLV_WR_BUF_DONE_INT_CLR_S  11
+/* SPI_SLV_RD_BUF_DONE_INT_CLR : WT ;bitpos:[10] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_SLV_RD_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_RD_BUF_DONE_INT_CLR    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_CLR_M  (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_CLR_V  0x1
+#define SPI_SLV_RD_BUF_DONE_INT_CLR_S  10
+/* SPI_SLV_WR_DMA_DONE_INT_CLR : WT ;bitpos:[9] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_SLV_WR_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_WR_DMA_DONE_INT_CLR    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_CLR_M  (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_CLR_V  0x1
+#define SPI_SLV_WR_DMA_DONE_INT_CLR_S  9
+/* SPI_SLV_RD_DMA_DONE_INT_CLR : WT ;bitpos:[8] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_SLV_RD_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_RD_DMA_DONE_INT_CLR    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_CLR_M  (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_CLR_V  0x1
+#define SPI_SLV_RD_DMA_DONE_INT_CLR_S  8
+/* SPI_SLV_CMDA_INT_CLR : WT ;bitpos:[7] ;default: 1'b0 ; */
+/*description: The clear bit for SPI slave CMDA interrupt..*/
+#define SPI_SLV_CMDA_INT_CLR    (BIT(7))
+#define SPI_SLV_CMDA_INT_CLR_M  (BIT(7))
+#define SPI_SLV_CMDA_INT_CLR_V  0x1
+#define SPI_SLV_CMDA_INT_CLR_S  7
+/* SPI_SLV_CMD9_INT_CLR : WT ;bitpos:[6] ;default: 1'b0 ; */
+/*description: The clear bit for SPI slave CMD9 interrupt..*/
+#define SPI_SLV_CMD9_INT_CLR    (BIT(6))
+#define SPI_SLV_CMD9_INT_CLR_M  (BIT(6))
+#define SPI_SLV_CMD9_INT_CLR_V  0x1
+#define SPI_SLV_CMD9_INT_CLR_S  6
+/* SPI_SLV_CMD8_INT_CLR : WT ;bitpos:[5] ;default: 1'b0 ; */
+/*description: The clear bit for SPI slave CMD8 interrupt..*/
+#define SPI_SLV_CMD8_INT_CLR    (BIT(5))
+#define SPI_SLV_CMD8_INT_CLR_M  (BIT(5))
+#define SPI_SLV_CMD8_INT_CLR_V  0x1
+#define SPI_SLV_CMD8_INT_CLR_S  5
+/* SPI_SLV_CMD7_INT_CLR : WT ;bitpos:[4] ;default: 1'b0 ; */
+/*description: The clear bit for SPI slave CMD7 interrupt..*/
+#define SPI_SLV_CMD7_INT_CLR    (BIT(4))
+#define SPI_SLV_CMD7_INT_CLR_M  (BIT(4))
+#define SPI_SLV_CMD7_INT_CLR_V  0x1
+#define SPI_SLV_CMD7_INT_CLR_S  4
+/* SPI_SLV_EN_QPI_INT_CLR : WT ;bitpos:[3] ;default: 1'b0 ; */
+/*description: The clear bit for SPI slave En_QPI interrupt..*/
+#define SPI_SLV_EN_QPI_INT_CLR    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_CLR_M  (BIT(3))
+#define SPI_SLV_EN_QPI_INT_CLR_V  0x1
+#define SPI_SLV_EN_QPI_INT_CLR_S  3
+/* SPI_SLV_EX_QPI_INT_CLR : WT ;bitpos:[2] ;default: 1'b0 ; */
+/*description: The clear bit for SPI slave Ex_QPI interrupt..*/
+#define SPI_SLV_EX_QPI_INT_CLR    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_CLR_M  (BIT(2))
+#define SPI_SLV_EX_QPI_INT_CLR_V  0x1
+#define SPI_SLV_EX_QPI_INT_CLR_S  2
+/* SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR : WT ;bitpos:[1] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt..*/
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_M  (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_V  0x1
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_S  1
+/* SPI_DMA_INFIFO_FULL_ERR_INT_CLR : WT ;bitpos:[0] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt..*/
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR_M  (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR_V  0x1
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR_S  0
+
+#define SPI_DMA_INT_RAW_REG(i)          (REG_SPI_BASE(i) + 0x3C)
+/* SPI_APP1_INT_RAW : R/WTC/SS ;bitpos:[20] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_APP1_INT interrupt. The value is only controlled by software
+..*/
+#define SPI_APP1_INT_RAW    (BIT(20))
+#define SPI_APP1_INT_RAW_M  (BIT(20))
+#define SPI_APP1_INT_RAW_V  0x1
+#define SPI_APP1_INT_RAW_S  20
+/* SPI_APP2_INT_RAW : R/WTC/SS ;bitpos:[19] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_APP2_INT interrupt. The value is only controlled by software
+..*/
+#define SPI_APP2_INT_RAW    (BIT(19))
+#define SPI_APP2_INT_RAW_M  (BIT(19))
+#define SPI_APP2_INT_RAW_V  0x1
+#define SPI_APP2_INT_RAW_S  19
+/* SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW : R/WTC/SS ;bitpos:[18] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt. 1: There is a TX BUF
+AFIFO read-empty error when SPI outputs data in master mode. 0: Others..*/
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_M  (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_V  0x1
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_S  18
+/* SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW : R/WTC/SS ;bitpos:[17] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt. 1: There is a RX AFIFO
+ write-full error when SPI inputs data in master mode. 0: Others..*/
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_M  (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_V  0x1
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_S  17
+/* SPI_SLV_CMD_ERR_INT_RAW : R/WTC/SS ;bitpos:[16] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_SLV_CMD_ERR_INT interrupt. 1: The slave command value in the
+ current SPI slave HD mode transmission is not supported. 0: Others..*/
+#define SPI_SLV_CMD_ERR_INT_RAW    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_RAW_M  (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_RAW_V  0x1
+#define SPI_SLV_CMD_ERR_INT_RAW_S  16
+/* SPI_SLV_BUF_ADDR_ERR_INT_RAW : R/WTC/SS ;bitpos:[15] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt. 1: The accessing data address
+s of the current SPI slave mode CPU controlled FD, Wr_BUF or Rd_BUF transmission
+ is bigger than 63. 0: Others..*/
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW_M  (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW_V  0x1
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW_S  15
+/* SPI_SEG_MAGIC_ERR_INT_RAW : R/WTC/SS ;bitpos:[14] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_SEG_MAGIC_ERR_INT interrupt. 1: The magic value in CONF buff
+er is error in the DMA seg-conf-trans. 0: others..*/
+#define SPI_SEG_MAGIC_ERR_INT_RAW    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_RAW_M  (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_RAW_V  0x1
+#define SPI_SEG_MAGIC_ERR_INT_RAW_S  14
+/* SPI_DMA_SEG_TRANS_DONE_INT_RAW : R/WTC/SS ;bitpos:[13] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt. 1:  spi master DMA full-du
+plex/half-duplex seg-conf-trans ends or slave half-duplex seg-trans ends. And da
+ta has been pushed to corresponding memory.  0:  seg-conf-trans or seg-trans is
+not ended or not occurred. .*/
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW_M  (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW_V  0x1
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW_S  13
+/* SPI_TRANS_DONE_INT_RAW : R/WTC/SS ;bitpos:[12] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_TRANS_DONE_INT interrupt. 1: SPI master mode transmission is
+ ended. 0: others..*/
+#define SPI_TRANS_DONE_INT_RAW    (BIT(12))
+#define SPI_TRANS_DONE_INT_RAW_M  (BIT(12))
+#define SPI_TRANS_DONE_INT_RAW_V  0x1
+#define SPI_TRANS_DONE_INT_RAW_S  12
+/* SPI_SLV_WR_BUF_DONE_INT_RAW : R/WTC/SS ;bitpos:[11] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_SLV_WR_BUF_DONE_INT interrupt. 1: SPI slave mode Wr_BUF tran
+smission is ended. 0: Others..*/
+#define SPI_SLV_WR_BUF_DONE_INT_RAW    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_RAW_M  (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_RAW_V  0x1
+#define SPI_SLV_WR_BUF_DONE_INT_RAW_S  11
+/* SPI_SLV_RD_BUF_DONE_INT_RAW : R/WTC/SS ;bitpos:[10] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_SLV_RD_BUF_DONE_INT interrupt. 1: SPI slave mode Rd_BUF tran
+smission is ended. 0: Others..*/
+#define SPI_SLV_RD_BUF_DONE_INT_RAW    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_RAW_M  (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_RAW_V  0x1
+#define SPI_SLV_RD_BUF_DONE_INT_RAW_S  10
+/* SPI_SLV_WR_DMA_DONE_INT_RAW : R/WTC/SS ;bitpos:[9] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_SLV_WR_DMA_DONE_INT interrupt. 1: SPI slave mode Wr_DMA tran
+smission is ended. 0: Others..*/
+#define SPI_SLV_WR_DMA_DONE_INT_RAW    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_RAW_M  (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_RAW_V  0x1
+#define SPI_SLV_WR_DMA_DONE_INT_RAW_S  9
+/* SPI_SLV_RD_DMA_DONE_INT_RAW : R/WTC/SS ;bitpos:[8] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_SLV_RD_DMA_DONE_INT interrupt. 1: SPI slave mode Rd_DMA tran
+smission is ended. 0: Others..*/
+#define SPI_SLV_RD_DMA_DONE_INT_RAW    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_RAW_M  (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_RAW_V  0x1
+#define SPI_SLV_RD_DMA_DONE_INT_RAW_S  8
+/* SPI_SLV_CMDA_INT_RAW : R/WTC/SS ;bitpos:[7] ;default: 1'b0 ; */
+/*description: The raw bit for SPI slave CMDA interrupt. 1: SPI slave mode CMDA transmission is
+ ended. 0: Others..*/
+#define SPI_SLV_CMDA_INT_RAW    (BIT(7))
+#define SPI_SLV_CMDA_INT_RAW_M  (BIT(7))
+#define SPI_SLV_CMDA_INT_RAW_V  0x1
+#define SPI_SLV_CMDA_INT_RAW_S  7
+/* SPI_SLV_CMD9_INT_RAW : R/WTC/SS ;bitpos:[6] ;default: 1'b0 ; */
+/*description: The raw bit for SPI slave CMD9 interrupt. 1: SPI slave mode CMD9 transmission is
+ ended. 0: Others..*/
+#define SPI_SLV_CMD9_INT_RAW    (BIT(6))
+#define SPI_SLV_CMD9_INT_RAW_M  (BIT(6))
+#define SPI_SLV_CMD9_INT_RAW_V  0x1
+#define SPI_SLV_CMD9_INT_RAW_S  6
+/* SPI_SLV_CMD8_INT_RAW : R/WTC/SS ;bitpos:[5] ;default: 1'b0 ; */
+/*description: The raw bit for SPI slave CMD8 interrupt. 1: SPI slave mode CMD8 transmission is
+ ended. 0: Others..*/
+#define SPI_SLV_CMD8_INT_RAW    (BIT(5))
+#define SPI_SLV_CMD8_INT_RAW_M  (BIT(5))
+#define SPI_SLV_CMD8_INT_RAW_V  0x1
+#define SPI_SLV_CMD8_INT_RAW_S  5
+/* SPI_SLV_CMD7_INT_RAW : R/WTC/SS ;bitpos:[4] ;default: 1'b0 ; */
+/*description: The raw bit for SPI slave CMD7 interrupt. 1: SPI slave mode CMD7 transmission is
+ ended. 0: Others..*/
+#define SPI_SLV_CMD7_INT_RAW    (BIT(4))
+#define SPI_SLV_CMD7_INT_RAW_M  (BIT(4))
+#define SPI_SLV_CMD7_INT_RAW_V  0x1
+#define SPI_SLV_CMD7_INT_RAW_S  4
+/* SPI_SLV_EN_QPI_INT_RAW : R/WTC/SS ;bitpos:[3] ;default: 1'b0 ; */
+/*description: The raw bit for SPI slave En_QPI interrupt. 1: SPI slave mode En_QPI transmissio
+n is ended. 0: Others..*/
+#define SPI_SLV_EN_QPI_INT_RAW    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_RAW_M  (BIT(3))
+#define SPI_SLV_EN_QPI_INT_RAW_V  0x1
+#define SPI_SLV_EN_QPI_INT_RAW_S  3
+/* SPI_SLV_EX_QPI_INT_RAW : R/WTC/SS ;bitpos:[2] ;default: 1'b0 ; */
+/*description: The raw bit for SPI slave Ex_QPI interrupt. 1: SPI slave mode Ex_QPI transmissio
+n is ended. 0: Others..*/
+#define SPI_SLV_EX_QPI_INT_RAW    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_RAW_M  (BIT(2))
+#define SPI_SLV_EX_QPI_INT_RAW_V  0x1
+#define SPI_SLV_EX_QPI_INT_RAW_S  2
+/* SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW : R/WTC/SS ;bitpos:[1] ;default: 1'b0 ; */
+/*description: 1: The current data rate of DMA TX is smaller than that of SPI. SPI will stop in
+ master mode and send out all 0 in slave mode.  0: Others.  .*/
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_M  (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_V  0x1
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_S  1
+/* SPI_DMA_INFIFO_FULL_ERR_INT_RAW : R/WTC/SS ;bitpos:[0] ;default: 1'b0 ; */
+/*description: 1: The current data rate of DMA Rx is smaller than that of SPI, which will lose
+the receive data.  0: Others.  .*/
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW_M  (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW_V  0x1
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW_S  0
+
+#define SPI_DMA_INT_ST_REG(i)          (REG_SPI_BASE(i) + 0x40)
+/* SPI_APP1_INT_ST : RO ;bitpos:[20] ;default: 1'b0 ; */
+/*description: The status bit for SPI_APP1_INT interrupt..*/
+#define SPI_APP1_INT_ST    (BIT(20))
+#define SPI_APP1_INT_ST_M  (BIT(20))
+#define SPI_APP1_INT_ST_V  0x1
+#define SPI_APP1_INT_ST_S  20
+/* SPI_APP2_INT_ST : RO ;bitpos:[19] ;default: 1'b0 ; */
+/*description: The status bit for SPI_APP2_INT interrupt..*/
+#define SPI_APP2_INT_ST    (BIT(19))
+#define SPI_APP2_INT_ST_M  (BIT(19))
+#define SPI_APP2_INT_ST_V  0x1
+#define SPI_APP2_INT_ST_S  19
+/* SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST : RO ;bitpos:[18] ;default: 1'b0 ; */
+/*description: The status bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt..*/
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_M  (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_V  0x1
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_S  18
+/* SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST : RO ;bitpos:[17] ;default: 1'b0 ; */
+/*description: The status bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt..*/
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_M  (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_V  0x1
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_S  17
+/* SPI_SLV_CMD_ERR_INT_ST : RO ;bitpos:[16] ;default: 1'b0 ; */
+/*description: The status bit for SPI_SLV_CMD_ERR_INT interrupt..*/
+#define SPI_SLV_CMD_ERR_INT_ST    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_ST_M  (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_ST_V  0x1
+#define SPI_SLV_CMD_ERR_INT_ST_S  16
+/* SPI_SLV_BUF_ADDR_ERR_INT_ST : RO ;bitpos:[15] ;default: 1'b0 ; */
+/*description: The status bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt..*/
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST_M  (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST_V  0x1
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST_S  15
+/* SPI_SEG_MAGIC_ERR_INT_ST : RO ;bitpos:[14] ;default: 1'b0 ; */
+/*description: The status bit for SPI_SEG_MAGIC_ERR_INT interrupt..*/
+#define SPI_SEG_MAGIC_ERR_INT_ST    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_ST_M  (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_ST_V  0x1
+#define SPI_SEG_MAGIC_ERR_INT_ST_S  14
+/* SPI_DMA_SEG_TRANS_DONE_INT_ST : RO ;bitpos:[13] ;default: 1'b0 ; */
+/*description: The status bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt..*/
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST_M  (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST_V  0x1
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST_S  13
+/* SPI_TRANS_DONE_INT_ST : RO ;bitpos:[12] ;default: 1'b0 ; */
+/*description: The status bit for SPI_TRANS_DONE_INT interrupt..*/
+#define SPI_TRANS_DONE_INT_ST    (BIT(12))
+#define SPI_TRANS_DONE_INT_ST_M  (BIT(12))
+#define SPI_TRANS_DONE_INT_ST_V  0x1
+#define SPI_TRANS_DONE_INT_ST_S  12
+/* SPI_SLV_WR_BUF_DONE_INT_ST : RO ;bitpos:[11] ;default: 1'b0 ; */
+/*description: The status bit for SPI_SLV_WR_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_WR_BUF_DONE_INT_ST    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_ST_M  (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_ST_V  0x1
+#define SPI_SLV_WR_BUF_DONE_INT_ST_S  11
+/* SPI_SLV_RD_BUF_DONE_INT_ST : RO ;bitpos:[10] ;default: 1'b0 ; */
+/*description: The status bit for SPI_SLV_RD_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_RD_BUF_DONE_INT_ST    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_ST_M  (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_ST_V  0x1
+#define SPI_SLV_RD_BUF_DONE_INT_ST_S  10
+/* SPI_SLV_WR_DMA_DONE_INT_ST : RO ;bitpos:[9] ;default: 1'b0 ; */
+/*description: The status bit for SPI_SLV_WR_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_WR_DMA_DONE_INT_ST    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_ST_M  (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_ST_V  0x1
+#define SPI_SLV_WR_DMA_DONE_INT_ST_S  9
+/* SPI_SLV_RD_DMA_DONE_INT_ST : RO ;bitpos:[8] ;default: 1'b0 ; */
+/*description: The status bit for SPI_SLV_RD_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_RD_DMA_DONE_INT_ST    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_ST_M  (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_ST_V  0x1
+#define SPI_SLV_RD_DMA_DONE_INT_ST_S  8
+/* SPI_SLV_CMDA_INT_ST : RO ;bitpos:[7] ;default: 1'b0 ; */
+/*description: The status bit for SPI slave CMDA interrupt..*/
+#define SPI_SLV_CMDA_INT_ST    (BIT(7))
+#define SPI_SLV_CMDA_INT_ST_M  (BIT(7))
+#define SPI_SLV_CMDA_INT_ST_V  0x1
+#define SPI_SLV_CMDA_INT_ST_S  7
+/* SPI_SLV_CMD9_INT_ST : RO ;bitpos:[6] ;default: 1'b0 ; */
+/*description: The status bit for SPI slave CMD9 interrupt..*/
+#define SPI_SLV_CMD9_INT_ST    (BIT(6))
+#define SPI_SLV_CMD9_INT_ST_M  (BIT(6))
+#define SPI_SLV_CMD9_INT_ST_V  0x1
+#define SPI_SLV_CMD9_INT_ST_S  6
+/* SPI_SLV_CMD8_INT_ST : RO ;bitpos:[5] ;default: 1'b0 ; */
+/*description: The status bit for SPI slave CMD8 interrupt..*/
+#define SPI_SLV_CMD8_INT_ST    (BIT(5))
+#define SPI_SLV_CMD8_INT_ST_M  (BIT(5))
+#define SPI_SLV_CMD8_INT_ST_V  0x1
+#define SPI_SLV_CMD8_INT_ST_S  5
+/* SPI_SLV_CMD7_INT_ST : RO ;bitpos:[4] ;default: 1'b0 ; */
+/*description: The status bit for SPI slave CMD7 interrupt..*/
+#define SPI_SLV_CMD7_INT_ST    (BIT(4))
+#define SPI_SLV_CMD7_INT_ST_M  (BIT(4))
+#define SPI_SLV_CMD7_INT_ST_V  0x1
+#define SPI_SLV_CMD7_INT_ST_S  4
+/* SPI_SLV_EN_QPI_INT_ST : RO ;bitpos:[3] ;default: 1'b0 ; */
+/*description: The status bit for SPI slave En_QPI interrupt..*/
+#define SPI_SLV_EN_QPI_INT_ST    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_ST_M  (BIT(3))
+#define SPI_SLV_EN_QPI_INT_ST_V  0x1
+#define SPI_SLV_EN_QPI_INT_ST_S  3
+/* SPI_SLV_EX_QPI_INT_ST : RO ;bitpos:[2] ;default: 1'b0 ; */
+/*description: The status bit for SPI slave Ex_QPI interrupt..*/
+#define SPI_SLV_EX_QPI_INT_ST    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_ST_M  (BIT(2))
+#define SPI_SLV_EX_QPI_INT_ST_V  0x1
+#define SPI_SLV_EX_QPI_INT_ST_S  2
+/* SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST : RO ;bitpos:[1] ;default: 1'b0 ; */
+/*description: The status bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt..*/
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_M  (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_V  0x1
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_S  1
+/* SPI_DMA_INFIFO_FULL_ERR_INT_ST : RO ;bitpos:[0] ;default: 1'b0 ; */
+/*description: The status bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt..*/
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST_M  (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST_V  0x1
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST_S  0
+
+#define SPI_DMA_INT_SET_REG(i)          (REG_SPI_BASE(i) + 0x44)
+/* SPI_APP1_INT_SET : WT ;bitpos:[20] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_APP1_INT interrupt..*/
+#define SPI_APP1_INT_SET    (BIT(20))
+#define SPI_APP1_INT_SET_M  (BIT(20))
+#define SPI_APP1_INT_SET_V  0x1
+#define SPI_APP1_INT_SET_S  20
+/* SPI_APP2_INT_SET : WT ;bitpos:[19] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_APP2_INT interrupt..*/
+#define SPI_APP2_INT_SET    (BIT(19))
+#define SPI_APP2_INT_SET_M  (BIT(19))
+#define SPI_APP2_INT_SET_V  0x1
+#define SPI_APP2_INT_SET_S  19
+/* SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET : WT ;bitpos:[18] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt..*/
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET_M  (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET_V  0x1
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET_S  18
+/* SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET : WT ;bitpos:[17] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt..*/
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET_M  (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET_V  0x1
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET_S  17
+/* SPI_SLV_CMD_ERR_INT_SET : WT ;bitpos:[16] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_SLV_CMD_ERR_INT interrupt..*/
+#define SPI_SLV_CMD_ERR_INT_SET    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_SET_M  (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_SET_V  0x1
+#define SPI_SLV_CMD_ERR_INT_SET_S  16
+/* SPI_SLV_BUF_ADDR_ERR_INT_SET : WT ;bitpos:[15] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt..*/
+#define SPI_SLV_BUF_ADDR_ERR_INT_SET    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_SET_M  (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_SET_V  0x1
+#define SPI_SLV_BUF_ADDR_ERR_INT_SET_S  15
+/* SPI_SEG_MAGIC_ERR_INT_SET : WT ;bitpos:[14] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_SEG_MAGIC_ERR_INT interrupt..*/
+#define SPI_SEG_MAGIC_ERR_INT_SET    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_SET_M  (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_SET_V  0x1
+#define SPI_SEG_MAGIC_ERR_INT_SET_S  14
+/* SPI_DMA_SEG_TRANS_DONE_INT_SET : WT ;bitpos:[13] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt..*/
+#define SPI_DMA_SEG_TRANS_DONE_INT_SET    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_SET_M  (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_SET_V  0x1
+#define SPI_DMA_SEG_TRANS_DONE_INT_SET_S  13
+/* SPI_TRANS_DONE_INT_SET : WT ;bitpos:[12] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_TRANS_DONE_INT interrupt..*/
+#define SPI_TRANS_DONE_INT_SET    (BIT(12))
+#define SPI_TRANS_DONE_INT_SET_M  (BIT(12))
+#define SPI_TRANS_DONE_INT_SET_V  0x1
+#define SPI_TRANS_DONE_INT_SET_S  12
+/* SPI_SLV_WR_BUF_DONE_INT_SET : WT ;bitpos:[11] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_SLV_WR_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_WR_BUF_DONE_INT_SET    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_SET_M  (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_SET_V  0x1
+#define SPI_SLV_WR_BUF_DONE_INT_SET_S  11
+/* SPI_SLV_RD_BUF_DONE_INT_SET : WT ;bitpos:[10] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_SLV_RD_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_RD_BUF_DONE_INT_SET    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_SET_M  (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_SET_V  0x1
+#define SPI_SLV_RD_BUF_DONE_INT_SET_S  10
+/* SPI_SLV_WR_DMA_DONE_INT_SET : WT ;bitpos:[9] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_SLV_WR_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_WR_DMA_DONE_INT_SET    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_SET_M  (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_SET_V  0x1
+#define SPI_SLV_WR_DMA_DONE_INT_SET_S  9
+/* SPI_SLV_RD_DMA_DONE_INT_SET : WT ;bitpos:[8] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_SLV_RD_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_RD_DMA_DONE_INT_SET    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_SET_M  (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_SET_V  0x1
+#define SPI_SLV_RD_DMA_DONE_INT_SET_S  8
+/* SPI_SLV_CMDA_INT_SET : WT ;bitpos:[7] ;default: 1'b0 ; */
+/*description: The software set bit for SPI slave CMDA interrupt..*/
+#define SPI_SLV_CMDA_INT_SET    (BIT(7))
+#define SPI_SLV_CMDA_INT_SET_M  (BIT(7))
+#define SPI_SLV_CMDA_INT_SET_V  0x1
+#define SPI_SLV_CMDA_INT_SET_S  7
+/* SPI_SLV_CMD9_INT_SET : WT ;bitpos:[6] ;default: 1'b0 ; */
+/*description: The software set bit for SPI slave CMD9 interrupt..*/
+#define SPI_SLV_CMD9_INT_SET    (BIT(6))
+#define SPI_SLV_CMD9_INT_SET_M  (BIT(6))
+#define SPI_SLV_CMD9_INT_SET_V  0x1
+#define SPI_SLV_CMD9_INT_SET_S  6
+/* SPI_SLV_CMD8_INT_SET : WT ;bitpos:[5] ;default: 1'b0 ; */
+/*description: The software set bit for SPI slave CMD8 interrupt..*/
+#define SPI_SLV_CMD8_INT_SET    (BIT(5))
+#define SPI_SLV_CMD8_INT_SET_M  (BIT(5))
+#define SPI_SLV_CMD8_INT_SET_V  0x1
+#define SPI_SLV_CMD8_INT_SET_S  5
+/* SPI_SLV_CMD7_INT_SET : WT ;bitpos:[4] ;default: 1'b0 ; */
+/*description: The software set bit for SPI slave CMD7 interrupt..*/
+#define SPI_SLV_CMD7_INT_SET    (BIT(4))
+#define SPI_SLV_CMD7_INT_SET_M  (BIT(4))
+#define SPI_SLV_CMD7_INT_SET_V  0x1
+#define SPI_SLV_CMD7_INT_SET_S  4
+/* SPI_SLV_EN_QPI_INT_SET : WT ;bitpos:[3] ;default: 1'b0 ; */
+/*description: The software set bit for SPI slave En_QPI interrupt..*/
+#define SPI_SLV_EN_QPI_INT_SET    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_SET_M  (BIT(3))
+#define SPI_SLV_EN_QPI_INT_SET_V  0x1
+#define SPI_SLV_EN_QPI_INT_SET_S  3
+/* SPI_SLV_EX_QPI_INT_SET : WT ;bitpos:[2] ;default: 1'b0 ; */
+/*description: The software set bit for SPI slave Ex_QPI interrupt..*/
+#define SPI_SLV_EX_QPI_INT_SET    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_SET_M  (BIT(2))
+#define SPI_SLV_EX_QPI_INT_SET_V  0x1
+#define SPI_SLV_EX_QPI_INT_SET_S  2
+/* SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET : WT ;bitpos:[1] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt..*/
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET_M  (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET_V  0x1
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET_S  1
+/* SPI_DMA_INFIFO_FULL_ERR_INT_SET : WT ;bitpos:[0] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt..*/
+#define SPI_DMA_INFIFO_FULL_ERR_INT_SET    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_SET_M  (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_SET_V  0x1
+#define SPI_DMA_INFIFO_FULL_ERR_INT_SET_S  0
+
+#define SPI_W0_REG(i)          (REG_SPI_BASE(i) + 0x98)
+/* SPI_BUF0 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF0    0xFFFFFFFF
+#define SPI_BUF0_M  ((SPI_BUF0_V)<<(SPI_BUF0_S))
+#define SPI_BUF0_V  0xFFFFFFFF
+#define SPI_BUF0_S  0
+
+#define SPI_W1_REG(i)          (REG_SPI_BASE(i) + 0x9C)
+/* SPI_BUF1 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF1    0xFFFFFFFF
+#define SPI_BUF1_M  ((SPI_BUF1_V)<<(SPI_BUF1_S))
+#define SPI_BUF1_V  0xFFFFFFFF
+#define SPI_BUF1_S  0
+
+#define SPI_W2_REG(i)          (REG_SPI_BASE(i) + 0xA0)
+/* SPI_BUF2 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF2    0xFFFFFFFF
+#define SPI_BUF2_M  ((SPI_BUF2_V)<<(SPI_BUF2_S))
+#define SPI_BUF2_V  0xFFFFFFFF
+#define SPI_BUF2_S  0
+
+#define SPI_W3_REG(i)          (REG_SPI_BASE(i) + 0xA4)
+/* SPI_BUF3 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF3    0xFFFFFFFF
+#define SPI_BUF3_M  ((SPI_BUF3_V)<<(SPI_BUF3_S))
+#define SPI_BUF3_V  0xFFFFFFFF
+#define SPI_BUF3_S  0
+
+#define SPI_W4_REG(i)          (REG_SPI_BASE(i) + 0xA8)
+/* SPI_BUF4 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF4    0xFFFFFFFF
+#define SPI_BUF4_M  ((SPI_BUF4_V)<<(SPI_BUF4_S))
+#define SPI_BUF4_V  0xFFFFFFFF
+#define SPI_BUF4_S  0
+
+#define SPI_W5_REG(i)          (REG_SPI_BASE(i) + 0xAC)
+/* SPI_BUF5 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF5    0xFFFFFFFF
+#define SPI_BUF5_M  ((SPI_BUF5_V)<<(SPI_BUF5_S))
+#define SPI_BUF5_V  0xFFFFFFFF
+#define SPI_BUF5_S  0
+
+#define SPI_W6_REG(i)          (REG_SPI_BASE(i) + 0xB0)
+/* SPI_BUF6 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF6    0xFFFFFFFF
+#define SPI_BUF6_M  ((SPI_BUF6_V)<<(SPI_BUF6_S))
+#define SPI_BUF6_V  0xFFFFFFFF
+#define SPI_BUF6_S  0
+
+#define SPI_W7_REG(i)          (REG_SPI_BASE(i) + 0xB4)
+/* SPI_BUF7 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF7    0xFFFFFFFF
+#define SPI_BUF7_M  ((SPI_BUF7_V)<<(SPI_BUF7_S))
+#define SPI_BUF7_V  0xFFFFFFFF
+#define SPI_BUF7_S  0
+
+#define SPI_W8_REG(i)          (REG_SPI_BASE(i) + 0xB8)
+/* SPI_BUF8 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF8    0xFFFFFFFF
+#define SPI_BUF8_M  ((SPI_BUF8_V)<<(SPI_BUF8_S))
+#define SPI_BUF8_V  0xFFFFFFFF
+#define SPI_BUF8_S  0
+
+#define SPI_W9_REG(i)          (REG_SPI_BASE(i) + 0xBC)
+/* SPI_BUF9 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF9    0xFFFFFFFF
+#define SPI_BUF9_M  ((SPI_BUF9_V)<<(SPI_BUF9_S))
+#define SPI_BUF9_V  0xFFFFFFFF
+#define SPI_BUF9_S  0
+
+#define SPI_W10_REG(i)          (REG_SPI_BASE(i) + 0xC0)
+/* SPI_BUF10 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF10    0xFFFFFFFF
+#define SPI_BUF10_M  ((SPI_BUF10_V)<<(SPI_BUF10_S))
+#define SPI_BUF10_V  0xFFFFFFFF
+#define SPI_BUF10_S  0
+
+#define SPI_W11_REG(i)          (REG_SPI_BASE(i) + 0xC4)
+/* SPI_BUF11 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF11    0xFFFFFFFF
+#define SPI_BUF11_M  ((SPI_BUF11_V)<<(SPI_BUF11_S))
+#define SPI_BUF11_V  0xFFFFFFFF
+#define SPI_BUF11_S  0
+
+#define SPI_W12_REG(i)          (REG_SPI_BASE(i) + 0xC8)
+/* SPI_BUF12 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF12    0xFFFFFFFF
+#define SPI_BUF12_M  ((SPI_BUF12_V)<<(SPI_BUF12_S))
+#define SPI_BUF12_V  0xFFFFFFFF
+#define SPI_BUF12_S  0
+
+#define SPI_W13_REG(i)          (REG_SPI_BASE(i) + 0xCC)
+/* SPI_BUF13 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF13    0xFFFFFFFF
+#define SPI_BUF13_M  ((SPI_BUF13_V)<<(SPI_BUF13_S))
+#define SPI_BUF13_V  0xFFFFFFFF
+#define SPI_BUF13_S  0
+
+#define SPI_W14_REG(i)          (REG_SPI_BASE(i) + 0xD0)
+/* SPI_BUF14 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF14    0xFFFFFFFF
+#define SPI_BUF14_M  ((SPI_BUF14_V)<<(SPI_BUF14_S))
+#define SPI_BUF14_V  0xFFFFFFFF
+#define SPI_BUF14_S  0
+
+#define SPI_W15_REG(i)          (REG_SPI_BASE(i) + 0xD4)
+/* SPI_BUF15 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF15    0xFFFFFFFF
+#define SPI_BUF15_M  ((SPI_BUF15_V)<<(SPI_BUF15_S))
+#define SPI_BUF15_V  0xFFFFFFFF
+#define SPI_BUF15_S  0
+
+#define SPI_SLAVE_REG(i)          (REG_SPI_BASE(i) + 0xE0)
+/* SPI_USR_CONF : R/W ;bitpos:[28] ;default: 1'b0 ; */
+/*description: 1: Enable the DMA CONF phase of current seg-trans operation, which means seg-tra
+ns will start. 0: This is not seg-trans mode..*/
+#define SPI_USR_CONF    (BIT(28))
+#define SPI_USR_CONF_M  (BIT(28))
+#define SPI_USR_CONF_V  0x1
+#define SPI_USR_CONF_S  28
+/* SPI_SOFT_RESET : WT ;bitpos:[27] ;default: 1'b0 ; */
+/*description: Software reset enable, reset the spi clock line cs line and data lines. Can be c
+onfigured in CONF state..*/
+#define SPI_SOFT_RESET    (BIT(27))
+#define SPI_SOFT_RESET_M  (BIT(27))
+#define SPI_SOFT_RESET_V  0x1
+#define SPI_SOFT_RESET_S  27
+/* SPI_SLAVE_MODE : R/W ;bitpos:[26] ;default: 1'b0 ; */
+/*description: Set SPI work mode. 1: slave mode 0: master mode..*/
+#define SPI_SLAVE_MODE    (BIT(26))
+#define SPI_SLAVE_MODE_M  (BIT(26))
+#define SPI_SLAVE_MODE_V  0x1
+#define SPI_SLAVE_MODE_S  26
+/* SPI_DMA_SEG_MAGIC_VALUE : R/W ;bitpos:[25:22] ;default: 4'd10 ; */
+/*description: The magic value of BM table in master DMA seg-trans..*/
+#define SPI_DMA_SEG_MAGIC_VALUE    0x0000000F
+#define SPI_DMA_SEG_MAGIC_VALUE_M  ((SPI_DMA_SEG_MAGIC_VALUE_V)<<(SPI_DMA_SEG_MAGIC_VALUE_S))
+#define SPI_DMA_SEG_MAGIC_VALUE_V  0xF
+#define SPI_DMA_SEG_MAGIC_VALUE_S  22
+/* SPI_SLV_WRBUF_BITLEN_EN : R/W ;bitpos:[11] ;default: 1'b0 ; */
+/*description: 1: SPI_SLV_DATA_BITLEN stores data bit length of master-write-to-slave data leng
+th in CPU controlled mode(Wr_BUF). 0: others.*/
+#define SPI_SLV_WRBUF_BITLEN_EN    (BIT(11))
+#define SPI_SLV_WRBUF_BITLEN_EN_M  (BIT(11))
+#define SPI_SLV_WRBUF_BITLEN_EN_V  0x1
+#define SPI_SLV_WRBUF_BITLEN_EN_S  11
+/* SPI_SLV_RDBUF_BITLEN_EN : R/W ;bitpos:[10] ;default: 1'b0 ; */
+/*description: 1: SPI_SLV_DATA_BITLEN stores data bit length of master-read-slave data length i
+n CPU controlled mode(Rd_BUF). 0: others.*/
+#define SPI_SLV_RDBUF_BITLEN_EN    (BIT(10))
+#define SPI_SLV_RDBUF_BITLEN_EN_M  (BIT(10))
+#define SPI_SLV_RDBUF_BITLEN_EN_V  0x1
+#define SPI_SLV_RDBUF_BITLEN_EN_S  10
+/* SPI_SLV_WRDMA_BITLEN_EN : R/W ;bitpos:[9] ;default: 1'b0 ; */
+/*description: 1: SPI_SLV_DATA_BITLEN stores data bit length of master-write-to-slave data leng
+th in DMA controlled mode(Wr_DMA). 0: others.*/
+#define SPI_SLV_WRDMA_BITLEN_EN    (BIT(9))
+#define SPI_SLV_WRDMA_BITLEN_EN_M  (BIT(9))
+#define SPI_SLV_WRDMA_BITLEN_EN_V  0x1
+#define SPI_SLV_WRDMA_BITLEN_EN_S  9
+/* SPI_SLV_RDDMA_BITLEN_EN : R/W ;bitpos:[8] ;default: 1'b0 ; */
+/*description: 1: SPI_SLV_DATA_BITLEN stores data bit length of master-read-slave data length i
+n DMA controlled mode(Rd_DMA). 0: others.*/
+#define SPI_SLV_RDDMA_BITLEN_EN    (BIT(8))
+#define SPI_SLV_RDDMA_BITLEN_EN_M  (BIT(8))
+#define SPI_SLV_RDDMA_BITLEN_EN_V  0x1
+#define SPI_SLV_RDDMA_BITLEN_EN_S  8
+/* SPI_RSCK_DATA_OUT : R/W ;bitpos:[3] ;default: 1'b0 ; */
+/*description: It saves half a cycle when tsck is the same as rsck. 1: output data at rsck pose
+dge   0: output data at tsck posedge .*/
+#define SPI_RSCK_DATA_OUT    (BIT(3))
+#define SPI_RSCK_DATA_OUT_M  (BIT(3))
+#define SPI_RSCK_DATA_OUT_V  0x1
+#define SPI_RSCK_DATA_OUT_S  3
+/* SPI_CLK_MODE_13 : R/W ;bitpos:[2] ;default: 1'b0 ; */
+/*description: {CPOL, CPHA},1: support spi clk mode 1 and 3, first edge output data B[0]/B[7].
+ 0: support spi clk mode 0 and 2, first edge output data B[1]/B[6]..*/
+#define SPI_CLK_MODE_13    (BIT(2))
+#define SPI_CLK_MODE_13_M  (BIT(2))
+#define SPI_CLK_MODE_13_V  0x1
+#define SPI_CLK_MODE_13_S  2
+/* SPI_CLK_MODE : R/W ;bitpos:[1:0] ;default: 2'b0 ; */
+/*description: SPI clock mode bits. 0: SPI clock is off when CS inactive 1: SPI clock is delaye
+d one cycle after CS inactive 2: SPI clock is delayed two cycles after CS inacti
+ve 3: SPI clock is always on. Can be configured in CONF state..*/
+#define SPI_CLK_MODE    0x00000003
+#define SPI_CLK_MODE_M  ((SPI_CLK_MODE_V)<<(SPI_CLK_MODE_S))
+#define SPI_CLK_MODE_V  0x3
+#define SPI_CLK_MODE_S  0
+
+#define SPI_SLAVE1_REG(i)          (REG_SPI_BASE(i) + 0xE4)
+/* SPI_SLV_LAST_ADDR : R/W/SS ;bitpos:[31:26] ;default: 6'd0 ; */
+/*description: In the slave mode it is the value of address..*/
+#define SPI_SLV_LAST_ADDR    0x0000003F
+#define SPI_SLV_LAST_ADDR_M  ((SPI_SLV_LAST_ADDR_V)<<(SPI_SLV_LAST_ADDR_S))
+#define SPI_SLV_LAST_ADDR_V  0x3F
+#define SPI_SLV_LAST_ADDR_S  26
+/* SPI_SLV_LAST_COMMAND : R/W/SS ;bitpos:[25:18] ;default: 8'b0 ; */
+/*description: In the slave mode it is the value of command..*/
+#define SPI_SLV_LAST_COMMAND    0x000000FF
+#define SPI_SLV_LAST_COMMAND_M  ((SPI_SLV_LAST_COMMAND_V)<<(SPI_SLV_LAST_COMMAND_S))
+#define SPI_SLV_LAST_COMMAND_V  0xFF
+#define SPI_SLV_LAST_COMMAND_S  18
+/* SPI_SLV_DATA_BITLEN : R/W/SS ;bitpos:[17:0] ;default: 18'd0 ; */
+/*description: The transferred data bit length in SPI slave FD and HD mode. .*/
+#define SPI_SLV_DATA_BITLEN    0x0003FFFF
+#define SPI_SLV_DATA_BITLEN_M  ((SPI_SLV_DATA_BITLEN_V)<<(SPI_SLV_DATA_BITLEN_S))
+#define SPI_SLV_DATA_BITLEN_V  0x3FFFF
+#define SPI_SLV_DATA_BITLEN_S  0
+
+#define SPI_CLK_GATE_REG(i)          (REG_SPI_BASE(i) + 0xE8)
+/* SPI_MST_CLK_SEL : R/W ;bitpos:[2] ;default: 1'b0 ; */
+/*description: This bit is used to select SPI module clock source in master mode. 1: PLL_CLK_80
+M. 0: XTAL CLK..*/
+#define SPI_MST_CLK_SEL    (BIT(2))
+#define SPI_MST_CLK_SEL_M  (BIT(2))
+#define SPI_MST_CLK_SEL_V  0x1
+#define SPI_MST_CLK_SEL_S  2
+/* SPI_MST_CLK_ACTIVE : R/W ;bitpos:[1] ;default: 1'b0 ; */
+/*description: Set this bit to power on the SPI module clock..*/
+#define SPI_MST_CLK_ACTIVE    (BIT(1))
+#define SPI_MST_CLK_ACTIVE_M  (BIT(1))
+#define SPI_MST_CLK_ACTIVE_V  0x1
+#define SPI_MST_CLK_ACTIVE_S  1
+/* SPI_CLK_EN : R/W ;bitpos:[0] ;default: 1'b0 ; */
+/*description: Set this bit to enable clk gate.*/
+#define SPI_CLK_EN    (BIT(0))
+#define SPI_CLK_EN_M  (BIT(0))
+#define SPI_CLK_EN_V  0x1
+#define SPI_CLK_EN_S  0
+
+#define SPI_DATE_REG(i)          (REG_SPI_BASE(i) + 0xF0)
+/* SPI_DATE : R/W ;bitpos:[27:0] ;default: 28'h2101190 ; */
+/*description: SPI register version..*/
+#define SPI_DATE    0x0FFFFFFF
+#define SPI_DATE_M  ((SPI_DATE_V)<<(SPI_DATE_S))
+#define SPI_DATE_V  0xFFFFFFF
+#define SPI_DATE_S  0
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/target/esp32c2/ld/esp32c2.rom.extra.ld
+++ b/src/target/esp32c2/ld/esp32c2.rom.extra.ld
@@ -1,0 +1,9 @@
+/***************************************
+ * Manually added ROM symbols for esp32c2
+ * These symbols are not in the auto-generated ROM linker scripts
+ * but are needed for ECO version handling
+ ***************************************/
+
+/* ROM version variables */
+_rom_chip_id = 0x40000010;
+_rom_eco_version = 0x40000014;

--- a/src/target/esp32c2/src/spi.c
+++ b/src/target/esp32c2/src/spi.c
@@ -1,0 +1,244 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * SPI (download boot) transport for the ESP32-C2 flasher stub.
+ *
+ * GP-SPI2 slave + GDMA (channel 0) are left configured by the ROM download
+ * boot; the driver only arms the DMA and drives the shared W0..W3 handshake
+ * registers.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <esp-stub-lib/bit_utils.h>
+#include <esp-stub-lib/err.h>
+#include <esp-stub-lib/soc_utils.h>
+
+#include <target/spi.h>
+
+#include <private/helpers.h>
+#include <private/spi_slave_protocol.h>
+
+#include <soc/spi_reg.h>
+
+#define SPI_SLV_HOST                2 /* GP-SPI2, bound to GDMA channel 0 by the ROM */
+
+#define SPI_SLV_REG_VER             SPI_W0_REG(SPI_SLV_HOST)
+#define SPI_SLV_REG_RXSTA           SPI_W1_REG(SPI_SLV_HOST)
+#define SPI_SLV_REG_TXSTA           SPI_W2_REG(SPI_SLV_HOST)
+#define SPI_SLV_REG_CMD             SPI_W3_REG(SPI_SLV_HOST)
+
+/* Host WRDMA writes to us (RX); host RDDMA reads from us (TX). */
+#define SPI_SLV_RX_DONE             SPI_SLV_WR_DMA_DONE_INT_RAW
+#define SPI_SLV_RX_DONE_CLR         SPI_SLV_WR_DMA_DONE_INT_CLR
+#define SPI_SLV_TX_DONE             SPI_SLV_RD_DMA_DONE_INT_RAW
+#define SPI_SLV_TX_DONE_CLR         SPI_SLV_RD_DMA_DONE_INT_CLR
+
+/* GDMA channel-0 registers (from soc/gdma_reg.h); only the few we drive. */
+#define GDMA_BASE                   0x6003f000U
+#define GDMA_INT_CLR_CH0_REG        (GDMA_BASE + 0x00cU)
+#define GDMA_IN_CONF0_CH0_REG       (GDMA_BASE + 0x070U)
+#define GDMA_IN_LINK_CH0_REG        (GDMA_BASE + 0x080U)
+#define GDMA_OUT_CONF0_CH0_REG      (GDMA_BASE + 0x0d0U)
+#define GDMA_OUT_LINK_CH0_REG       (GDMA_BASE + 0x0e0U)
+#define GDMA_IN_RST_CH0             (1U << 0)
+#define GDMA_OUT_RST_CH0            (1U << 0)
+#define GDMA_INLINK_ADDR_CH0        0x000FFFFFU
+#define GDMA_INLINK_START_CH0       (1U << 22)
+#define GDMA_OUTLINK_START_CH0      (1U << 21)
+#define GDMA_INFIFO_UDF_CH0_INT_CLR (1U << 10)
+
+/* DMA descriptor (ROM lldesc_spi_t layout, 3 words). */
+typedef struct lldesc_spi_s {
+    volatile uint32_t size : 12, length : 12, offset : 5, sosf : 1, eof : 1, owner : 1;
+    volatile uint8_t *buf;
+    struct lldesc_spi_s *next;
+} lldesc_spi_t;
+
+#define LLDESC_SPI_MAX_BUFFER_SIZE (4096U - 4U)
+#define LLDESC_SPI_SIZE_MASK       0xFFFU
+
+/* Chain sized to cover FRAME_BUFFER_SIZE (0x4107). */
+#define SPI_SLV_RX_DESC_COUNT      5U
+#define SPI_SLV_RX_MAX_LEN         (SPI_SLV_RX_DESC_COUNT * LLDESC_SPI_MAX_BUFFER_SIZE)
+
+static lldesc_spi_t dmadesc_tx;
+static lldesc_spi_t dmadesc_rx[SPI_SLV_RX_DESC_COUNT];
+
+extern void esp_rom_software_reset_cpu(uint32_t);
+
+static uint32_t s_seq_rx;
+static uint32_t s_seq_tx;
+static volatile bool s_rx_armed;
+
+/* Saved so tx_frame() can re-arm RX after a TX rewrites SPI_DMA_CONF. */
+static uint8_t *s_rx_buf;
+static uint32_t s_rx_len;
+
+bool stub_target_spi_is_active(void)
+{
+    if (!(READ_PERI_REG(SPI_SLAVE_REG(SPI_SLV_HOST)) & SPI_SLAVE_MODE)) {
+        return false;
+    }
+    uint32_t cmd = READ_PERI_REG(SPI_SLV_REG_CMD) & 0xFFU;
+    return (cmd == SPI_SLV_CMD_READY) || (cmd == SPI_SLV_CMD_DONE);
+}
+
+void stub_target_spi_init(void)
+{
+    /* Silence the ROM's SPI2 DMA interrupts so they can't race our polling
+     * (RAW status we poll is unaffected). */
+    WRITE_PERI_REG(SPI_DMA_INT_ENA_REG(SPI_SLV_HOST), 0);
+
+    /* ROM download boot leaves CMD = DONE; the host's stub-connect handshake
+     * busy-waits for IDLE, so this reset is required. */
+    WRITE_PERI_REG(SPI_SLV_REG_CMD, SPI_SLV_CMD_IDLE);
+
+    s_seq_rx = SPI_SLV_STATE_INIT;
+    s_seq_tx = SPI_SLV_STATE_INIT;
+    s_rx_armed = false;
+}
+
+/* Split buf into <=4092-byte descriptors and (re)start the RX inlink. */
+static void spi_slv_rxdma_arm(uint8_t *buf, uint32_t len)
+{
+    uint32_t remaining = len;
+    uint8_t *buf_pos = buf;
+    uint32_t desc_idx = 0;
+    while (remaining) {
+        uint32_t chunk = (remaining > LLDESC_SPI_MAX_BUFFER_SIZE) ? LLDESC_SPI_MAX_BUFFER_SIZE : remaining;
+        uint32_t aligned_len = (chunk + 3U) & ~3U; /* RX needs word-aligned length */
+        dmadesc_rx[desc_idx].size = aligned_len & LLDESC_SPI_SIZE_MASK;
+        dmadesc_rx[desc_idx].length = aligned_len & LLDESC_SPI_SIZE_MASK;
+        dmadesc_rx[desc_idx].buf = buf_pos;
+        dmadesc_rx[desc_idx].sosf = 0;
+        dmadesc_rx[desc_idx].owner = 1;
+        if (remaining <= chunk) {
+            dmadesc_rx[desc_idx].eof = 1;
+            dmadesc_rx[desc_idx].next = NULL;
+        } else {
+            dmadesc_rx[desc_idx].eof = 0;
+            dmadesc_rx[desc_idx].next = &dmadesc_rx[desc_idx + 1];
+        }
+        remaining -= chunk;
+        buf_pos += chunk;
+        desc_idx++;
+    }
+
+    /* gdma_ll_rxdma_reset */
+    SET_PERI_REG_MASK(GDMA_IN_CONF0_CH0_REG, GDMA_IN_RST_CH0);
+    CLEAR_PERI_REG_MASK(GDMA_IN_CONF0_CH0_REG, GDMA_IN_RST_CH0);
+    /* spi_ll_rxdma_start */
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_RX_DONE_CLR);
+    WRITE_PERI_REG(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_AFIFO_RST | SPI_BUF_AFIFO_RST | SPI_RX_AFIFO_RST);
+    SET_PERI_REG_MASK(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_RX_ENA);
+    /* gdma_ll_load_rx_link */
+    WRITE_PERI_REG(GDMA_IN_LINK_CH0_REG, (uint32_t)(uintptr_t)dmadesc_rx & GDMA_INLINK_ADDR_CH0);
+    WRITE_PERI_REG(GDMA_INT_CLR_CH0_REG, GDMA_INFIFO_UDF_CH0_INT_CLR);
+    SET_PERI_REG_MASK(GDMA_IN_LINK_CH0_REG, GDMA_INLINK_START_CH0);
+}
+
+int stub_target_spi_rearm(uint8_t *buf, size_t max_size)
+{
+    if (s_rx_armed) {
+        return STUB_LIB_OK;
+    }
+    if (buf == NULL || max_size == 0) {
+        return STUB_LIB_ERR_INVALID_ARG;
+    }
+
+    if (max_size > SPI_SLV_RX_MAX_LEN) {
+        max_size = SPI_SLV_RX_MAX_LEN;
+    }
+
+    spi_slv_rxdma_arm(buf, (uint32_t)max_size);
+    s_rx_buf = buf;
+    s_rx_len = (uint32_t)max_size;
+
+    s_seq_rx ^= SPI_SLV_STA_TOGGLE;
+    uint32_t rxsta = s_seq_rx | ((uint32_t)max_size << SPI_SLV_STA_LEN_SHIFT);
+    s_seq_rx &= ~SPI_SLV_STA_INIT;
+    WRITE_PERI_REG(SPI_SLV_REG_RXSTA, rxsta);
+
+    s_rx_armed = true;
+    return STUB_LIB_OK;
+}
+
+static void spi_slv_service_cmd(void)
+{
+    uint32_t cmd = READ_PERI_REG(SPI_SLV_REG_CMD) & 0xFFU;
+    switch (cmd) {
+    case SPI_SLV_CMD_READY:
+        WRITE_PERI_REG(SPI_SLV_REG_CMD, SPI_SLV_CMD_READY);
+        break;
+    case SPI_SLV_CMD_REBOOT:
+        esp_rom_software_reset_cpu(0);
+        break;
+    default:
+        break;
+    }
+}
+
+bool stub_target_spi_take_rx_frame(size_t *out_len)
+{
+    spi_slv_service_cmd();
+
+    if (!(READ_PERI_REG(SPI_DMA_INT_RAW_REG(SPI_SLV_HOST)) & SPI_SLV_RX_DONE)) {
+        return false;
+    }
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_RX_DONE_CLR);
+
+    if (out_len) {
+        uint32_t bitlen = READ_PERI_REG(SPI_SLAVE1_REG(SPI_SLV_HOST)) & SPI_SLV_DATA_BITLEN;
+        *out_len = bitlen / 8U;
+    }
+
+    s_rx_armed = false;
+    return true;
+}
+
+int stub_target_spi_tx_frame(const void *data, size_t len)
+{
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_TX_DONE_CLR);
+
+    dmadesc_tx.size = (uint32_t)len & LLDESC_SPI_SIZE_MASK;
+    dmadesc_tx.length = (uint32_t)len & LLDESC_SPI_SIZE_MASK;
+    dmadesc_tx.buf = (uint8_t *)data;
+    dmadesc_tx.sosf = 0;
+    dmadesc_tx.eof = 1;
+    dmadesc_tx.owner = 1;
+    dmadesc_tx.next = NULL;
+
+    /* gdma_ll_txdma_reset */
+    SET_PERI_REG_MASK(GDMA_OUT_CONF0_CH0_REG, GDMA_OUT_RST_CH0);
+    CLEAR_PERI_REG_MASK(GDMA_OUT_CONF0_CH0_REG, GDMA_OUT_RST_CH0);
+    /* gdma_ll_load_tx_link */
+    WRITE_PERI_REG(GDMA_OUT_LINK_CH0_REG, (uint32_t)(uintptr_t)&dmadesc_tx & GDMA_INLINK_ADDR_CH0);
+    SET_PERI_REG_MASK(GDMA_OUT_LINK_CH0_REG, GDMA_OUTLINK_START_CH0);
+    /* spi_ll_txdma_start */
+    WRITE_PERI_REG(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_AFIFO_RST | SPI_BUF_AFIFO_RST | SPI_RX_AFIFO_RST);
+    SET_PERI_REG_MASK(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_TX_ENA);
+
+    s_seq_tx ^= SPI_SLV_STA_TOGGLE;
+    uint32_t txsta = s_seq_tx | ((uint32_t)len << SPI_SLV_STA_LEN_SHIFT);
+    s_seq_tx &= ~SPI_SLV_STA_INIT;
+    WRITE_PERI_REG(SPI_SLV_REG_TXSTA, txsta);
+
+    /* Leave TXSTA set until the next frame; clearing it early races the host. */
+    uint64_t timeout_us = SPI_SLV_TX_TIMEOUT_US;
+    int ret = stub_target_wait_reg_bit_set(SPI_DMA_INT_RAW_REG(SPI_SLV_HOST), SPI_SLV_TX_DONE, &timeout_us);
+    if (ret != STUB_LIB_OK) {
+        return STUB_LIB_FAIL;
+    }
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_TX_DONE_CLR);
+
+    /* Enabling TX DMA rewrote SPI_DMA_CONF and disarmed RX DMA; re-arm it. */
+    if (s_rx_armed && s_rx_buf != NULL) {
+        spi_slv_rxdma_arm(s_rx_buf, s_rx_len);
+    }
+    return STUB_LIB_OK;
+}

--- a/src/target/esp32c3/CMakeLists.txt
+++ b/src/target/esp32c3/CMakeLists.txt
@@ -6,6 +6,7 @@ set(srcs
     src/uart.c
     src/usb_serial_jtag.c
     src/security.c
+    src/spi.c
 )
 
 add_library(${ESP_TARGET_LIB} STATIC ${srcs})

--- a/src/target/esp32c3/include/soc/spi_reg.h
+++ b/src/target/esp32c3/include/soc/spi_reg.h
@@ -1,0 +1,1755 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include <esp-stub-lib/bit_utils.h>
+#include <esp-stub-lib/soc_utils.h>
+#include <soc/reg_base.h>
+
+#include <soc/soc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* C3 has a single GP-SPI peripheral (SPI2); its soc.h does not define the
+ * indexed REG_SPI_BASE() helper the register macros below use, so provide it
+ * here. Only i == 2 is meaningful. */
+#ifndef REG_SPI_BASE
+#define REG_SPI_BASE(i) (DR_REG_SPI2_BASE + ((i) - 2) * 0x1000)
+#endif
+
+#define SPI_CMD_REG(i)          (REG_SPI_BASE(i) + 0x0)
+/* SPI_USR : R/W/SC ;bitpos:[24] ;default: 1'b0 ; */
+/*description: User define command enable.  An operation will be triggered when the bit is set.
+ The bit will be cleared once the operation done.1: enable 0: disable. Can not b
+e changed by CONF_buf..*/
+#define SPI_USR    (BIT(24))
+#define SPI_USR_M  (BIT(24))
+#define SPI_USR_V  0x1
+#define SPI_USR_S  24
+/* SPI_UPDATE : WT ;bitpos:[23] ;default: 1'b0 ; */
+/*description: Set this bit to synchronize SPI registers from APB clock domain into SPI module
+clock domain, which is only used in SPI master mode..*/
+#define SPI_UPDATE    (BIT(23))
+#define SPI_UPDATE_M  (BIT(23))
+#define SPI_UPDATE_V  0x1
+#define SPI_UPDATE_S  23
+/* SPI_CONF_BITLEN : R/W ;bitpos:[17:0] ;default: 18'd0 ; */
+/*description: Define the APB cycles of  SPI_CONF state. Can be configured in CONF state..*/
+#define SPI_CONF_BITLEN    0x0003FFFF
+#define SPI_CONF_BITLEN_M  ((SPI_CONF_BITLEN_V)<<(SPI_CONF_BITLEN_S))
+#define SPI_CONF_BITLEN_V  0x3FFFF
+#define SPI_CONF_BITLEN_S  0
+
+#define SPI_ADDR_REG(i)          (REG_SPI_BASE(i) + 0x4)
+/* SPI_USR_ADDR_VALUE : R/W ;bitpos:[31:0] ;default: 32'b0 ; */
+/*description: Address to slave. Can be configured in CONF state..*/
+#define SPI_USR_ADDR_VALUE    0xFFFFFFFF
+#define SPI_USR_ADDR_VALUE_M  ((SPI_USR_ADDR_VALUE_V)<<(SPI_USR_ADDR_VALUE_S))
+#define SPI_USR_ADDR_VALUE_V  0xFFFFFFFF
+#define SPI_USR_ADDR_VALUE_S  0
+
+#define SPI_CTRL_REG(i)          (REG_SPI_BASE(i) + 0x8)
+/* SPI_WR_BIT_ORDER : R/W ;bitpos:[26:25] ;default: 2'b0 ; */
+/*description: In command address write-data (MOSI) phases 1: LSB first 0: MSB first. Can be con
+figured in CONF state..*/
+#define SPI_WR_BIT_ORDER    0x00000003
+#define SPI_WR_BIT_ORDER_M  ((SPI_WR_BIT_ORDER_V)<<(SPI_WR_BIT_ORDER_S))
+#define SPI_WR_BIT_ORDER_V  0x3
+#define SPI_WR_BIT_ORDER_S  25
+/* SPI_RD_BIT_ORDER : R/W ;bitpos:[24:23] ;default: 2'b0 ; */
+/*description: In read-data (MISO) phase 1: LSB first 0: MSB first. Can be configured in CONF s
+tate..*/
+#define SPI_RD_BIT_ORDER    0x00000003
+#define SPI_RD_BIT_ORDER_M  ((SPI_RD_BIT_ORDER_V)<<(SPI_RD_BIT_ORDER_S))
+#define SPI_RD_BIT_ORDER_V  0x3
+#define SPI_RD_BIT_ORDER_S  23
+/* SPI_WP_POL : R/W ;bitpos:[21] ;default: 1'b1 ; */
+/*description: Write protect signal output when SPI is idle.  1: output high, 0: output low.  C
+an be configured in CONF state..*/
+#define SPI_WP_POL    (BIT(21))
+#define SPI_WP_POL_M  (BIT(21))
+#define SPI_WP_POL_V  0x1
+#define SPI_WP_POL_S  21
+/* SPI_HOLD_POL : R/W ;bitpos:[20] ;default: 1'b1 ; */
+/*description: SPI_HOLD output value when SPI is idle. 1: output high, 0: output low. Can be co
+nfigured in CONF state..*/
+#define SPI_HOLD_POL    (BIT(20))
+#define SPI_HOLD_POL_M  (BIT(20))
+#define SPI_HOLD_POL_V  0x1
+#define SPI_HOLD_POL_S  20
+/* SPI_D_POL : R/W ;bitpos:[19] ;default: 1'b1 ; */
+/*description: The bit is used to set MOSI line polarity, 1: high 0, low. Can be configured in
+CONF state..*/
+#define SPI_D_POL    (BIT(19))
+#define SPI_D_POL_M  (BIT(19))
+#define SPI_D_POL_V  0x1
+#define SPI_D_POL_S  19
+/* SPI_Q_POL : R/W ;bitpos:[18] ;default: 1'b1 ; */
+/*description: The bit is used to set MISO line polarity, 1: high 0, low. Can be configured in
+CONF state..*/
+#define SPI_Q_POL    (BIT(18))
+#define SPI_Q_POL_M  (BIT(18))
+#define SPI_Q_POL_V  0x1
+#define SPI_Q_POL_S  18
+/* SPI_FREAD_OCT : R/W ;bitpos:[16] ;default: 1'b0 ; */
+/*description: In the read operations read-data phase apply 8 signals. 1: enable 0: disable.  C
+an be configured in CONF state..*/
+#define SPI_FREAD_OCT    (BIT(16))
+#define SPI_FREAD_OCT_M  (BIT(16))
+#define SPI_FREAD_OCT_V  0x1
+#define SPI_FREAD_OCT_S  16
+/* SPI_FREAD_QUAD : R/W ;bitpos:[15] ;default: 1'b0 ; */
+/*description: In the read operations read-data phase apply 4 signals. 1: enable 0: disable.  C
+an be configured in CONF state..*/
+#define SPI_FREAD_QUAD    (BIT(15))
+#define SPI_FREAD_QUAD_M  (BIT(15))
+#define SPI_FREAD_QUAD_V  0x1
+#define SPI_FREAD_QUAD_S  15
+/* SPI_FREAD_DUAL : R/W ;bitpos:[14] ;default: 1'b0 ; */
+/*description: In the read operations, read-data phase apply 2 signals. 1: enable 0: disable. C
+an be configured in CONF state..*/
+#define SPI_FREAD_DUAL    (BIT(14))
+#define SPI_FREAD_DUAL_M  (BIT(14))
+#define SPI_FREAD_DUAL_V  0x1
+#define SPI_FREAD_DUAL_S  14
+/* SPI_FCMD_OCT : R/W ;bitpos:[10] ;default: 1'b0 ; */
+/*description: Apply 8 signals during command phase 1:enable 0: disable. Can be configured in C
+ONF state..*/
+#define SPI_FCMD_OCT    (BIT(10))
+#define SPI_FCMD_OCT_M  (BIT(10))
+#define SPI_FCMD_OCT_V  0x1
+#define SPI_FCMD_OCT_S  10
+/* SPI_FCMD_QUAD : R/W ;bitpos:[9] ;default: 1'b0 ; */
+/*description: Apply 4 signals during command phase 1:enable 0: disable. Can be configured in C
+ONF state..*/
+#define SPI_FCMD_QUAD    (BIT(9))
+#define SPI_FCMD_QUAD_M  (BIT(9))
+#define SPI_FCMD_QUAD_V  0x1
+#define SPI_FCMD_QUAD_S  9
+/* SPI_FCMD_DUAL : R/W ;bitpos:[8] ;default: 1'b0 ; */
+/*description: Apply 2 signals during command phase 1:enable 0: disable. Can be configured in C
+ONF state..*/
+#define SPI_FCMD_DUAL    (BIT(8))
+#define SPI_FCMD_DUAL_M  (BIT(8))
+#define SPI_FCMD_DUAL_V  0x1
+#define SPI_FCMD_DUAL_S  8
+/* SPI_FADDR_OCT : R/W ;bitpos:[7] ;default: 1'b0 ; */
+/*description: Apply 8 signals during addr phase 1:enable 0: disable. Can be configured in CONF
+ state..*/
+#define SPI_FADDR_OCT    (BIT(7))
+#define SPI_FADDR_OCT_M  (BIT(7))
+#define SPI_FADDR_OCT_V  0x1
+#define SPI_FADDR_OCT_S  7
+/* SPI_FADDR_QUAD : R/W ;bitpos:[6] ;default: 1'b0 ; */
+/*description: Apply 4 signals during addr phase 1:enable 0: disable. Can be configured in CONF
+ state..*/
+#define SPI_FADDR_QUAD    (BIT(6))
+#define SPI_FADDR_QUAD_M  (BIT(6))
+#define SPI_FADDR_QUAD_V  0x1
+#define SPI_FADDR_QUAD_S  6
+/* SPI_FADDR_DUAL : R/W ;bitpos:[5] ;default: 1'b0 ; */
+/*description: Apply 2 signals during addr phase 1:enable 0: disable. Can be configured in CONF
+ state..*/
+#define SPI_FADDR_DUAL    (BIT(5))
+#define SPI_FADDR_DUAL_M  (BIT(5))
+#define SPI_FADDR_DUAL_V  0x1
+#define SPI_FADDR_DUAL_S  5
+/* SPI_DUMMY_OUT : R/W ;bitpos:[3] ;default: 1'b0 ; */
+/*description: 0: In the dummy phase, the FSPI bus signals are not output. 1: In the dummy phas
+e, the FSPI bus signals are output. Can be configured in CONF state..*/
+#define SPI_DUMMY_OUT    (BIT(3))
+#define SPI_DUMMY_OUT_M  (BIT(3))
+#define SPI_DUMMY_OUT_V  0x1
+#define SPI_DUMMY_OUT_S  3
+
+#define SPI_CLOCK_REG(i)          (REG_SPI_BASE(i) + 0xC)
+/* SPI_CLK_EQU_SYSCLK : R/W ;bitpos:[31] ;default: 1'b1 ; */
+/*description: In the master mode 1: spi_clk is equal to system 0: spi_clk is divided from syst
+em clock. Can be configured in CONF state..*/
+#define SPI_CLK_EQU_SYSCLK    (BIT(31))
+#define SPI_CLK_EQU_SYSCLK_M  (BIT(31))
+#define SPI_CLK_EQU_SYSCLK_V  0x1
+#define SPI_CLK_EQU_SYSCLK_S  31
+/* SPI_CLKDIV_PRE : R/W ;bitpos:[21:18] ;default: 4'b0 ; */
+/*description: In the master mode it is pre-divider of spi_clk.  Can be configured in CONF stat
+e..*/
+#define SPI_CLKDIV_PRE    0x0000000F
+#define SPI_CLKDIV_PRE_M  ((SPI_CLKDIV_PRE_V)<<(SPI_CLKDIV_PRE_S))
+#define SPI_CLKDIV_PRE_V  0xF
+#define SPI_CLKDIV_PRE_S  18
+/* SPI_CLKCNT_N : R/W ;bitpos:[17:12] ;default: 6'h3 ; */
+/*description: In the master mode it is the divider of spi_clk. So spi_clk frequency is system/
+(spi_clkdiv_pre+1)/(spi_clkcnt_N+1). Can be configured in CONF state..*/
+#define SPI_CLKCNT_N    0x0000003F
+#define SPI_CLKCNT_N_M  ((SPI_CLKCNT_N_V)<<(SPI_CLKCNT_N_S))
+#define SPI_CLKCNT_N_V  0x3F
+#define SPI_CLKCNT_N_S  12
+/* SPI_CLKCNT_H : R/W ;bitpos:[11:6] ;default: 6'h1 ; */
+/*description: In the master mode it must be floor((spi_clkcnt_N+1)/2-1). In the slave mode it
+must be 0. Can be configured in CONF state..*/
+#define SPI_CLKCNT_H    0x0000003F
+#define SPI_CLKCNT_H_M  ((SPI_CLKCNT_H_V)<<(SPI_CLKCNT_H_S))
+#define SPI_CLKCNT_H_V  0x3F
+#define SPI_CLKCNT_H_S  6
+/* SPI_CLKCNT_L : R/W ;bitpos:[5:0] ;default: 6'h3 ; */
+/*description: In the master mode it must be equal to spi_clkcnt_N. In the slave mode it must b
+e 0. Can be configured in CONF state..*/
+#define SPI_CLKCNT_L    0x0000003F
+#define SPI_CLKCNT_L_M  ((SPI_CLKCNT_L_V)<<(SPI_CLKCNT_L_S))
+#define SPI_CLKCNT_L_V  0x3F
+#define SPI_CLKCNT_L_S  0
+
+#define SPI_USER_REG(i)          (REG_SPI_BASE(i) + 0x10)
+/* SPI_USR_COMMAND : R/W ;bitpos:[31] ;default: 1'b1 ; */
+/*description: This bit enable the command phase of an operation. Can be configured in CONF
+state..*/
+#define SPI_USR_COMMAND    (BIT(31))
+#define SPI_USR_COMMAND_M  (BIT(31))
+#define SPI_USR_COMMAND_V  0x1
+#define SPI_USR_COMMAND_S  31
+/* SPI_USR_ADDR : R/W ;bitpos:[30] ;default: 1'b0 ; */
+/*description: This bit enable the address phase of an operation. Can be configured in CONF
+state..*/
+#define SPI_USR_ADDR    (BIT(30))
+#define SPI_USR_ADDR_M  (BIT(30))
+#define SPI_USR_ADDR_V  0x1
+#define SPI_USR_ADDR_S  30
+/* SPI_USR_DUMMY : R/W ;bitpos:[29] ;default: 1'b0 ; */
+/*description: This bit enable the dummy phase of an operation. Can be configured in CONF state
+..*/
+#define SPI_USR_DUMMY    (BIT(29))
+#define SPI_USR_DUMMY_M  (BIT(29))
+#define SPI_USR_DUMMY_V  0x1
+#define SPI_USR_DUMMY_S  29
+/* SPI_USR_MISO : R/W ;bitpos:[28] ;default: 1'b0 ; */
+/*description: This bit enable the read-data phase of an operation. Can be configured in CONF s
+tate..*/
+#define SPI_USR_MISO    (BIT(28))
+#define SPI_USR_MISO_M  (BIT(28))
+#define SPI_USR_MISO_V  0x1
+#define SPI_USR_MISO_S  28
+/* SPI_USR_MOSI : R/W ;bitpos:[27] ;default: 1'b0 ; */
+/*description: This bit enable the write-data phase of an operation. Can be configured in CONF
+state..*/
+#define SPI_USR_MOSI    (BIT(27))
+#define SPI_USR_MOSI_M  (BIT(27))
+#define SPI_USR_MOSI_V  0x1
+#define SPI_USR_MOSI_S  27
+/* SPI_USR_DUMMY_IDLE : R/W ;bitpos:[26] ;default: 1'b0 ; */
+/*description: spi clock is disable in dummy phase when the bit is enable. Can be configured in
+ CONF state..*/
+#define SPI_USR_DUMMY_IDLE    (BIT(26))
+#define SPI_USR_DUMMY_IDLE_M  (BIT(26))
+#define SPI_USR_DUMMY_IDLE_V  0x1
+#define SPI_USR_DUMMY_IDLE_S  26
+/* SPI_USR_MOSI_HIGHPART : R/W ;bitpos:[25] ;default: 1'b0 ; */
+/*description: write-data phase only access to high-part of the buffer spi_w8~spi_w15. 1: enabl
+e 0: disable.  Can be configured in CONF state..*/
+#define SPI_USR_MOSI_HIGHPART    (BIT(25))
+#define SPI_USR_MOSI_HIGHPART_M  (BIT(25))
+#define SPI_USR_MOSI_HIGHPART_V  0x1
+#define SPI_USR_MOSI_HIGHPART_S  25
+/* SPI_USR_MISO_HIGHPART : R/W ;bitpos:[24] ;default: 1'b0 ; */
+/*description: read-data phase only access to high-part of the buffer spi_w8~spi_w15. 1: enable
+ 0: disable. Can be configured in CONF state..*/
+#define SPI_USR_MISO_HIGHPART    (BIT(24))
+#define SPI_USR_MISO_HIGHPART_M  (BIT(24))
+#define SPI_USR_MISO_HIGHPART_V  0x1
+#define SPI_USR_MISO_HIGHPART_S  24
+/* SPI_SIO : R/W ;bitpos:[17] ;default: 1'b0 ; */
+/*description: Set the bit to enable 3-line half duplex communication mosi and miso signals sha
+re the same pin. 1: enable 0: disable. Can be configured in CONF state..*/
+#define SPI_SIO    (BIT(17))
+#define SPI_SIO_M  (BIT(17))
+#define SPI_SIO_V  0x1
+#define SPI_SIO_S  17
+/* SPI_USR_CONF_NXT : R/W ;bitpos:[15] ;default: 1'b0 ; */
+/*description: 1: Enable the DMA CONF phase of next seg-trans operation, which means seg-trans
+will continue. 0: The seg-trans will end after the current SPI seg-trans or this
+ is not seg-trans mode. Can be configured in CONF state..*/
+#define SPI_USR_CONF_NXT    (BIT(15))
+#define SPI_USR_CONF_NXT_M  (BIT(15))
+#define SPI_USR_CONF_NXT_V  0x1
+#define SPI_USR_CONF_NXT_S  15
+/* SPI_FWRITE_OCT : R/W ;bitpos:[14] ;default: 1'b0 ; */
+/*description: In the write operations read-data phase apply 8 signals. Can be configured in CO
+NF state..*/
+#define SPI_FWRITE_OCT    (BIT(14))
+#define SPI_FWRITE_OCT_M  (BIT(14))
+#define SPI_FWRITE_OCT_V  0x1
+#define SPI_FWRITE_OCT_S  14
+/* SPI_FWRITE_QUAD : R/W ;bitpos:[13] ;default: 1'b0 ; */
+/*description: In the write operations read-data phase apply 4 signals. Can be configured in CO
+NF state..*/
+#define SPI_FWRITE_QUAD    (BIT(13))
+#define SPI_FWRITE_QUAD_M  (BIT(13))
+#define SPI_FWRITE_QUAD_V  0x1
+#define SPI_FWRITE_QUAD_S  13
+/* SPI_FWRITE_DUAL : R/W ;bitpos:[12] ;default: 1'b0 ; */
+/*description: In the write operations read-data phase apply 2 signals. Can be configured in CO
+NF state..*/
+#define SPI_FWRITE_DUAL    (BIT(12))
+#define SPI_FWRITE_DUAL_M  (BIT(12))
+#define SPI_FWRITE_DUAL_V  0x1
+#define SPI_FWRITE_DUAL_S  12
+/* SPI_CK_OUT_EDGE : R/W ;bitpos:[9] ;default: 1'b0 ; */
+/*description: the bit combined with spi_mosi_delay_mode bits to set mosi signal delay mode. Ca
+n be configured in CONF state..*/
+#define SPI_CK_OUT_EDGE    (BIT(9))
+#define SPI_CK_OUT_EDGE_M  (BIT(9))
+#define SPI_CK_OUT_EDGE_V  0x1
+#define SPI_CK_OUT_EDGE_S  9
+/* SPI_RSCK_I_EDGE : R/W ;bitpos:[8] ;default: 1'b0 ; */
+/*description: In the slave mode, this bit can be used to change the polarity of rsck. 0: rsck
+= !spi_ck_i. 1:rsck = spi_ck_i..*/
+#define SPI_RSCK_I_EDGE    (BIT(8))
+#define SPI_RSCK_I_EDGE_M  (BIT(8))
+#define SPI_RSCK_I_EDGE_V  0x1
+#define SPI_RSCK_I_EDGE_S  8
+/* SPI_CS_SETUP : R/W ;bitpos:[7] ;default: 1'b1 ; */
+/*description: spi cs is enable when spi is in  prepare  phase. 1: enable 0: disable. Can be co
+nfigured in CONF state..*/
+#define SPI_CS_SETUP    (BIT(7))
+#define SPI_CS_SETUP_M  (BIT(7))
+#define SPI_CS_SETUP_V  0x1
+#define SPI_CS_SETUP_S  7
+/* SPI_CS_HOLD : R/W ;bitpos:[6] ;default: 1'b1 ; */
+/*description: spi cs keep low when spi is in  done  phase. 1: enable 0: disable. Can be config
+ured in CONF state..*/
+#define SPI_CS_HOLD    (BIT(6))
+#define SPI_CS_HOLD_M  (BIT(6))
+#define SPI_CS_HOLD_V  0x1
+#define SPI_CS_HOLD_S  6
+/* SPI_TSCK_I_EDGE : R/W ;bitpos:[5] ;default: 1'b0 ; */
+/*description: In the slave mode, this bit can be used to change the polarity of tsck. 0: tsck
+= spi_ck_i. 1:tsck = !spi_ck_i..*/
+#define SPI_TSCK_I_EDGE    (BIT(5))
+#define SPI_TSCK_I_EDGE_M  (BIT(5))
+#define SPI_TSCK_I_EDGE_V  0x1
+#define SPI_TSCK_I_EDGE_S  5
+/* SPI_OPI_MODE : R/W ;bitpos:[4] ;default: 1'b0 ; */
+/*description: Just for master mode. 1: spi controller is in OPI mode (all in 8-b-m). 0: others
+. Can be configured in CONF state..*/
+#define SPI_OPI_MODE    (BIT(4))
+#define SPI_OPI_MODE_M  (BIT(4))
+#define SPI_OPI_MODE_V  0x1
+#define SPI_OPI_MODE_S  4
+/* SPI_QPI_MODE : R/W/SS/SC ;bitpos:[3] ;default: 1'b0 ; */
+/*description: Both for master mode and slave mode. 1: spi controller is in QPI mode. 0: others
+. Can be configured in CONF state..*/
+#define SPI_QPI_MODE    (BIT(3))
+#define SPI_QPI_MODE_M  (BIT(3))
+#define SPI_QPI_MODE_V  0x1
+#define SPI_QPI_MODE_S  3
+/* SPI_DOUTDIN : R/W ;bitpos:[0] ;default: 1'b0 ; */
+/*description: Set the bit to enable full duplex communication. 1: enable 0: disable. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUTDIN    (BIT(0))
+#define SPI_DOUTDIN_M  (BIT(0))
+#define SPI_DOUTDIN_V  0x1
+#define SPI_DOUTDIN_S  0
+
+#define SPI_USER1_REG(i)          (REG_SPI_BASE(i) + 0x14)
+/* SPI_USR_ADDR_BITLEN : R/W ;bitpos:[31:27] ;default: 5'd23 ; */
+/*description: The length in bits of address phase. The register value shall be (bit_num-1). Ca
+n be configured in CONF state..*/
+#define SPI_USR_ADDR_BITLEN    0x0000001F
+#define SPI_USR_ADDR_BITLEN_M  ((SPI_USR_ADDR_BITLEN_V)<<(SPI_USR_ADDR_BITLEN_S))
+#define SPI_USR_ADDR_BITLEN_V  0x1F
+#define SPI_USR_ADDR_BITLEN_S  27
+/* SPI_CS_HOLD_TIME : R/W ;bitpos:[26:22] ;default: 5'h1 ; */
+/*description: delay cycles of cs pin by spi clock this bits are combined with spi_cs_hold bit.
+ Can be configured in CONF state..*/
+#define SPI_CS_HOLD_TIME    0x0000001F
+#define SPI_CS_HOLD_TIME_M  ((SPI_CS_HOLD_TIME_V)<<(SPI_CS_HOLD_TIME_S))
+#define SPI_CS_HOLD_TIME_V  0x1F
+#define SPI_CS_HOLD_TIME_S  22
+/* SPI_CS_SETUP_TIME : R/W ;bitpos:[21:17] ;default: 5'b0 ; */
+/*description: (cycles+1) of prepare phase by spi clock this bits are combined with spi_cs_setu
+p bit. Can be configured in CONF state..*/
+#define SPI_CS_SETUP_TIME    0x0000001F
+#define SPI_CS_SETUP_TIME_M  ((SPI_CS_SETUP_TIME_V)<<(SPI_CS_SETUP_TIME_S))
+#define SPI_CS_SETUP_TIME_V  0x1F
+#define SPI_CS_SETUP_TIME_S  17
+/* SPI_MST_WFULL_ERR_END_EN : R/W ;bitpos:[16] ;default: 1'b1 ; */
+/*description: 1: SPI transfer is ended when SPI RX AFIFO wfull error is valid in GP-SPI master
+ FD/HD-mode. 0: SPI transfer is not ended when SPI RX AFIFO wfull error is valid
+ in GP-SPI master FD/HD-mode..*/
+#define SPI_MST_WFULL_ERR_END_EN    (BIT(16))
+#define SPI_MST_WFULL_ERR_END_EN_M  (BIT(16))
+#define SPI_MST_WFULL_ERR_END_EN_V  0x1
+#define SPI_MST_WFULL_ERR_END_EN_S  16
+/* SPI_USR_DUMMY_CYCLELEN : R/W ;bitpos:[7:0] ;default: 8'd7 ; */
+/*description: The length in spi_clk cycles of dummy phase. The register value shall be (cycle_
+num-1). Can be configured in CONF state..*/
+#define SPI_USR_DUMMY_CYCLELEN    0x000000FF
+#define SPI_USR_DUMMY_CYCLELEN_M  ((SPI_USR_DUMMY_CYCLELEN_V)<<(SPI_USR_DUMMY_CYCLELEN_S))
+#define SPI_USR_DUMMY_CYCLELEN_V  0xFF
+#define SPI_USR_DUMMY_CYCLELEN_S  0
+
+#define SPI_USER2_REG(i)          (REG_SPI_BASE(i) + 0x18)
+/* SPI_USR_COMMAND_BITLEN : R/W ;bitpos:[31:28] ;default: 4'd7 ; */
+/*description: The length in bits of command phase. The register value shall be (bit_num-1). Ca
+n be configured in CONF state..*/
+#define SPI_USR_COMMAND_BITLEN    0x0000000F
+#define SPI_USR_COMMAND_BITLEN_M  ((SPI_USR_COMMAND_BITLEN_V)<<(SPI_USR_COMMAND_BITLEN_S))
+#define SPI_USR_COMMAND_BITLEN_V  0xF
+#define SPI_USR_COMMAND_BITLEN_S  28
+/* SPI_MST_REMPTY_ERR_END_EN : R/W ;bitpos:[27] ;default: 1'b1 ; */
+/*description: 1: SPI transfer is ended when SPI TX AFIFO read empty error is valid in GP-SPI m
+aster FD/HD-mode. 0: SPI transfer is not ended when SPI TX AFIFO read empty error
+r is valid in GP-SPI master FD/HD-mode..*/
+#define SPI_MST_REMPTY_ERR_END_EN    (BIT(27))
+#define SPI_MST_REMPTY_ERR_END_EN_M  (BIT(27))
+#define SPI_MST_REMPTY_ERR_END_EN_V  0x1
+#define SPI_MST_REMPTY_ERR_END_EN_S  27
+/* SPI_USR_COMMAND_VALUE : R/W ;bitpos:[15:0] ;default: 16'b0 ; */
+/*description: The value of  command. Can be configured in CONF state..*/
+#define SPI_USR_COMMAND_VALUE    0x0000FFFF
+#define SPI_USR_COMMAND_VALUE_M  ((SPI_USR_COMMAND_VALUE_V)<<(SPI_USR_COMMAND_VALUE_S))
+#define SPI_USR_COMMAND_VALUE_V  0xFFFF
+#define SPI_USR_COMMAND_VALUE_S  0
+
+#define SPI_MS_DLEN_REG(i)          (REG_SPI_BASE(i) + 0x1C)
+/* SPI_MS_DATA_BITLEN : R/W ;bitpos:[17:0] ;default: 18'b0 ; */
+/*description: The value of these bits is the configured SPI transmission data bit length in ma
+ster mode DMA controlled transfer or CPU controlled transfer. The value is also
+the configured bit length in slave mode DMA RX controlled transfer. The register
+ value shall be (bit_num-1). Can be configured in CONF state..*/
+#define SPI_MS_DATA_BITLEN    0x0003FFFF
+#define SPI_MS_DATA_BITLEN_M  ((SPI_MS_DATA_BITLEN_V)<<(SPI_MS_DATA_BITLEN_S))
+#define SPI_MS_DATA_BITLEN_V  0x3FFFF
+#define SPI_MS_DATA_BITLEN_S  0
+
+#define SPI_MISC_REG(i)          (REG_SPI_BASE(i) + 0x20)
+/* SPI_QUAD_DIN_PIN_SWAP : R/W ;bitpos:[31] ;default: 1'b0 ; */
+/*description: 1: SPI quad input swap enable, swap FSPID with FSPIQ, swap FSPIWP with FSPIHD. 0
+:  spi quad input swap disable. Can be configured in CONF state..*/
+#define SPI_QUAD_DIN_PIN_SWAP    (BIT(31))
+#define SPI_QUAD_DIN_PIN_SWAP_M  (BIT(31))
+#define SPI_QUAD_DIN_PIN_SWAP_V  0x1
+#define SPI_QUAD_DIN_PIN_SWAP_S  31
+/* SPI_CS_KEEP_ACTIVE : R/W ;bitpos:[30] ;default: 1'b0 ; */
+/*description: spi cs line keep low when the bit is set. Can be configured in CONF state..*/
+#define SPI_CS_KEEP_ACTIVE    (BIT(30))
+#define SPI_CS_KEEP_ACTIVE_M  (BIT(30))
+#define SPI_CS_KEEP_ACTIVE_V  0x1
+#define SPI_CS_KEEP_ACTIVE_S  30
+/* SPI_CK_IDLE_EDGE : R/W ;bitpos:[29] ;default: 1'b0 ; */
+/*description: 1: spi clk line is high when idle     0: spi clk line is low when idle. Can be c
+onfigured in CONF state..*/
+#define SPI_CK_IDLE_EDGE    (BIT(29))
+#define SPI_CK_IDLE_EDGE_M  (BIT(29))
+#define SPI_CK_IDLE_EDGE_V  0x1
+#define SPI_CK_IDLE_EDGE_S  29
+/* SPI_DQS_IDLE_EDGE : R/W ;bitpos:[24] ;default: 1'b0 ; */
+/*description: The default value of spi_dqs. Can be configured in CONF state..*/
+#define SPI_DQS_IDLE_EDGE    (BIT(24))
+#define SPI_DQS_IDLE_EDGE_M  (BIT(24))
+#define SPI_DQS_IDLE_EDGE_V  0x1
+#define SPI_DQS_IDLE_EDGE_S  24
+/* SPI_SLAVE_CS_POL : R/W ;bitpos:[23] ;default: 1'b0 ; */
+/*description: spi slave input cs polarity select. 1: inv  0: not change. Can be configured in
+CONF state..*/
+#define SPI_SLAVE_CS_POL    (BIT(23))
+#define SPI_SLAVE_CS_POL_M  (BIT(23))
+#define SPI_SLAVE_CS_POL_V  0x1
+#define SPI_SLAVE_CS_POL_S  23
+/* SPI_CMD_DTR_EN : R/W ;bitpos:[19] ;default: 1'b0 ; */
+/*description: 1: SPI clk and data of SPI_SEND_CMD state are in DTR mode, including master 1/2/
+4/8-bm. 0:  SPI clk and data of SPI_SEND_CMD state are in STR mode. Can be confi
+gured in CONF state..*/
+#define SPI_CMD_DTR_EN    (BIT(19))
+#define SPI_CMD_DTR_EN_M  (BIT(19))
+#define SPI_CMD_DTR_EN_V  0x1
+#define SPI_CMD_DTR_EN_S  19
+/* SPI_ADDR_DTR_EN : R/W ;bitpos:[18] ;default: 1'b0 ; */
+/*description: 1: SPI clk and data of SPI_SEND_ADDR state are in DTR mode, including master 1/2
+/4/8-bm.  0:  SPI clk and data of SPI_SEND_ADDR state are in STR mode. Can be co
+nfigured in CONF state..*/
+#define SPI_ADDR_DTR_EN    (BIT(18))
+#define SPI_ADDR_DTR_EN_M  (BIT(18))
+#define SPI_ADDR_DTR_EN_V  0x1
+#define SPI_ADDR_DTR_EN_S  18
+/* SPI_DATA_DTR_EN : R/W ;bitpos:[17] ;default: 1'b0 ; */
+/*description: 1: SPI clk and data of SPI_DOUT and SPI_DIN state are in DTR mode, including mas
+ter 1/2/4/8-bm.  0:  SPI clk and data of SPI_DOUT and SPI_DIN state are in STR m
+ode. Can be configured in CONF state..*/
+#define SPI_DATA_DTR_EN    (BIT(17))
+#define SPI_DATA_DTR_EN_M  (BIT(17))
+#define SPI_DATA_DTR_EN_V  0x1
+#define SPI_DATA_DTR_EN_S  17
+/* SPI_CLK_DATA_DTR_EN : R/W ;bitpos:[16] ;default: 1'b0 ; */
+/*description: 1: SPI master DTR mode is applied to SPI clk, data and spi_dqs.  0: SPI master D
+TR mode is  only applied to spi_dqs. This bit should be used with bit 17/18/19. .*/
+#define SPI_CLK_DATA_DTR_EN    (BIT(16))
+#define SPI_CLK_DATA_DTR_EN_M  (BIT(16))
+#define SPI_CLK_DATA_DTR_EN_V  0x1
+#define SPI_CLK_DATA_DTR_EN_S  16
+/* SPI_MASTER_CS_POL : R/W ;bitpos:[12:7] ;default: 6'b0 ; */
+/*description: In the master mode the bits are the polarity of spi cs line, the value is equiva
+lent to spi_cs ^ spi_master_cs_pol. Can be configured in CONF state..*/
+#define SPI_MASTER_CS_POL    0x0000003F
+#define SPI_MASTER_CS_POL_M  ((SPI_MASTER_CS_POL_V)<<(SPI_MASTER_CS_POL_S))
+#define SPI_MASTER_CS_POL_V  0x3F
+#define SPI_MASTER_CS_POL_S  7
+/* SPI_CK_DIS : R/W ;bitpos:[6] ;default: 1'b0 ; */
+/*description: 1: spi clk out disable,  0: spi clk out enable. Can be configured in CONF state..*/
+#define SPI_CK_DIS    (BIT(6))
+#define SPI_CK_DIS_M  (BIT(6))
+#define SPI_CK_DIS_V  0x1
+#define SPI_CK_DIS_S  6
+/* SPI_CS5_DIS : R/W ;bitpos:[5] ;default: 1'b1 ; */
+/*description: SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Ca
+n be configured in CONF state..*/
+#define SPI_CS5_DIS    (BIT(5))
+#define SPI_CS5_DIS_M  (BIT(5))
+#define SPI_CS5_DIS_V  0x1
+#define SPI_CS5_DIS_S  5
+/* SPI_CS4_DIS : R/W ;bitpos:[4] ;default: 1'b1 ; */
+/*description: SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Ca
+n be configured in CONF state..*/
+#define SPI_CS4_DIS    (BIT(4))
+#define SPI_CS4_DIS_M  (BIT(4))
+#define SPI_CS4_DIS_V  0x1
+#define SPI_CS4_DIS_S  4
+/* SPI_CS3_DIS : R/W ;bitpos:[3] ;default: 1'b1 ; */
+/*description: SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Ca
+n be configured in CONF state..*/
+#define SPI_CS3_DIS    (BIT(3))
+#define SPI_CS3_DIS_M  (BIT(3))
+#define SPI_CS3_DIS_V  0x1
+#define SPI_CS3_DIS_S  3
+/* SPI_CS2_DIS : R/W ;bitpos:[2] ;default: 1'b1 ; */
+/*description: SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Ca
+n be configured in CONF state..*/
+#define SPI_CS2_DIS    (BIT(2))
+#define SPI_CS2_DIS_M  (BIT(2))
+#define SPI_CS2_DIS_V  0x1
+#define SPI_CS2_DIS_S  2
+/* SPI_CS1_DIS : R/W ;bitpos:[1] ;default: 1'b1 ; */
+/*description: SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Ca
+n be configured in CONF state..*/
+#define SPI_CS1_DIS    (BIT(1))
+#define SPI_CS1_DIS_M  (BIT(1))
+#define SPI_CS1_DIS_V  0x1
+#define SPI_CS1_DIS_S  1
+/* SPI_CS0_DIS : R/W ;bitpos:[0] ;default: 1'b0 ; */
+/*description: SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Ca
+n be configured in CONF state..*/
+#define SPI_CS0_DIS    (BIT(0))
+#define SPI_CS0_DIS_M  (BIT(0))
+#define SPI_CS0_DIS_V  0x1
+#define SPI_CS0_DIS_S  0
+
+#define SPI_DIN_MODE_REG(i)          (REG_SPI_BASE(i) + 0x24)
+/* SPI_TIMING_HCLK_ACTIVE : R/W ;bitpos:[16] ;default: 1'b0 ; */
+/*description: 1:enable hclk in SPI input timing module.  0: disable it. Can be configured in C
+ONF state..*/
+#define SPI_TIMING_HCLK_ACTIVE    (BIT(16))
+#define SPI_TIMING_HCLK_ACTIVE_M  (BIT(16))
+#define SPI_TIMING_HCLK_ACTIVE_V  0x1
+#define SPI_TIMING_HCLK_ACTIVE_S  16
+/* SPI_DIN7_MODE : R/W ;bitpos:[15:14] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN7_MODE    0x00000003
+#define SPI_DIN7_MODE_M  ((SPI_DIN7_MODE_V)<<(SPI_DIN7_MODE_S))
+#define SPI_DIN7_MODE_V  0x3
+#define SPI_DIN7_MODE_S  14
+/* SPI_DIN6_MODE : R/W ;bitpos:[13:12] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN6_MODE    0x00000003
+#define SPI_DIN6_MODE_M  ((SPI_DIN6_MODE_V)<<(SPI_DIN6_MODE_S))
+#define SPI_DIN6_MODE_V  0x3
+#define SPI_DIN6_MODE_S  12
+/* SPI_DIN5_MODE : R/W ;bitpos:[11:10] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN5_MODE    0x00000003
+#define SPI_DIN5_MODE_M  ((SPI_DIN5_MODE_V)<<(SPI_DIN5_MODE_S))
+#define SPI_DIN5_MODE_V  0x3
+#define SPI_DIN5_MODE_S  10
+/* SPI_DIN4_MODE : R/W ;bitpos:[9:8] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN4_MODE    0x00000003
+#define SPI_DIN4_MODE_M  ((SPI_DIN4_MODE_V)<<(SPI_DIN4_MODE_S))
+#define SPI_DIN4_MODE_V  0x3
+#define SPI_DIN4_MODE_S  8
+/* SPI_DIN3_MODE : R/W ;bitpos:[7:6] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN3_MODE    0x00000003
+#define SPI_DIN3_MODE_M  ((SPI_DIN3_MODE_V)<<(SPI_DIN3_MODE_S))
+#define SPI_DIN3_MODE_V  0x3
+#define SPI_DIN3_MODE_S  6
+/* SPI_DIN2_MODE : R/W ;bitpos:[5:4] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN2_MODE    0x00000003
+#define SPI_DIN2_MODE_M  ((SPI_DIN2_MODE_V)<<(SPI_DIN2_MODE_S))
+#define SPI_DIN2_MODE_V  0x3
+#define SPI_DIN2_MODE_S  4
+/* SPI_DIN1_MODE : R/W ;bitpos:[3:2] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN1_MODE    0x00000003
+#define SPI_DIN1_MODE_M  ((SPI_DIN1_MODE_V)<<(SPI_DIN1_MODE_S))
+#define SPI_DIN1_MODE_V  0x3
+#define SPI_DIN1_MODE_S  2
+/* SPI_DIN0_MODE : R/W ;bitpos:[1:0] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: input without delay
+ed, 1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3:
+ input with the spi_clk. Can be configured in CONF state..*/
+#define SPI_DIN0_MODE    0x00000003
+#define SPI_DIN0_MODE_M  ((SPI_DIN0_MODE_V)<<(SPI_DIN0_MODE_S))
+#define SPI_DIN0_MODE_V  0x3
+#define SPI_DIN0_MODE_S  0
+
+#define SPI_DIN_NUM_REG(i)          (REG_SPI_BASE(i) + 0x28)
+/* SPI_DIN7_NUM : R/W ;bitpos:[15:14] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN7_NUM    0x00000003
+#define SPI_DIN7_NUM_M  ((SPI_DIN7_NUM_V)<<(SPI_DIN7_NUM_S))
+#define SPI_DIN7_NUM_V  0x3
+#define SPI_DIN7_NUM_S  14
+/* SPI_DIN6_NUM : R/W ;bitpos:[13:12] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN6_NUM    0x00000003
+#define SPI_DIN6_NUM_M  ((SPI_DIN6_NUM_V)<<(SPI_DIN6_NUM_S))
+#define SPI_DIN6_NUM_V  0x3
+#define SPI_DIN6_NUM_S  12
+/* SPI_DIN5_NUM : R/W ;bitpos:[11:10] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN5_NUM    0x00000003
+#define SPI_DIN5_NUM_M  ((SPI_DIN5_NUM_V)<<(SPI_DIN5_NUM_S))
+#define SPI_DIN5_NUM_V  0x3
+#define SPI_DIN5_NUM_S  10
+/* SPI_DIN4_NUM : R/W ;bitpos:[9:8] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN4_NUM    0x00000003
+#define SPI_DIN4_NUM_M  ((SPI_DIN4_NUM_V)<<(SPI_DIN4_NUM_S))
+#define SPI_DIN4_NUM_V  0x3
+#define SPI_DIN4_NUM_S  8
+/* SPI_DIN3_NUM : R/W ;bitpos:[7:6] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN3_NUM    0x00000003
+#define SPI_DIN3_NUM_M  ((SPI_DIN3_NUM_V)<<(SPI_DIN3_NUM_S))
+#define SPI_DIN3_NUM_V  0x3
+#define SPI_DIN3_NUM_S  6
+/* SPI_DIN2_NUM : R/W ;bitpos:[5:4] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN2_NUM    0x00000003
+#define SPI_DIN2_NUM_M  ((SPI_DIN2_NUM_V)<<(SPI_DIN2_NUM_S))
+#define SPI_DIN2_NUM_V  0x3
+#define SPI_DIN2_NUM_S  4
+/* SPI_DIN1_NUM : R/W ;bitpos:[3:2] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN1_NUM    0x00000003
+#define SPI_DIN1_NUM_M  ((SPI_DIN1_NUM_V)<<(SPI_DIN1_NUM_S))
+#define SPI_DIN1_NUM_V  0x3
+#define SPI_DIN1_NUM_S  2
+/* SPI_DIN0_NUM : R/W ;bitpos:[1:0] ;default: 2'b0 ; */
+/*description: the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle,
+ 1: delayed by 2 cycles,...  Can be configured in CONF state..*/
+#define SPI_DIN0_NUM    0x00000003
+#define SPI_DIN0_NUM_M  ((SPI_DIN0_NUM_V)<<(SPI_DIN0_NUM_S))
+#define SPI_DIN0_NUM_V  0x3
+#define SPI_DIN0_NUM_S  0
+
+#define SPI_DOUT_MODE_REG(i)          (REG_SPI_BASE(i) + 0x2C)
+/* SPI_D_DQS_MODE : R/W ;bitpos:[8] ;default: 1'b0 ; */
+/*description: The output signal SPI_DQS is delayed by the SPI module clock, 0: output without
+delayed, 1: output delay for a SPI module clock cycle at its negative edge. Can
+be configured in CONF state..*/
+#define SPI_D_DQS_MODE    (BIT(8))
+#define SPI_D_DQS_MODE_M  (BIT(8))
+#define SPI_D_DQS_MODE_V  0x1
+#define SPI_D_DQS_MODE_S  8
+/* SPI_DOUT7_MODE : R/W ;bitpos:[7] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT7_MODE    (BIT(7))
+#define SPI_DOUT7_MODE_M  (BIT(7))
+#define SPI_DOUT7_MODE_V  0x1
+#define SPI_DOUT7_MODE_S  7
+/* SPI_DOUT6_MODE : R/W ;bitpos:[6] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT6_MODE    (BIT(6))
+#define SPI_DOUT6_MODE_M  (BIT(6))
+#define SPI_DOUT6_MODE_V  0x1
+#define SPI_DOUT6_MODE_S  6
+/* SPI_DOUT5_MODE : R/W ;bitpos:[5] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT5_MODE    (BIT(5))
+#define SPI_DOUT5_MODE_M  (BIT(5))
+#define SPI_DOUT5_MODE_V  0x1
+#define SPI_DOUT5_MODE_S  5
+/* SPI_DOUT4_MODE : R/W ;bitpos:[4] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT4_MODE    (BIT(4))
+#define SPI_DOUT4_MODE_M  (BIT(4))
+#define SPI_DOUT4_MODE_V  0x1
+#define SPI_DOUT4_MODE_S  4
+/* SPI_DOUT3_MODE : R/W ;bitpos:[3] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT3_MODE    (BIT(3))
+#define SPI_DOUT3_MODE_M  (BIT(3))
+#define SPI_DOUT3_MODE_V  0x1
+#define SPI_DOUT3_MODE_S  3
+/* SPI_DOUT2_MODE : R/W ;bitpos:[2] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT2_MODE    (BIT(2))
+#define SPI_DOUT2_MODE_M  (BIT(2))
+#define SPI_DOUT2_MODE_V  0x1
+#define SPI_DOUT2_MODE_S  2
+/* SPI_DOUT1_MODE : R/W ;bitpos:[1] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT1_MODE    (BIT(1))
+#define SPI_DOUT1_MODE_M  (BIT(1))
+#define SPI_DOUT1_MODE_V  0x1
+#define SPI_DOUT1_MODE_S  1
+/* SPI_DOUT0_MODE : R/W ;bitpos:[0] ;default: 1'b0 ; */
+/*description: The output signal $n is delayed by the SPI module clock, 0: output without delay
+ed, 1: output delay for a SPI module clock cycle at its negative edge. Can be co
+nfigured in CONF state..*/
+#define SPI_DOUT0_MODE    (BIT(0))
+#define SPI_DOUT0_MODE_M  (BIT(0))
+#define SPI_DOUT0_MODE_V  0x1
+#define SPI_DOUT0_MODE_S  0
+
+#define SPI_DMA_CONF_REG(i)          (REG_SPI_BASE(i) + 0x30)
+/* SPI_DMA_AFIFO_RST : WT ;bitpos:[31] ;default: 1'b0 ; */
+/*description: Set this bit to reset DMA TX AFIFO, which is used to send data out in SPI slave
+DMA controlled mode transfer..*/
+#define SPI_DMA_AFIFO_RST    (BIT(31))
+#define SPI_DMA_AFIFO_RST_M  (BIT(31))
+#define SPI_DMA_AFIFO_RST_V  0x1
+#define SPI_DMA_AFIFO_RST_S  31
+/* SPI_BUF_AFIFO_RST : WT ;bitpos:[30] ;default: 1'b0 ; */
+/*description: Set this bit to reset BUF TX AFIFO, which is used send data out in SPI slave CPU
+ controlled mode transfer and master mode transfer..*/
+#define SPI_BUF_AFIFO_RST    (BIT(30))
+#define SPI_BUF_AFIFO_RST_M  (BIT(30))
+#define SPI_BUF_AFIFO_RST_V  0x1
+#define SPI_BUF_AFIFO_RST_S  30
+/* SPI_RX_AFIFO_RST : WT ;bitpos:[29] ;default: 1'b0 ; */
+/*description: Set this bit to reset RX AFIFO, which is used to receive data in SPI master and
+slave mode transfer..*/
+#define SPI_RX_AFIFO_RST    (BIT(29))
+#define SPI_RX_AFIFO_RST_M  (BIT(29))
+#define SPI_RX_AFIFO_RST_V  0x1
+#define SPI_RX_AFIFO_RST_S  29
+/* SPI_DMA_TX_ENA : R/W ;bitpos:[28] ;default: 1'b0 ; */
+/*description: Set this bit to enable SPI DMA controlled send data mode..*/
+#define SPI_DMA_TX_ENA    (BIT(28))
+#define SPI_DMA_TX_ENA_M  (BIT(28))
+#define SPI_DMA_TX_ENA_V  0x1
+#define SPI_DMA_TX_ENA_S  28
+/* SPI_DMA_RX_ENA : R/W ;bitpos:[27] ;default: 1'd0 ; */
+/*description: Set this bit to enable SPI DMA controlled receive data mode..*/
+#define SPI_DMA_RX_ENA    (BIT(27))
+#define SPI_DMA_RX_ENA_M  (BIT(27))
+#define SPI_DMA_RX_ENA_V  0x1
+#define SPI_DMA_RX_ENA_S  27
+/* SPI_RX_EOF_EN : R/W ;bitpos:[21] ;default: 1'b0 ; */
+/*description: 1: spi_dma_inlink_eof is set when the number of dma pushed data bytes is equal t
+o the value of spi_slv/mst_dma_rd_bytelen[19:0] in spi dma transition.  0: spi_d
+ma_inlink_eof is set by spi_trans_done in non-seg-trans or spi_dma_seg_trans_don
+e in seg-trans..*/
+#define SPI_RX_EOF_EN    (BIT(21))
+#define SPI_RX_EOF_EN_M  (BIT(21))
+#define SPI_RX_EOF_EN_V  0x1
+#define SPI_RX_EOF_EN_S  21
+/* SPI_SLV_TX_SEG_TRANS_CLR_EN : R/W ;bitpos:[20] ;default: 1'b0 ; */
+/*description: 1: spi_dma_outfifo_empty_vld is cleared by spi slave cmd 6. 0: spi_dma_outfifo_e
+mpty_vld is cleared by spi_trans_done..*/
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN    (BIT(20))
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN_M  (BIT(20))
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN_V  0x1
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN_S  20
+/* SPI_SLV_RX_SEG_TRANS_CLR_EN : R/W ;bitpos:[19] ;default: 1'b0 ; */
+/*description: 1: spi_dma_infifo_full_vld is cleared by spi slave cmd 5. 0: spi_dma_infifo_full
+_vld is cleared by spi_trans_done..*/
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN    (BIT(19))
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN_M  (BIT(19))
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN_V  0x1
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN_S  19
+/* SPI_DMA_SLV_SEG_TRANS_EN : R/W ;bitpos:[18] ;default: 1'b0 ; */
+/*description: Enable dma segment transfer in spi dma half slave mode. 1: enable. 0: disable..*/
+#define SPI_DMA_SLV_SEG_TRANS_EN    (BIT(18))
+#define SPI_DMA_SLV_SEG_TRANS_EN_M  (BIT(18))
+#define SPI_DMA_SLV_SEG_TRANS_EN_V  0x1
+#define SPI_DMA_SLV_SEG_TRANS_EN_S  18
+/* SPI_DMA_INFIFO_FULL : RO ;bitpos:[1] ;default: 1'b1 ; */
+/*description: Records the status of DMA RX FIFO. 1: DMA RX FIFO is not ready for receiving dat
+a. 0: DMA RX FIFO is ready for receiving data..*/
+#define SPI_DMA_INFIFO_FULL    (BIT(1))
+#define SPI_DMA_INFIFO_FULL_M  (BIT(1))
+#define SPI_DMA_INFIFO_FULL_V  0x1
+#define SPI_DMA_INFIFO_FULL_S  1
+/* SPI_DMA_OUTFIFO_EMPTY : RO ;bitpos:[0] ;default: 1'b1 ; */
+/*description: Records the status of DMA TX FIFO. 1: DMA TX FIFO is not ready for sending data.
+ 0: DMA TX FIFO is ready for sending data..*/
+#define SPI_DMA_OUTFIFO_EMPTY    (BIT(0))
+#define SPI_DMA_OUTFIFO_EMPTY_M  (BIT(0))
+#define SPI_DMA_OUTFIFO_EMPTY_V  0x1
+#define SPI_DMA_OUTFIFO_EMPTY_S  0
+
+#define SPI_DMA_INT_ENA_REG(i)          (REG_SPI_BASE(i) + 0x34)
+/* SPI_APP1_INT_ENA : R/W ;bitpos:[20] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_APP1_INT interrupt..*/
+#define SPI_APP1_INT_ENA    (BIT(20))
+#define SPI_APP1_INT_ENA_M  (BIT(20))
+#define SPI_APP1_INT_ENA_V  0x1
+#define SPI_APP1_INT_ENA_S  20
+/* SPI_APP2_INT_ENA : R/W ;bitpos:[19] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_APP2_INT interrupt..*/
+#define SPI_APP2_INT_ENA    (BIT(19))
+#define SPI_APP2_INT_ENA_M  (BIT(19))
+#define SPI_APP2_INT_ENA_V  0x1
+#define SPI_APP2_INT_ENA_S  19
+/* SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA : R/W ;bitpos:[18] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt..*/
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_M  (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_V  0x1
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_S  18
+/* SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA : R/W ;bitpos:[17] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt..*/
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_M  (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_V  0x1
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_S  17
+/* SPI_SLV_CMD_ERR_INT_ENA : R/W ;bitpos:[16] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_SLV_CMD_ERR_INT interrupt..*/
+#define SPI_SLV_CMD_ERR_INT_ENA    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_ENA_M  (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_ENA_V  0x1
+#define SPI_SLV_CMD_ERR_INT_ENA_S  16
+/* SPI_SLV_BUF_ADDR_ERR_INT_ENA : R/W ;bitpos:[15] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt..*/
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA_M  (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA_V  0x1
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA_S  15
+/* SPI_SEG_MAGIC_ERR_INT_ENA : R/W ;bitpos:[14] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_SEG_MAGIC_ERR_INT interrupt..*/
+#define SPI_SEG_MAGIC_ERR_INT_ENA    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_ENA_M  (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_ENA_V  0x1
+#define SPI_SEG_MAGIC_ERR_INT_ENA_S  14
+/* SPI_DMA_SEG_TRANS_DONE_INT_ENA : R/W ;bitpos:[13] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt..*/
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA_M  (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA_V  0x1
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA_S  13
+/* SPI_TRANS_DONE_INT_ENA : R/W ;bitpos:[12] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_TRANS_DONE_INT interrupt..*/
+#define SPI_TRANS_DONE_INT_ENA    (BIT(12))
+#define SPI_TRANS_DONE_INT_ENA_M  (BIT(12))
+#define SPI_TRANS_DONE_INT_ENA_V  0x1
+#define SPI_TRANS_DONE_INT_ENA_S  12
+/* SPI_SLV_WR_BUF_DONE_INT_ENA : R/W ;bitpos:[11] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_SLV_WR_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_WR_BUF_DONE_INT_ENA    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_ENA_M  (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_ENA_V  0x1
+#define SPI_SLV_WR_BUF_DONE_INT_ENA_S  11
+/* SPI_SLV_RD_BUF_DONE_INT_ENA : R/W ;bitpos:[10] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_SLV_RD_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_RD_BUF_DONE_INT_ENA    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_ENA_M  (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_ENA_V  0x1
+#define SPI_SLV_RD_BUF_DONE_INT_ENA_S  10
+/* SPI_SLV_WR_DMA_DONE_INT_ENA : R/W ;bitpos:[9] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_SLV_WR_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_WR_DMA_DONE_INT_ENA    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_ENA_M  (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_ENA_V  0x1
+#define SPI_SLV_WR_DMA_DONE_INT_ENA_S  9
+/* SPI_SLV_RD_DMA_DONE_INT_ENA : R/W ;bitpos:[8] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_SLV_RD_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_RD_DMA_DONE_INT_ENA    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_ENA_M  (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_ENA_V  0x1
+#define SPI_SLV_RD_DMA_DONE_INT_ENA_S  8
+/* SPI_SLV_CMDA_INT_ENA : R/W ;bitpos:[7] ;default: 1'b0 ; */
+/*description: The enable bit for SPI slave CMDA interrupt..*/
+#define SPI_SLV_CMDA_INT_ENA    (BIT(7))
+#define SPI_SLV_CMDA_INT_ENA_M  (BIT(7))
+#define SPI_SLV_CMDA_INT_ENA_V  0x1
+#define SPI_SLV_CMDA_INT_ENA_S  7
+/* SPI_SLV_CMD9_INT_ENA : R/W ;bitpos:[6] ;default: 1'b0 ; */
+/*description: The enable bit for SPI slave CMD9 interrupt..*/
+#define SPI_SLV_CMD9_INT_ENA    (BIT(6))
+#define SPI_SLV_CMD9_INT_ENA_M  (BIT(6))
+#define SPI_SLV_CMD9_INT_ENA_V  0x1
+#define SPI_SLV_CMD9_INT_ENA_S  6
+/* SPI_SLV_CMD8_INT_ENA : R/W ;bitpos:[5] ;default: 1'b0 ; */
+/*description: The enable bit for SPI slave CMD8 interrupt..*/
+#define SPI_SLV_CMD8_INT_ENA    (BIT(5))
+#define SPI_SLV_CMD8_INT_ENA_M  (BIT(5))
+#define SPI_SLV_CMD8_INT_ENA_V  0x1
+#define SPI_SLV_CMD8_INT_ENA_S  5
+/* SPI_SLV_CMD7_INT_ENA : R/W ;bitpos:[4] ;default: 1'b0 ; */
+/*description: The enable bit for SPI slave CMD7 interrupt..*/
+#define SPI_SLV_CMD7_INT_ENA    (BIT(4))
+#define SPI_SLV_CMD7_INT_ENA_M  (BIT(4))
+#define SPI_SLV_CMD7_INT_ENA_V  0x1
+#define SPI_SLV_CMD7_INT_ENA_S  4
+/* SPI_SLV_EN_QPI_INT_ENA : R/W ;bitpos:[3] ;default: 1'b0 ; */
+/*description: The enable bit for SPI slave En_QPI interrupt..*/
+#define SPI_SLV_EN_QPI_INT_ENA    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_ENA_M  (BIT(3))
+#define SPI_SLV_EN_QPI_INT_ENA_V  0x1
+#define SPI_SLV_EN_QPI_INT_ENA_S  3
+/* SPI_SLV_EX_QPI_INT_ENA : R/W ;bitpos:[2] ;default: 1'b0 ; */
+/*description: The enable bit for SPI slave Ex_QPI interrupt..*/
+#define SPI_SLV_EX_QPI_INT_ENA    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_ENA_M  (BIT(2))
+#define SPI_SLV_EX_QPI_INT_ENA_V  0x1
+#define SPI_SLV_EX_QPI_INT_ENA_S  2
+/* SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA : R/W ;bitpos:[1] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt..*/
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_M  (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_V  0x1
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_S  1
+/* SPI_DMA_INFIFO_FULL_ERR_INT_ENA : R/W ;bitpos:[0] ;default: 1'b0 ; */
+/*description: The enable bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt..*/
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA_M  (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA_V  0x1
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA_S  0
+
+#define SPI_DMA_INT_CLR_REG(i)          (REG_SPI_BASE(i) + 0x38)
+/* SPI_APP1_INT_CLR : WT ;bitpos:[20] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_APP1_INT interrupt..*/
+#define SPI_APP1_INT_CLR    (BIT(20))
+#define SPI_APP1_INT_CLR_M  (BIT(20))
+#define SPI_APP1_INT_CLR_V  0x1
+#define SPI_APP1_INT_CLR_S  20
+/* SPI_APP2_INT_CLR : WT ;bitpos:[19] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_APP2_INT interrupt..*/
+#define SPI_APP2_INT_CLR    (BIT(19))
+#define SPI_APP2_INT_CLR_M  (BIT(19))
+#define SPI_APP2_INT_CLR_V  0x1
+#define SPI_APP2_INT_CLR_S  19
+/* SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR : WT ;bitpos:[18] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt..*/
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_M  (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_V  0x1
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_S  18
+/* SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR : WT ;bitpos:[17] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt..*/
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_M  (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_V  0x1
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_S  17
+/* SPI_SLV_CMD_ERR_INT_CLR : WT ;bitpos:[16] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_SLV_CMD_ERR_INT interrupt..*/
+#define SPI_SLV_CMD_ERR_INT_CLR    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_CLR_M  (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_CLR_V  0x1
+#define SPI_SLV_CMD_ERR_INT_CLR_S  16
+/* SPI_SLV_BUF_ADDR_ERR_INT_CLR : WT ;bitpos:[15] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt..*/
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR_M  (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR_V  0x1
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR_S  15
+/* SPI_SEG_MAGIC_ERR_INT_CLR : WT ;bitpos:[14] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_SEG_MAGIC_ERR_INT interrupt..*/
+#define SPI_SEG_MAGIC_ERR_INT_CLR    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_CLR_M  (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_CLR_V  0x1
+#define SPI_SEG_MAGIC_ERR_INT_CLR_S  14
+/* SPI_DMA_SEG_TRANS_DONE_INT_CLR : WT ;bitpos:[13] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt..*/
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR_M  (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR_V  0x1
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR_S  13
+/* SPI_TRANS_DONE_INT_CLR : WT ;bitpos:[12] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_TRANS_DONE_INT interrupt..*/
+#define SPI_TRANS_DONE_INT_CLR    (BIT(12))
+#define SPI_TRANS_DONE_INT_CLR_M  (BIT(12))
+#define SPI_TRANS_DONE_INT_CLR_V  0x1
+#define SPI_TRANS_DONE_INT_CLR_S  12
+/* SPI_SLV_WR_BUF_DONE_INT_CLR : WT ;bitpos:[11] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_SLV_WR_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_WR_BUF_DONE_INT_CLR    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_CLR_M  (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_CLR_V  0x1
+#define SPI_SLV_WR_BUF_DONE_INT_CLR_S  11
+/* SPI_SLV_RD_BUF_DONE_INT_CLR : WT ;bitpos:[10] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_SLV_RD_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_RD_BUF_DONE_INT_CLR    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_CLR_M  (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_CLR_V  0x1
+#define SPI_SLV_RD_BUF_DONE_INT_CLR_S  10
+/* SPI_SLV_WR_DMA_DONE_INT_CLR : WT ;bitpos:[9] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_SLV_WR_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_WR_DMA_DONE_INT_CLR    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_CLR_M  (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_CLR_V  0x1
+#define SPI_SLV_WR_DMA_DONE_INT_CLR_S  9
+/* SPI_SLV_RD_DMA_DONE_INT_CLR : WT ;bitpos:[8] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_SLV_RD_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_RD_DMA_DONE_INT_CLR    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_CLR_M  (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_CLR_V  0x1
+#define SPI_SLV_RD_DMA_DONE_INT_CLR_S  8
+/* SPI_SLV_CMDA_INT_CLR : WT ;bitpos:[7] ;default: 1'b0 ; */
+/*description: The clear bit for SPI slave CMDA interrupt..*/
+#define SPI_SLV_CMDA_INT_CLR    (BIT(7))
+#define SPI_SLV_CMDA_INT_CLR_M  (BIT(7))
+#define SPI_SLV_CMDA_INT_CLR_V  0x1
+#define SPI_SLV_CMDA_INT_CLR_S  7
+/* SPI_SLV_CMD9_INT_CLR : WT ;bitpos:[6] ;default: 1'b0 ; */
+/*description: The clear bit for SPI slave CMD9 interrupt..*/
+#define SPI_SLV_CMD9_INT_CLR    (BIT(6))
+#define SPI_SLV_CMD9_INT_CLR_M  (BIT(6))
+#define SPI_SLV_CMD9_INT_CLR_V  0x1
+#define SPI_SLV_CMD9_INT_CLR_S  6
+/* SPI_SLV_CMD8_INT_CLR : WT ;bitpos:[5] ;default: 1'b0 ; */
+/*description: The clear bit for SPI slave CMD8 interrupt..*/
+#define SPI_SLV_CMD8_INT_CLR    (BIT(5))
+#define SPI_SLV_CMD8_INT_CLR_M  (BIT(5))
+#define SPI_SLV_CMD8_INT_CLR_V  0x1
+#define SPI_SLV_CMD8_INT_CLR_S  5
+/* SPI_SLV_CMD7_INT_CLR : WT ;bitpos:[4] ;default: 1'b0 ; */
+/*description: The clear bit for SPI slave CMD7 interrupt..*/
+#define SPI_SLV_CMD7_INT_CLR    (BIT(4))
+#define SPI_SLV_CMD7_INT_CLR_M  (BIT(4))
+#define SPI_SLV_CMD7_INT_CLR_V  0x1
+#define SPI_SLV_CMD7_INT_CLR_S  4
+/* SPI_SLV_EN_QPI_INT_CLR : WT ;bitpos:[3] ;default: 1'b0 ; */
+/*description: The clear bit for SPI slave En_QPI interrupt..*/
+#define SPI_SLV_EN_QPI_INT_CLR    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_CLR_M  (BIT(3))
+#define SPI_SLV_EN_QPI_INT_CLR_V  0x1
+#define SPI_SLV_EN_QPI_INT_CLR_S  3
+/* SPI_SLV_EX_QPI_INT_CLR : WT ;bitpos:[2] ;default: 1'b0 ; */
+/*description: The clear bit for SPI slave Ex_QPI interrupt..*/
+#define SPI_SLV_EX_QPI_INT_CLR    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_CLR_M  (BIT(2))
+#define SPI_SLV_EX_QPI_INT_CLR_V  0x1
+#define SPI_SLV_EX_QPI_INT_CLR_S  2
+/* SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR : WT ;bitpos:[1] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt..*/
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_M  (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_V  0x1
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_S  1
+/* SPI_DMA_INFIFO_FULL_ERR_INT_CLR : WT ;bitpos:[0] ;default: 1'b0 ; */
+/*description: The clear bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt..*/
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR_M  (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR_V  0x1
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR_S  0
+
+#define SPI_DMA_INT_RAW_REG(i)          (REG_SPI_BASE(i) + 0x3C)
+/* SPI_APP1_INT_RAW : R/WTC/SS ;bitpos:[20] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_APP1_INT interrupt. The value is only controlled by software
+..*/
+#define SPI_APP1_INT_RAW    (BIT(20))
+#define SPI_APP1_INT_RAW_M  (BIT(20))
+#define SPI_APP1_INT_RAW_V  0x1
+#define SPI_APP1_INT_RAW_S  20
+/* SPI_APP2_INT_RAW : R/WTC/SS ;bitpos:[19] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_APP2_INT interrupt. The value is only controlled by software
+..*/
+#define SPI_APP2_INT_RAW    (BIT(19))
+#define SPI_APP2_INT_RAW_M  (BIT(19))
+#define SPI_APP2_INT_RAW_V  0x1
+#define SPI_APP2_INT_RAW_S  19
+/* SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW : R/WTC/SS ;bitpos:[18] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt. 1: There is a TX BUF
+AFIFO read-empty error when SPI outputs data in master mode. 0: Others..*/
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_M  (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_V  0x1
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_S  18
+/* SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW : R/WTC/SS ;bitpos:[17] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt. 1: There is a RX AFIFO
+ write-full error when SPI inputs data in master mode. 0: Others..*/
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_M  (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_V  0x1
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_S  17
+/* SPI_SLV_CMD_ERR_INT_RAW : R/WTC/SS ;bitpos:[16] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_SLV_CMD_ERR_INT interrupt. 1: The slave command value in the
+ current SPI slave HD mode transmission is not supported. 0: Others..*/
+#define SPI_SLV_CMD_ERR_INT_RAW    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_RAW_M  (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_RAW_V  0x1
+#define SPI_SLV_CMD_ERR_INT_RAW_S  16
+/* SPI_SLV_BUF_ADDR_ERR_INT_RAW : R/WTC/SS ;bitpos:[15] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt. 1: The accessing data address
+s of the current SPI slave mode CPU controlled FD, Wr_BUF or Rd_BUF transmission
+ is bigger than 63. 0: Others..*/
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW_M  (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW_V  0x1
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW_S  15
+/* SPI_SEG_MAGIC_ERR_INT_RAW : R/WTC/SS ;bitpos:[14] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_SEG_MAGIC_ERR_INT interrupt. 1: The magic value in CONF buff
+er is error in the DMA seg-conf-trans. 0: others..*/
+#define SPI_SEG_MAGIC_ERR_INT_RAW    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_RAW_M  (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_RAW_V  0x1
+#define SPI_SEG_MAGIC_ERR_INT_RAW_S  14
+/* SPI_DMA_SEG_TRANS_DONE_INT_RAW : R/WTC/SS ;bitpos:[13] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt. 1:  spi master DMA full-du
+plex/half-duplex seg-conf-trans ends or slave half-duplex seg-trans ends. And da
+ta has been pushed to corresponding memory.  0:  seg-conf-trans or seg-trans is
+not ended or not occurred. .*/
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW_M  (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW_V  0x1
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW_S  13
+/* SPI_TRANS_DONE_INT_RAW : R/WTC/SS ;bitpos:[12] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_TRANS_DONE_INT interrupt. 1: SPI master mode transmission is
+ ended. 0: others..*/
+#define SPI_TRANS_DONE_INT_RAW    (BIT(12))
+#define SPI_TRANS_DONE_INT_RAW_M  (BIT(12))
+#define SPI_TRANS_DONE_INT_RAW_V  0x1
+#define SPI_TRANS_DONE_INT_RAW_S  12
+/* SPI_SLV_WR_BUF_DONE_INT_RAW : R/WTC/SS ;bitpos:[11] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_SLV_WR_BUF_DONE_INT interrupt. 1: SPI slave mode Wr_BUF tran
+smission is ended. 0: Others..*/
+#define SPI_SLV_WR_BUF_DONE_INT_RAW    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_RAW_M  (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_RAW_V  0x1
+#define SPI_SLV_WR_BUF_DONE_INT_RAW_S  11
+/* SPI_SLV_RD_BUF_DONE_INT_RAW : R/WTC/SS ;bitpos:[10] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_SLV_RD_BUF_DONE_INT interrupt. 1: SPI slave mode Rd_BUF tran
+smission is ended. 0: Others..*/
+#define SPI_SLV_RD_BUF_DONE_INT_RAW    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_RAW_M  (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_RAW_V  0x1
+#define SPI_SLV_RD_BUF_DONE_INT_RAW_S  10
+/* SPI_SLV_WR_DMA_DONE_INT_RAW : R/WTC/SS ;bitpos:[9] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_SLV_WR_DMA_DONE_INT interrupt. 1: SPI slave mode Wr_DMA tran
+smission is ended. 0: Others..*/
+#define SPI_SLV_WR_DMA_DONE_INT_RAW    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_RAW_M  (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_RAW_V  0x1
+#define SPI_SLV_WR_DMA_DONE_INT_RAW_S  9
+/* SPI_SLV_RD_DMA_DONE_INT_RAW : R/WTC/SS ;bitpos:[8] ;default: 1'b0 ; */
+/*description: The raw bit for SPI_SLV_RD_DMA_DONE_INT interrupt. 1: SPI slave mode Rd_DMA tran
+smission is ended. 0: Others..*/
+#define SPI_SLV_RD_DMA_DONE_INT_RAW    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_RAW_M  (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_RAW_V  0x1
+#define SPI_SLV_RD_DMA_DONE_INT_RAW_S  8
+/* SPI_SLV_CMDA_INT_RAW : R/WTC/SS ;bitpos:[7] ;default: 1'b0 ; */
+/*description: The raw bit for SPI slave CMDA interrupt. 1: SPI slave mode CMDA transmission is
+ ended. 0: Others..*/
+#define SPI_SLV_CMDA_INT_RAW    (BIT(7))
+#define SPI_SLV_CMDA_INT_RAW_M  (BIT(7))
+#define SPI_SLV_CMDA_INT_RAW_V  0x1
+#define SPI_SLV_CMDA_INT_RAW_S  7
+/* SPI_SLV_CMD9_INT_RAW : R/WTC/SS ;bitpos:[6] ;default: 1'b0 ; */
+/*description: The raw bit for SPI slave CMD9 interrupt. 1: SPI slave mode CMD9 transmission is
+ ended. 0: Others..*/
+#define SPI_SLV_CMD9_INT_RAW    (BIT(6))
+#define SPI_SLV_CMD9_INT_RAW_M  (BIT(6))
+#define SPI_SLV_CMD9_INT_RAW_V  0x1
+#define SPI_SLV_CMD9_INT_RAW_S  6
+/* SPI_SLV_CMD8_INT_RAW : R/WTC/SS ;bitpos:[5] ;default: 1'b0 ; */
+/*description: The raw bit for SPI slave CMD8 interrupt. 1: SPI slave mode CMD8 transmission is
+ ended. 0: Others..*/
+#define SPI_SLV_CMD8_INT_RAW    (BIT(5))
+#define SPI_SLV_CMD8_INT_RAW_M  (BIT(5))
+#define SPI_SLV_CMD8_INT_RAW_V  0x1
+#define SPI_SLV_CMD8_INT_RAW_S  5
+/* SPI_SLV_CMD7_INT_RAW : R/WTC/SS ;bitpos:[4] ;default: 1'b0 ; */
+/*description: The raw bit for SPI slave CMD7 interrupt. 1: SPI slave mode CMD7 transmission is
+ ended. 0: Others..*/
+#define SPI_SLV_CMD7_INT_RAW    (BIT(4))
+#define SPI_SLV_CMD7_INT_RAW_M  (BIT(4))
+#define SPI_SLV_CMD7_INT_RAW_V  0x1
+#define SPI_SLV_CMD7_INT_RAW_S  4
+/* SPI_SLV_EN_QPI_INT_RAW : R/WTC/SS ;bitpos:[3] ;default: 1'b0 ; */
+/*description: The raw bit for SPI slave En_QPI interrupt. 1: SPI slave mode En_QPI transmissio
+n is ended. 0: Others..*/
+#define SPI_SLV_EN_QPI_INT_RAW    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_RAW_M  (BIT(3))
+#define SPI_SLV_EN_QPI_INT_RAW_V  0x1
+#define SPI_SLV_EN_QPI_INT_RAW_S  3
+/* SPI_SLV_EX_QPI_INT_RAW : R/WTC/SS ;bitpos:[2] ;default: 1'b0 ; */
+/*description: The raw bit for SPI slave Ex_QPI interrupt. 1: SPI slave mode Ex_QPI transmissio
+n is ended. 0: Others..*/
+#define SPI_SLV_EX_QPI_INT_RAW    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_RAW_M  (BIT(2))
+#define SPI_SLV_EX_QPI_INT_RAW_V  0x1
+#define SPI_SLV_EX_QPI_INT_RAW_S  2
+/* SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW : R/WTC/SS ;bitpos:[1] ;default: 1'b0 ; */
+/*description: 1: The current data rate of DMA TX is smaller than that of SPI. SPI will stop in
+ master mode and send out all 0 in slave mode.  0: Others.  .*/
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_M  (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_V  0x1
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_S  1
+/* SPI_DMA_INFIFO_FULL_ERR_INT_RAW : R/WTC/SS ;bitpos:[0] ;default: 1'b0 ; */
+/*description: 1: The current data rate of DMA Rx is smaller than that of SPI, which will lose
+the receive data.  0: Others.  .*/
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW_M  (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW_V  0x1
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW_S  0
+
+#define SPI_DMA_INT_ST_REG(i)          (REG_SPI_BASE(i) + 0x40)
+/* SPI_APP1_INT_ST : RO ;bitpos:[20] ;default: 1'b0 ; */
+/*description: The status bit for SPI_APP1_INT interrupt..*/
+#define SPI_APP1_INT_ST    (BIT(20))
+#define SPI_APP1_INT_ST_M  (BIT(20))
+#define SPI_APP1_INT_ST_V  0x1
+#define SPI_APP1_INT_ST_S  20
+/* SPI_APP2_INT_ST : RO ;bitpos:[19] ;default: 1'b0 ; */
+/*description: The status bit for SPI_APP2_INT interrupt..*/
+#define SPI_APP2_INT_ST    (BIT(19))
+#define SPI_APP2_INT_ST_M  (BIT(19))
+#define SPI_APP2_INT_ST_V  0x1
+#define SPI_APP2_INT_ST_S  19
+/* SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST : RO ;bitpos:[18] ;default: 1'b0 ; */
+/*description: The status bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt..*/
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_M  (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_V  0x1
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_S  18
+/* SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST : RO ;bitpos:[17] ;default: 1'b0 ; */
+/*description: The status bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt..*/
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_M  (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_V  0x1
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_S  17
+/* SPI_SLV_CMD_ERR_INT_ST : RO ;bitpos:[16] ;default: 1'b0 ; */
+/*description: The status bit for SPI_SLV_CMD_ERR_INT interrupt..*/
+#define SPI_SLV_CMD_ERR_INT_ST    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_ST_M  (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_ST_V  0x1
+#define SPI_SLV_CMD_ERR_INT_ST_S  16
+/* SPI_SLV_BUF_ADDR_ERR_INT_ST : RO ;bitpos:[15] ;default: 1'b0 ; */
+/*description: The status bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt..*/
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST_M  (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST_V  0x1
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST_S  15
+/* SPI_SEG_MAGIC_ERR_INT_ST : RO ;bitpos:[14] ;default: 1'b0 ; */
+/*description: The status bit for SPI_SEG_MAGIC_ERR_INT interrupt..*/
+#define SPI_SEG_MAGIC_ERR_INT_ST    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_ST_M  (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_ST_V  0x1
+#define SPI_SEG_MAGIC_ERR_INT_ST_S  14
+/* SPI_DMA_SEG_TRANS_DONE_INT_ST : RO ;bitpos:[13] ;default: 1'b0 ; */
+/*description: The status bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt..*/
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST_M  (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST_V  0x1
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST_S  13
+/* SPI_TRANS_DONE_INT_ST : RO ;bitpos:[12] ;default: 1'b0 ; */
+/*description: The status bit for SPI_TRANS_DONE_INT interrupt..*/
+#define SPI_TRANS_DONE_INT_ST    (BIT(12))
+#define SPI_TRANS_DONE_INT_ST_M  (BIT(12))
+#define SPI_TRANS_DONE_INT_ST_V  0x1
+#define SPI_TRANS_DONE_INT_ST_S  12
+/* SPI_SLV_WR_BUF_DONE_INT_ST : RO ;bitpos:[11] ;default: 1'b0 ; */
+/*description: The status bit for SPI_SLV_WR_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_WR_BUF_DONE_INT_ST    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_ST_M  (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_ST_V  0x1
+#define SPI_SLV_WR_BUF_DONE_INT_ST_S  11
+/* SPI_SLV_RD_BUF_DONE_INT_ST : RO ;bitpos:[10] ;default: 1'b0 ; */
+/*description: The status bit for SPI_SLV_RD_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_RD_BUF_DONE_INT_ST    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_ST_M  (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_ST_V  0x1
+#define SPI_SLV_RD_BUF_DONE_INT_ST_S  10
+/* SPI_SLV_WR_DMA_DONE_INT_ST : RO ;bitpos:[9] ;default: 1'b0 ; */
+/*description: The status bit for SPI_SLV_WR_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_WR_DMA_DONE_INT_ST    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_ST_M  (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_ST_V  0x1
+#define SPI_SLV_WR_DMA_DONE_INT_ST_S  9
+/* SPI_SLV_RD_DMA_DONE_INT_ST : RO ;bitpos:[8] ;default: 1'b0 ; */
+/*description: The status bit for SPI_SLV_RD_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_RD_DMA_DONE_INT_ST    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_ST_M  (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_ST_V  0x1
+#define SPI_SLV_RD_DMA_DONE_INT_ST_S  8
+/* SPI_SLV_CMDA_INT_ST : RO ;bitpos:[7] ;default: 1'b0 ; */
+/*description: The status bit for SPI slave CMDA interrupt..*/
+#define SPI_SLV_CMDA_INT_ST    (BIT(7))
+#define SPI_SLV_CMDA_INT_ST_M  (BIT(7))
+#define SPI_SLV_CMDA_INT_ST_V  0x1
+#define SPI_SLV_CMDA_INT_ST_S  7
+/* SPI_SLV_CMD9_INT_ST : RO ;bitpos:[6] ;default: 1'b0 ; */
+/*description: The status bit for SPI slave CMD9 interrupt..*/
+#define SPI_SLV_CMD9_INT_ST    (BIT(6))
+#define SPI_SLV_CMD9_INT_ST_M  (BIT(6))
+#define SPI_SLV_CMD9_INT_ST_V  0x1
+#define SPI_SLV_CMD9_INT_ST_S  6
+/* SPI_SLV_CMD8_INT_ST : RO ;bitpos:[5] ;default: 1'b0 ; */
+/*description: The status bit for SPI slave CMD8 interrupt..*/
+#define SPI_SLV_CMD8_INT_ST    (BIT(5))
+#define SPI_SLV_CMD8_INT_ST_M  (BIT(5))
+#define SPI_SLV_CMD8_INT_ST_V  0x1
+#define SPI_SLV_CMD8_INT_ST_S  5
+/* SPI_SLV_CMD7_INT_ST : RO ;bitpos:[4] ;default: 1'b0 ; */
+/*description: The status bit for SPI slave CMD7 interrupt..*/
+#define SPI_SLV_CMD7_INT_ST    (BIT(4))
+#define SPI_SLV_CMD7_INT_ST_M  (BIT(4))
+#define SPI_SLV_CMD7_INT_ST_V  0x1
+#define SPI_SLV_CMD7_INT_ST_S  4
+/* SPI_SLV_EN_QPI_INT_ST : RO ;bitpos:[3] ;default: 1'b0 ; */
+/*description: The status bit for SPI slave En_QPI interrupt..*/
+#define SPI_SLV_EN_QPI_INT_ST    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_ST_M  (BIT(3))
+#define SPI_SLV_EN_QPI_INT_ST_V  0x1
+#define SPI_SLV_EN_QPI_INT_ST_S  3
+/* SPI_SLV_EX_QPI_INT_ST : RO ;bitpos:[2] ;default: 1'b0 ; */
+/*description: The status bit for SPI slave Ex_QPI interrupt..*/
+#define SPI_SLV_EX_QPI_INT_ST    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_ST_M  (BIT(2))
+#define SPI_SLV_EX_QPI_INT_ST_V  0x1
+#define SPI_SLV_EX_QPI_INT_ST_S  2
+/* SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST : RO ;bitpos:[1] ;default: 1'b0 ; */
+/*description: The status bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt..*/
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_M  (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_V  0x1
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_S  1
+/* SPI_DMA_INFIFO_FULL_ERR_INT_ST : RO ;bitpos:[0] ;default: 1'b0 ; */
+/*description: The status bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt..*/
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST_M  (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST_V  0x1
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST_S  0
+
+#define SPI_DMA_INT_SET_REG(i)          (REG_SPI_BASE(i) + 0x44)
+/* SPI_APP1_INT_SET : WT ;bitpos:[20] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_APP1_INT interrupt..*/
+#define SPI_APP1_INT_SET    (BIT(20))
+#define SPI_APP1_INT_SET_M  (BIT(20))
+#define SPI_APP1_INT_SET_V  0x1
+#define SPI_APP1_INT_SET_S  20
+/* SPI_APP2_INT_SET : WT ;bitpos:[19] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_APP2_INT interrupt..*/
+#define SPI_APP2_INT_SET    (BIT(19))
+#define SPI_APP2_INT_SET_M  (BIT(19))
+#define SPI_APP2_INT_SET_V  0x1
+#define SPI_APP2_INT_SET_S  19
+/* SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET : WT ;bitpos:[18] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt..*/
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET_M  (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET_V  0x1
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET_S  18
+/* SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET : WT ;bitpos:[17] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt..*/
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET_M  (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET_V  0x1
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET_S  17
+/* SPI_SLV_CMD_ERR_INT_SET : WT ;bitpos:[16] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_SLV_CMD_ERR_INT interrupt..*/
+#define SPI_SLV_CMD_ERR_INT_SET    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_SET_M  (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_SET_V  0x1
+#define SPI_SLV_CMD_ERR_INT_SET_S  16
+/* SPI_SLV_BUF_ADDR_ERR_INT_SET : WT ;bitpos:[15] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt..*/
+#define SPI_SLV_BUF_ADDR_ERR_INT_SET    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_SET_M  (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_SET_V  0x1
+#define SPI_SLV_BUF_ADDR_ERR_INT_SET_S  15
+/* SPI_SEG_MAGIC_ERR_INT_SET : WT ;bitpos:[14] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_SEG_MAGIC_ERR_INT interrupt..*/
+#define SPI_SEG_MAGIC_ERR_INT_SET    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_SET_M  (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_SET_V  0x1
+#define SPI_SEG_MAGIC_ERR_INT_SET_S  14
+/* SPI_DMA_SEG_TRANS_DONE_INT_SET : WT ;bitpos:[13] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt..*/
+#define SPI_DMA_SEG_TRANS_DONE_INT_SET    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_SET_M  (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_SET_V  0x1
+#define SPI_DMA_SEG_TRANS_DONE_INT_SET_S  13
+/* SPI_TRANS_DONE_INT_SET : WT ;bitpos:[12] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_TRANS_DONE_INT interrupt..*/
+#define SPI_TRANS_DONE_INT_SET    (BIT(12))
+#define SPI_TRANS_DONE_INT_SET_M  (BIT(12))
+#define SPI_TRANS_DONE_INT_SET_V  0x1
+#define SPI_TRANS_DONE_INT_SET_S  12
+/* SPI_SLV_WR_BUF_DONE_INT_SET : WT ;bitpos:[11] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_SLV_WR_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_WR_BUF_DONE_INT_SET    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_SET_M  (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_SET_V  0x1
+#define SPI_SLV_WR_BUF_DONE_INT_SET_S  11
+/* SPI_SLV_RD_BUF_DONE_INT_SET : WT ;bitpos:[10] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_SLV_RD_BUF_DONE_INT interrupt..*/
+#define SPI_SLV_RD_BUF_DONE_INT_SET    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_SET_M  (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_SET_V  0x1
+#define SPI_SLV_RD_BUF_DONE_INT_SET_S  10
+/* SPI_SLV_WR_DMA_DONE_INT_SET : WT ;bitpos:[9] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_SLV_WR_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_WR_DMA_DONE_INT_SET    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_SET_M  (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_SET_V  0x1
+#define SPI_SLV_WR_DMA_DONE_INT_SET_S  9
+/* SPI_SLV_RD_DMA_DONE_INT_SET : WT ;bitpos:[8] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_SLV_RD_DMA_DONE_INT interrupt..*/
+#define SPI_SLV_RD_DMA_DONE_INT_SET    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_SET_M  (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_SET_V  0x1
+#define SPI_SLV_RD_DMA_DONE_INT_SET_S  8
+/* SPI_SLV_CMDA_INT_SET : WT ;bitpos:[7] ;default: 1'b0 ; */
+/*description: The software set bit for SPI slave CMDA interrupt..*/
+#define SPI_SLV_CMDA_INT_SET    (BIT(7))
+#define SPI_SLV_CMDA_INT_SET_M  (BIT(7))
+#define SPI_SLV_CMDA_INT_SET_V  0x1
+#define SPI_SLV_CMDA_INT_SET_S  7
+/* SPI_SLV_CMD9_INT_SET : WT ;bitpos:[6] ;default: 1'b0 ; */
+/*description: The software set bit for SPI slave CMD9 interrupt..*/
+#define SPI_SLV_CMD9_INT_SET    (BIT(6))
+#define SPI_SLV_CMD9_INT_SET_M  (BIT(6))
+#define SPI_SLV_CMD9_INT_SET_V  0x1
+#define SPI_SLV_CMD9_INT_SET_S  6
+/* SPI_SLV_CMD8_INT_SET : WT ;bitpos:[5] ;default: 1'b0 ; */
+/*description: The software set bit for SPI slave CMD8 interrupt..*/
+#define SPI_SLV_CMD8_INT_SET    (BIT(5))
+#define SPI_SLV_CMD8_INT_SET_M  (BIT(5))
+#define SPI_SLV_CMD8_INT_SET_V  0x1
+#define SPI_SLV_CMD8_INT_SET_S  5
+/* SPI_SLV_CMD7_INT_SET : WT ;bitpos:[4] ;default: 1'b0 ; */
+/*description: The software set bit for SPI slave CMD7 interrupt..*/
+#define SPI_SLV_CMD7_INT_SET    (BIT(4))
+#define SPI_SLV_CMD7_INT_SET_M  (BIT(4))
+#define SPI_SLV_CMD7_INT_SET_V  0x1
+#define SPI_SLV_CMD7_INT_SET_S  4
+/* SPI_SLV_EN_QPI_INT_SET : WT ;bitpos:[3] ;default: 1'b0 ; */
+/*description: The software set bit for SPI slave En_QPI interrupt..*/
+#define SPI_SLV_EN_QPI_INT_SET    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_SET_M  (BIT(3))
+#define SPI_SLV_EN_QPI_INT_SET_V  0x1
+#define SPI_SLV_EN_QPI_INT_SET_S  3
+/* SPI_SLV_EX_QPI_INT_SET : WT ;bitpos:[2] ;default: 1'b0 ; */
+/*description: The software set bit for SPI slave Ex_QPI interrupt..*/
+#define SPI_SLV_EX_QPI_INT_SET    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_SET_M  (BIT(2))
+#define SPI_SLV_EX_QPI_INT_SET_V  0x1
+#define SPI_SLV_EX_QPI_INT_SET_S  2
+/* SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET : WT ;bitpos:[1] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt..*/
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET_M  (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET_V  0x1
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET_S  1
+/* SPI_DMA_INFIFO_FULL_ERR_INT_SET : WT ;bitpos:[0] ;default: 1'b0 ; */
+/*description: The software set bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt..*/
+#define SPI_DMA_INFIFO_FULL_ERR_INT_SET    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_SET_M  (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_SET_V  0x1
+#define SPI_DMA_INFIFO_FULL_ERR_INT_SET_S  0
+
+#define SPI_W0_REG(i)          (REG_SPI_BASE(i) + 0x98)
+/* SPI_BUF0 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF0    0xFFFFFFFF
+#define SPI_BUF0_M  ((SPI_BUF0_V)<<(SPI_BUF0_S))
+#define SPI_BUF0_V  0xFFFFFFFF
+#define SPI_BUF0_S  0
+
+#define SPI_W1_REG(i)          (REG_SPI_BASE(i) + 0x9C)
+/* SPI_BUF1 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF1    0xFFFFFFFF
+#define SPI_BUF1_M  ((SPI_BUF1_V)<<(SPI_BUF1_S))
+#define SPI_BUF1_V  0xFFFFFFFF
+#define SPI_BUF1_S  0
+
+#define SPI_W2_REG(i)          (REG_SPI_BASE(i) + 0xA0)
+/* SPI_BUF2 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF2    0xFFFFFFFF
+#define SPI_BUF2_M  ((SPI_BUF2_V)<<(SPI_BUF2_S))
+#define SPI_BUF2_V  0xFFFFFFFF
+#define SPI_BUF2_S  0
+
+#define SPI_W3_REG(i)          (REG_SPI_BASE(i) + 0xA4)
+/* SPI_BUF3 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF3    0xFFFFFFFF
+#define SPI_BUF3_M  ((SPI_BUF3_V)<<(SPI_BUF3_S))
+#define SPI_BUF3_V  0xFFFFFFFF
+#define SPI_BUF3_S  0
+
+#define SPI_W4_REG(i)          (REG_SPI_BASE(i) + 0xA8)
+/* SPI_BUF4 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF4    0xFFFFFFFF
+#define SPI_BUF4_M  ((SPI_BUF4_V)<<(SPI_BUF4_S))
+#define SPI_BUF4_V  0xFFFFFFFF
+#define SPI_BUF4_S  0
+
+#define SPI_W5_REG(i)          (REG_SPI_BASE(i) + 0xAC)
+/* SPI_BUF5 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF5    0xFFFFFFFF
+#define SPI_BUF5_M  ((SPI_BUF5_V)<<(SPI_BUF5_S))
+#define SPI_BUF5_V  0xFFFFFFFF
+#define SPI_BUF5_S  0
+
+#define SPI_W6_REG(i)          (REG_SPI_BASE(i) + 0xB0)
+/* SPI_BUF6 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF6    0xFFFFFFFF
+#define SPI_BUF6_M  ((SPI_BUF6_V)<<(SPI_BUF6_S))
+#define SPI_BUF6_V  0xFFFFFFFF
+#define SPI_BUF6_S  0
+
+#define SPI_W7_REG(i)          (REG_SPI_BASE(i) + 0xB4)
+/* SPI_BUF7 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF7    0xFFFFFFFF
+#define SPI_BUF7_M  ((SPI_BUF7_V)<<(SPI_BUF7_S))
+#define SPI_BUF7_V  0xFFFFFFFF
+#define SPI_BUF7_S  0
+
+#define SPI_W8_REG(i)          (REG_SPI_BASE(i) + 0xB8)
+/* SPI_BUF8 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF8    0xFFFFFFFF
+#define SPI_BUF8_M  ((SPI_BUF8_V)<<(SPI_BUF8_S))
+#define SPI_BUF8_V  0xFFFFFFFF
+#define SPI_BUF8_S  0
+
+#define SPI_W9_REG(i)          (REG_SPI_BASE(i) + 0xBC)
+/* SPI_BUF9 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF9    0xFFFFFFFF
+#define SPI_BUF9_M  ((SPI_BUF9_V)<<(SPI_BUF9_S))
+#define SPI_BUF9_V  0xFFFFFFFF
+#define SPI_BUF9_S  0
+
+#define SPI_W10_REG(i)          (REG_SPI_BASE(i) + 0xC0)
+/* SPI_BUF10 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF10    0xFFFFFFFF
+#define SPI_BUF10_M  ((SPI_BUF10_V)<<(SPI_BUF10_S))
+#define SPI_BUF10_V  0xFFFFFFFF
+#define SPI_BUF10_S  0
+
+#define SPI_W11_REG(i)          (REG_SPI_BASE(i) + 0xC4)
+/* SPI_BUF11 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF11    0xFFFFFFFF
+#define SPI_BUF11_M  ((SPI_BUF11_V)<<(SPI_BUF11_S))
+#define SPI_BUF11_V  0xFFFFFFFF
+#define SPI_BUF11_S  0
+
+#define SPI_W12_REG(i)          (REG_SPI_BASE(i) + 0xC8)
+/* SPI_BUF12 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF12    0xFFFFFFFF
+#define SPI_BUF12_M  ((SPI_BUF12_V)<<(SPI_BUF12_S))
+#define SPI_BUF12_V  0xFFFFFFFF
+#define SPI_BUF12_S  0
+
+#define SPI_W13_REG(i)          (REG_SPI_BASE(i) + 0xCC)
+/* SPI_BUF13 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF13    0xFFFFFFFF
+#define SPI_BUF13_M  ((SPI_BUF13_V)<<(SPI_BUF13_S))
+#define SPI_BUF13_V  0xFFFFFFFF
+#define SPI_BUF13_S  0
+
+#define SPI_W14_REG(i)          (REG_SPI_BASE(i) + 0xD0)
+/* SPI_BUF14 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF14    0xFFFFFFFF
+#define SPI_BUF14_M  ((SPI_BUF14_V)<<(SPI_BUF14_S))
+#define SPI_BUF14_V  0xFFFFFFFF
+#define SPI_BUF14_S  0
+
+#define SPI_W15_REG(i)          (REG_SPI_BASE(i) + 0xD4)
+/* SPI_BUF15 : R/W/SS ;bitpos:[31:0] ;default: 32'd0 ; */
+/*description: data buffer.*/
+#define SPI_BUF15    0xFFFFFFFF
+#define SPI_BUF15_M  ((SPI_BUF15_V)<<(SPI_BUF15_S))
+#define SPI_BUF15_V  0xFFFFFFFF
+#define SPI_BUF15_S  0
+
+#define SPI_SLAVE_REG(i)          (REG_SPI_BASE(i) + 0xE0)
+/* SPI_USR_CONF : R/W ;bitpos:[28] ;default: 1'b0 ; */
+/*description: 1: Enable the DMA CONF phase of current seg-trans operation, which means seg-tra
+ns will start. 0: This is not seg-trans mode..*/
+#define SPI_USR_CONF    (BIT(28))
+#define SPI_USR_CONF_M  (BIT(28))
+#define SPI_USR_CONF_V  0x1
+#define SPI_USR_CONF_S  28
+/* SPI_SOFT_RESET : WT ;bitpos:[27] ;default: 1'b0 ; */
+/*description: Software reset enable, reset the spi clock line cs line and data lines. Can be c
+onfigured in CONF state..*/
+#define SPI_SOFT_RESET    (BIT(27))
+#define SPI_SOFT_RESET_M  (BIT(27))
+#define SPI_SOFT_RESET_V  0x1
+#define SPI_SOFT_RESET_S  27
+/* SPI_SLAVE_MODE : R/W ;bitpos:[26] ;default: 1'b0 ; */
+/*description: Set SPI work mode. 1: slave mode 0: master mode..*/
+#define SPI_SLAVE_MODE    (BIT(26))
+#define SPI_SLAVE_MODE_M  (BIT(26))
+#define SPI_SLAVE_MODE_V  0x1
+#define SPI_SLAVE_MODE_S  26
+/* SPI_DMA_SEG_MAGIC_VALUE : R/W ;bitpos:[25:22] ;default: 4'd10 ; */
+/*description: The magic value of BM table in master DMA seg-trans..*/
+#define SPI_DMA_SEG_MAGIC_VALUE    0x0000000F
+#define SPI_DMA_SEG_MAGIC_VALUE_M  ((SPI_DMA_SEG_MAGIC_VALUE_V)<<(SPI_DMA_SEG_MAGIC_VALUE_S))
+#define SPI_DMA_SEG_MAGIC_VALUE_V  0xF
+#define SPI_DMA_SEG_MAGIC_VALUE_S  22
+/* SPI_SLV_WRBUF_BITLEN_EN : R/W ;bitpos:[11] ;default: 1'b0 ; */
+/*description: 1: SPI_SLV_DATA_BITLEN stores data bit length of master-write-to-slave data leng
+th in CPU controlled mode(Wr_BUF). 0: others.*/
+#define SPI_SLV_WRBUF_BITLEN_EN    (BIT(11))
+#define SPI_SLV_WRBUF_BITLEN_EN_M  (BIT(11))
+#define SPI_SLV_WRBUF_BITLEN_EN_V  0x1
+#define SPI_SLV_WRBUF_BITLEN_EN_S  11
+/* SPI_SLV_RDBUF_BITLEN_EN : R/W ;bitpos:[10] ;default: 1'b0 ; */
+/*description: 1: SPI_SLV_DATA_BITLEN stores data bit length of master-read-slave data length i
+n CPU controlled mode(Rd_BUF). 0: others.*/
+#define SPI_SLV_RDBUF_BITLEN_EN    (BIT(10))
+#define SPI_SLV_RDBUF_BITLEN_EN_M  (BIT(10))
+#define SPI_SLV_RDBUF_BITLEN_EN_V  0x1
+#define SPI_SLV_RDBUF_BITLEN_EN_S  10
+/* SPI_SLV_WRDMA_BITLEN_EN : R/W ;bitpos:[9] ;default: 1'b0 ; */
+/*description: 1: SPI_SLV_DATA_BITLEN stores data bit length of master-write-to-slave data leng
+th in DMA controlled mode(Wr_DMA). 0: others.*/
+#define SPI_SLV_WRDMA_BITLEN_EN    (BIT(9))
+#define SPI_SLV_WRDMA_BITLEN_EN_M  (BIT(9))
+#define SPI_SLV_WRDMA_BITLEN_EN_V  0x1
+#define SPI_SLV_WRDMA_BITLEN_EN_S  9
+/* SPI_SLV_RDDMA_BITLEN_EN : R/W ;bitpos:[8] ;default: 1'b0 ; */
+/*description: 1: SPI_SLV_DATA_BITLEN stores data bit length of master-read-slave data length i
+n DMA controlled mode(Rd_DMA). 0: others.*/
+#define SPI_SLV_RDDMA_BITLEN_EN    (BIT(8))
+#define SPI_SLV_RDDMA_BITLEN_EN_M  (BIT(8))
+#define SPI_SLV_RDDMA_BITLEN_EN_V  0x1
+#define SPI_SLV_RDDMA_BITLEN_EN_S  8
+/* SPI_RSCK_DATA_OUT : R/W ;bitpos:[3] ;default: 1'b0 ; */
+/*description: It saves half a cycle when tsck is the same as rsck. 1: output data at rsck pose
+dge   0: output data at tsck posedge .*/
+#define SPI_RSCK_DATA_OUT    (BIT(3))
+#define SPI_RSCK_DATA_OUT_M  (BIT(3))
+#define SPI_RSCK_DATA_OUT_V  0x1
+#define SPI_RSCK_DATA_OUT_S  3
+/* SPI_CLK_MODE_13 : R/W ;bitpos:[2] ;default: 1'b0 ; */
+/*description: {CPOL, CPHA},1: support spi clk mode 1 and 3, first edge output data B[0]/B[7].
+ 0: support spi clk mode 0 and 2, first edge output data B[1]/B[6]..*/
+#define SPI_CLK_MODE_13    (BIT(2))
+#define SPI_CLK_MODE_13_M  (BIT(2))
+#define SPI_CLK_MODE_13_V  0x1
+#define SPI_CLK_MODE_13_S  2
+/* SPI_CLK_MODE : R/W ;bitpos:[1:0] ;default: 2'b0 ; */
+/*description: SPI clock mode bits. 0: SPI clock is off when CS inactive 1: SPI clock is delaye
+d one cycle after CS inactive 2: SPI clock is delayed two cycles after CS inacti
+ve 3: SPI clock is always on. Can be configured in CONF state..*/
+#define SPI_CLK_MODE    0x00000003
+#define SPI_CLK_MODE_M  ((SPI_CLK_MODE_V)<<(SPI_CLK_MODE_S))
+#define SPI_CLK_MODE_V  0x3
+#define SPI_CLK_MODE_S  0
+
+#define SPI_SLAVE1_REG(i)          (REG_SPI_BASE(i) + 0xE4)
+/* SPI_SLV_LAST_ADDR : R/W/SS ;bitpos:[31:26] ;default: 6'd0 ; */
+/*description: In the slave mode it is the value of address..*/
+#define SPI_SLV_LAST_ADDR    0x0000003F
+#define SPI_SLV_LAST_ADDR_M  ((SPI_SLV_LAST_ADDR_V)<<(SPI_SLV_LAST_ADDR_S))
+#define SPI_SLV_LAST_ADDR_V  0x3F
+#define SPI_SLV_LAST_ADDR_S  26
+/* SPI_SLV_LAST_COMMAND : R/W/SS ;bitpos:[25:18] ;default: 8'b0 ; */
+/*description: In the slave mode it is the value of command..*/
+#define SPI_SLV_LAST_COMMAND    0x000000FF
+#define SPI_SLV_LAST_COMMAND_M  ((SPI_SLV_LAST_COMMAND_V)<<(SPI_SLV_LAST_COMMAND_S))
+#define SPI_SLV_LAST_COMMAND_V  0xFF
+#define SPI_SLV_LAST_COMMAND_S  18
+/* SPI_SLV_DATA_BITLEN : R/W/SS ;bitpos:[17:0] ;default: 18'd0 ; */
+/*description: The transferred data bit length in SPI slave FD and HD mode. .*/
+#define SPI_SLV_DATA_BITLEN    0x0003FFFF
+#define SPI_SLV_DATA_BITLEN_M  ((SPI_SLV_DATA_BITLEN_V)<<(SPI_SLV_DATA_BITLEN_S))
+#define SPI_SLV_DATA_BITLEN_V  0x3FFFF
+#define SPI_SLV_DATA_BITLEN_S  0
+
+#define SPI_CLK_GATE_REG(i)          (REG_SPI_BASE(i) + 0xE8)
+/* SPI_MST_CLK_SEL : R/W ;bitpos:[2] ;default: 1'b0 ; */
+/*description: This bit is used to select SPI module clock source in master mode. 1: PLL_CLK_80
+M. 0: XTAL CLK..*/
+#define SPI_MST_CLK_SEL    (BIT(2))
+#define SPI_MST_CLK_SEL_M  (BIT(2))
+#define SPI_MST_CLK_SEL_V  0x1
+#define SPI_MST_CLK_SEL_S  2
+/* SPI_MST_CLK_ACTIVE : R/W ;bitpos:[1] ;default: 1'b0 ; */
+/*description: Set this bit to power on the SPI module clock..*/
+#define SPI_MST_CLK_ACTIVE    (BIT(1))
+#define SPI_MST_CLK_ACTIVE_M  (BIT(1))
+#define SPI_MST_CLK_ACTIVE_V  0x1
+#define SPI_MST_CLK_ACTIVE_S  1
+/* SPI_CLK_EN : R/W ;bitpos:[0] ;default: 1'b0 ; */
+/*description: Set this bit to enable clk gate.*/
+#define SPI_CLK_EN    (BIT(0))
+#define SPI_CLK_EN_M  (BIT(0))
+#define SPI_CLK_EN_V  0x1
+#define SPI_CLK_EN_S  0
+
+#define SPI_DATE_REG(i)          (REG_SPI_BASE(i) + 0xF0)
+/* SPI_DATE : R/W ;bitpos:[27:0] ;default: 28'h2101190 ; */
+/*description: SPI register version..*/
+#define SPI_DATE    0x0FFFFFFF
+#define SPI_DATE_M  ((SPI_DATE_V)<<(SPI_DATE_S))
+#define SPI_DATE_V  0xFFFFFFF
+#define SPI_DATE_S  0
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/target/esp32c3/src/spi.c
+++ b/src/target/esp32c3/src/spi.c
@@ -1,0 +1,244 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * SPI (download boot) transport for the ESP32-C3 flasher stub.
+ *
+ * GP-SPI2 slave + GDMA (channel 0) are left configured by the ROM download
+ * boot; the driver only arms the DMA and drives the shared W0..W3 handshake
+ * registers.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <esp-stub-lib/bit_utils.h>
+#include <esp-stub-lib/err.h>
+#include <esp-stub-lib/soc_utils.h>
+
+#include <target/spi.h>
+
+#include <private/helpers.h>
+#include <private/spi_slave_protocol.h>
+
+#include <soc/spi_reg.h>
+
+#define SPI_SLV_HOST                2 /* GP-SPI2, bound to GDMA channel 0 by the ROM */
+
+#define SPI_SLV_REG_VER             SPI_W0_REG(SPI_SLV_HOST)
+#define SPI_SLV_REG_RXSTA           SPI_W1_REG(SPI_SLV_HOST)
+#define SPI_SLV_REG_TXSTA           SPI_W2_REG(SPI_SLV_HOST)
+#define SPI_SLV_REG_CMD             SPI_W3_REG(SPI_SLV_HOST)
+
+/* Host WRDMA writes to us (RX); host RDDMA reads from us (TX). */
+#define SPI_SLV_RX_DONE             SPI_SLV_WR_DMA_DONE_INT_RAW
+#define SPI_SLV_RX_DONE_CLR         SPI_SLV_WR_DMA_DONE_INT_CLR
+#define SPI_SLV_TX_DONE             SPI_SLV_RD_DMA_DONE_INT_RAW
+#define SPI_SLV_TX_DONE_CLR         SPI_SLV_RD_DMA_DONE_INT_CLR
+
+/* GDMA channel-0 registers (from soc/gdma_reg.h); only the few we drive. */
+#define GDMA_BASE                   0x6003f000U
+#define GDMA_INT_CLR_CH0_REG        (GDMA_BASE + 0x00cU)
+#define GDMA_IN_CONF0_CH0_REG       (GDMA_BASE + 0x070U)
+#define GDMA_IN_LINK_CH0_REG        (GDMA_BASE + 0x080U)
+#define GDMA_OUT_CONF0_CH0_REG      (GDMA_BASE + 0x0d0U)
+#define GDMA_OUT_LINK_CH0_REG       (GDMA_BASE + 0x0e0U)
+#define GDMA_IN_RST_CH0             (1U << 0)
+#define GDMA_OUT_RST_CH0            (1U << 0)
+#define GDMA_INLINK_ADDR_CH0        0x000FFFFFU
+#define GDMA_INLINK_START_CH0       (1U << 22)
+#define GDMA_OUTLINK_START_CH0      (1U << 21)
+#define GDMA_INFIFO_UDF_CH0_INT_CLR (1U << 10)
+
+/* DMA descriptor (ROM lldesc_spi_t layout, 3 words). */
+typedef struct lldesc_spi_s {
+    volatile uint32_t size : 12, length : 12, offset : 5, sosf : 1, eof : 1, owner : 1;
+    volatile uint8_t *buf;
+    struct lldesc_spi_s *next;
+} lldesc_spi_t;
+
+#define LLDESC_SPI_MAX_BUFFER_SIZE (4096U - 4U)
+#define LLDESC_SPI_SIZE_MASK       0xFFFU
+
+/* Chain sized to cover FRAME_BUFFER_SIZE (0x4107). */
+#define SPI_SLV_RX_DESC_COUNT      5U
+#define SPI_SLV_RX_MAX_LEN         (SPI_SLV_RX_DESC_COUNT * LLDESC_SPI_MAX_BUFFER_SIZE)
+
+static lldesc_spi_t dmadesc_tx;
+static lldesc_spi_t dmadesc_rx[SPI_SLV_RX_DESC_COUNT];
+
+extern void esp_rom_software_reset_cpu(uint32_t);
+
+static uint32_t s_seq_rx;
+static uint32_t s_seq_tx;
+static volatile bool s_rx_armed;
+
+/* Saved so tx_frame() can re-arm RX after a TX rewrites SPI_DMA_CONF. */
+static uint8_t *s_rx_buf;
+static uint32_t s_rx_len;
+
+bool stub_target_spi_is_active(void)
+{
+    if (!(READ_PERI_REG(SPI_SLAVE_REG(SPI_SLV_HOST)) & SPI_SLAVE_MODE)) {
+        return false;
+    }
+    uint32_t cmd = READ_PERI_REG(SPI_SLV_REG_CMD) & 0xFFU;
+    return (cmd == SPI_SLV_CMD_READY) || (cmd == SPI_SLV_CMD_DONE);
+}
+
+void stub_target_spi_init(void)
+{
+    /* Silence the ROM's SPI2 DMA interrupts so they can't race our polling
+     * (RAW status we poll is unaffected). */
+    WRITE_PERI_REG(SPI_DMA_INT_ENA_REG(SPI_SLV_HOST), 0);
+
+    /* ROM download boot leaves CMD = DONE; the host's stub-connect handshake
+     * busy-waits for IDLE, so this reset is required. */
+    WRITE_PERI_REG(SPI_SLV_REG_CMD, SPI_SLV_CMD_IDLE);
+
+    s_seq_rx = SPI_SLV_STATE_INIT;
+    s_seq_tx = SPI_SLV_STATE_INIT;
+    s_rx_armed = false;
+}
+
+/* Split buf into <=4092-byte descriptors and (re)start the RX inlink. */
+static void spi_slv_rxdma_arm(uint8_t *buf, uint32_t len)
+{
+    uint32_t remaining = len;
+    uint8_t *buf_pos = buf;
+    uint32_t desc_idx = 0;
+    while (remaining) {
+        uint32_t chunk = (remaining > LLDESC_SPI_MAX_BUFFER_SIZE) ? LLDESC_SPI_MAX_BUFFER_SIZE : remaining;
+        uint32_t aligned_len = (chunk + 3U) & ~3U; /* RX needs word-aligned length */
+        dmadesc_rx[desc_idx].size = aligned_len & LLDESC_SPI_SIZE_MASK;
+        dmadesc_rx[desc_idx].length = aligned_len & LLDESC_SPI_SIZE_MASK;
+        dmadesc_rx[desc_idx].buf = buf_pos;
+        dmadesc_rx[desc_idx].sosf = 0;
+        dmadesc_rx[desc_idx].owner = 1;
+        if (remaining <= chunk) {
+            dmadesc_rx[desc_idx].eof = 1;
+            dmadesc_rx[desc_idx].next = NULL;
+        } else {
+            dmadesc_rx[desc_idx].eof = 0;
+            dmadesc_rx[desc_idx].next = &dmadesc_rx[desc_idx + 1];
+        }
+        remaining -= chunk;
+        buf_pos += chunk;
+        desc_idx++;
+    }
+
+    /* gdma_ll_rxdma_reset */
+    SET_PERI_REG_MASK(GDMA_IN_CONF0_CH0_REG, GDMA_IN_RST_CH0);
+    CLEAR_PERI_REG_MASK(GDMA_IN_CONF0_CH0_REG, GDMA_IN_RST_CH0);
+    /* spi_ll_rxdma_start */
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_RX_DONE_CLR);
+    WRITE_PERI_REG(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_AFIFO_RST | SPI_BUF_AFIFO_RST | SPI_RX_AFIFO_RST);
+    SET_PERI_REG_MASK(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_RX_ENA);
+    /* gdma_ll_load_rx_link */
+    WRITE_PERI_REG(GDMA_IN_LINK_CH0_REG, (uint32_t)(uintptr_t)dmadesc_rx & GDMA_INLINK_ADDR_CH0);
+    WRITE_PERI_REG(GDMA_INT_CLR_CH0_REG, GDMA_INFIFO_UDF_CH0_INT_CLR);
+    SET_PERI_REG_MASK(GDMA_IN_LINK_CH0_REG, GDMA_INLINK_START_CH0);
+}
+
+int stub_target_spi_rearm(uint8_t *buf, size_t max_size)
+{
+    if (s_rx_armed) {
+        return STUB_LIB_OK;
+    }
+    if (buf == NULL || max_size == 0) {
+        return STUB_LIB_ERR_INVALID_ARG;
+    }
+
+    if (max_size > SPI_SLV_RX_MAX_LEN) {
+        max_size = SPI_SLV_RX_MAX_LEN;
+    }
+
+    spi_slv_rxdma_arm(buf, (uint32_t)max_size);
+    s_rx_buf = buf;
+    s_rx_len = (uint32_t)max_size;
+
+    s_seq_rx ^= SPI_SLV_STA_TOGGLE;
+    uint32_t rxsta = s_seq_rx | ((uint32_t)max_size << SPI_SLV_STA_LEN_SHIFT);
+    s_seq_rx &= ~SPI_SLV_STA_INIT;
+    WRITE_PERI_REG(SPI_SLV_REG_RXSTA, rxsta);
+
+    s_rx_armed = true;
+    return STUB_LIB_OK;
+}
+
+static void spi_slv_service_cmd(void)
+{
+    uint32_t cmd = READ_PERI_REG(SPI_SLV_REG_CMD) & 0xFFU;
+    switch (cmd) {
+    case SPI_SLV_CMD_READY:
+        WRITE_PERI_REG(SPI_SLV_REG_CMD, SPI_SLV_CMD_READY);
+        break;
+    case SPI_SLV_CMD_REBOOT:
+        esp_rom_software_reset_cpu(0);
+        break;
+    default:
+        break;
+    }
+}
+
+bool stub_target_spi_take_rx_frame(size_t *out_len)
+{
+    spi_slv_service_cmd();
+
+    if (!(READ_PERI_REG(SPI_DMA_INT_RAW_REG(SPI_SLV_HOST)) & SPI_SLV_RX_DONE)) {
+        return false;
+    }
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_RX_DONE_CLR);
+
+    if (out_len) {
+        uint32_t bitlen = READ_PERI_REG(SPI_SLAVE1_REG(SPI_SLV_HOST)) & SPI_SLV_DATA_BITLEN;
+        *out_len = bitlen / 8U;
+    }
+
+    s_rx_armed = false;
+    return true;
+}
+
+int stub_target_spi_tx_frame(const void *data, size_t len)
+{
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_TX_DONE_CLR);
+
+    dmadesc_tx.size = (uint32_t)len & LLDESC_SPI_SIZE_MASK;
+    dmadesc_tx.length = (uint32_t)len & LLDESC_SPI_SIZE_MASK;
+    dmadesc_tx.buf = (uint8_t *)data;
+    dmadesc_tx.sosf = 0;
+    dmadesc_tx.eof = 1;
+    dmadesc_tx.owner = 1;
+    dmadesc_tx.next = NULL;
+
+    /* gdma_ll_txdma_reset */
+    SET_PERI_REG_MASK(GDMA_OUT_CONF0_CH0_REG, GDMA_OUT_RST_CH0);
+    CLEAR_PERI_REG_MASK(GDMA_OUT_CONF0_CH0_REG, GDMA_OUT_RST_CH0);
+    /* gdma_ll_load_tx_link */
+    WRITE_PERI_REG(GDMA_OUT_LINK_CH0_REG, (uint32_t)(uintptr_t)&dmadesc_tx & GDMA_INLINK_ADDR_CH0);
+    SET_PERI_REG_MASK(GDMA_OUT_LINK_CH0_REG, GDMA_OUTLINK_START_CH0);
+    /* spi_ll_txdma_start */
+    WRITE_PERI_REG(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_AFIFO_RST | SPI_BUF_AFIFO_RST | SPI_RX_AFIFO_RST);
+    SET_PERI_REG_MASK(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_TX_ENA);
+
+    s_seq_tx ^= SPI_SLV_STA_TOGGLE;
+    uint32_t txsta = s_seq_tx | ((uint32_t)len << SPI_SLV_STA_LEN_SHIFT);
+    s_seq_tx &= ~SPI_SLV_STA_INIT;
+    WRITE_PERI_REG(SPI_SLV_REG_TXSTA, txsta);
+
+    /* Leave TXSTA set until the next frame; clearing it early races the host. */
+    uint64_t timeout_us = SPI_SLV_TX_TIMEOUT_US;
+    int ret = stub_target_wait_reg_bit_set(SPI_DMA_INT_RAW_REG(SPI_SLV_HOST), SPI_SLV_TX_DONE, &timeout_us);
+    if (ret != STUB_LIB_OK) {
+        return STUB_LIB_FAIL;
+    }
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_TX_DONE_CLR);
+
+    /* Enabling TX DMA rewrote SPI_DMA_CONF and disarmed RX DMA; re-arm it. */
+    if (s_rx_armed && s_rx_buf != NULL) {
+        spi_slv_rxdma_arm(s_rx_buf, s_rx_len);
+    }
+    return STUB_LIB_OK;
+}

--- a/src/target/esp32p4/CMakeLists.txt
+++ b/src/target/esp32p4/CMakeLists.txt
@@ -2,6 +2,7 @@ set(srcs
     src/cache.c
     src/flash.c
     src/mmu.c
+    src/spi.c
     src/uart.c
     src/usb_serial_jtag.c
     src/usb_otg.c

--- a/src/target/esp32p4/include/soc/axi_dma_reg.h
+++ b/src/target/esp32p4/include/soc/axi_dma_reg.h
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+#pragma once
+
+#include <esp-stub-lib/bit_utils.h>
+#include <soc/reg_base.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* AXI-DMA (GDMA) channel-0 subset needed by the SPI-slave DMA path. */
+
+/* Rx (IN) channel 0 */
+#define AXI_DMA_IN_INT_RAW_CH0_REG (DR_REG_AXI_DMA_BASE + 0x0)
+#define AXI_DMA_IN_SUC_EOF_CH0_INT_RAW (BIT(1))
+
+#define AXI_DMA_IN_INT_CLR_CH0_REG (DR_REG_AXI_DMA_BASE + 0xc)
+#define AXI_DMA_IN_SUC_EOF_CH0_INT_CLR (BIT(1))
+#define AXI_DMA_IN_DSCR_ERR_CH0_INT_CLR (BIT(3))
+#define AXI_DMA_INFIFO_L1_UDF_CH0_INT_CLR (BIT(6))
+#define AXI_DMA_INFIFO_L2_UDF_CH0_INT_CLR (BIT(8))
+#define AXI_DMA_INFIFO_L3_UDF_CH0_INT_CLR (BIT(10))
+
+#define AXI_DMA_IN_CONF0_CH0_REG (DR_REG_AXI_DMA_BASE + 0x10)
+#define AXI_DMA_IN_RST_CH0 (BIT(0))
+#define AXI_DMA_INDSCR_BURST_EN_CH0 (BIT(9))
+
+#define AXI_DMA_IN_LINK1_CH0_REG (DR_REG_AXI_DMA_BASE + 0x20)
+#define AXI_DMA_INLINK_STOP_CH0 (BIT(1))
+#define AXI_DMA_INLINK_START_CH0 (BIT(2))
+
+#define AXI_DMA_IN_LINK2_CH0_REG (DR_REG_AXI_DMA_BASE + 0x24)
+
+/* Tx (OUT) channel 0 */
+#define AXI_DMA_OUT_INT_RAW_CH0_REG (DR_REG_AXI_DMA_BASE + 0x138)
+#define AXI_DMA_OUT_DONE_CH0_INT_RAW (BIT(0))
+
+#define AXI_DMA_OUT_INT_CLR_CH0_REG (DR_REG_AXI_DMA_BASE + 0x144)
+#define AXI_DMA_OUT_DONE_CH0_INT_CLR (BIT(0))
+
+#define AXI_DMA_OUT_CONF0_CH0_REG (DR_REG_AXI_DMA_BASE + 0x148)
+#define AXI_DMA_OUT_RST_CH0 (BIT(0))
+#define AXI_DMA_OUT_EOF_MODE_CH0 (BIT(3))
+#define AXI_DMA_OUTDSCR_BURST_EN_CH0 (BIT(10))
+
+#define AXI_DMA_OUT_LINK1_CH0_REG (DR_REG_AXI_DMA_BASE + 0x158)
+#define AXI_DMA_OUTLINK_STOP_CH0 (BIT(0))
+#define AXI_DMA_OUTLINK_START_CH0 (BIT(1))
+
+#define AXI_DMA_OUT_LINK2_CH0_REG (DR_REG_AXI_DMA_BASE + 0x15c)
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/target/esp32p4/include/soc/spi_reg.h
+++ b/src/target/esp32p4/include/soc/spi_reg.h
@@ -1,0 +1,2162 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * GP-SPI2 register macros for ESP32-P4, copied from the esp-idf hw_ver1
+ * spi_reg.h (symbol names match those used by esp32c3/src/spi.c).
+ */
+#pragma once
+
+#include <esp-stub-lib/bit_utils.h>
+#include <esp-stub-lib/soc_utils.h>
+#include <soc/reg_base.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* P4 soc.h lacks the indexed REG_SPI_BASE() helper; only i == 2 (GP-SPI2) used. */
+#ifndef REG_SPI_BASE
+#define REG_SPI_BASE(i) (DR_REG_SPI2_BASE + ((i) - 2) * 0x1000)
+#endif
+
+/** SPI_CMD_REG register
+ *  Command control register
+ */
+#define SPI_CMD_REG(i) (REG_SPI_BASE(i) + 0x0)
+/** SPI_CONF_BITLEN : R/W; bitpos: [17:0]; default: 0;
+ *  Define the APB cycles of  SPI_CONF state. Can be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_CONF_BITLEN    0x0003FFFFU
+#define SPI_CONF_BITLEN_M  (SPI_CONF_BITLEN_V << SPI_CONF_BITLEN_S)
+#define SPI_CONF_BITLEN_V  0x0003FFFFU
+#define SPI_CONF_BITLEN_S  0
+/** SPI_UPDATE : WT; bitpos: [23]; default: 0;
+ *  Set this bit to synchronize SPI registers from APB clock domain into SPI module
+ *  clock domain, which is only used in SPI master mode.
+ */
+#define SPI_UPDATE    (BIT(23))
+#define SPI_UPDATE_M  (SPI_UPDATE_V << SPI_UPDATE_S)
+#define SPI_UPDATE_V  0x00000001U
+#define SPI_UPDATE_S  23
+/** SPI_USR : R/W/SC; bitpos: [24]; default: 0;
+ *  User define command enable.  An operation will be triggered when the bit is set.
+ *  The bit will be cleared once the operation done.1: enable 0: disable. Can not be
+ *  changed by CONF_buf.
+ */
+#define SPI_USR    (BIT(24))
+#define SPI_USR_M  (SPI_USR_V << SPI_USR_S)
+#define SPI_USR_V  0x00000001U
+#define SPI_USR_S  24
+
+/** SPI_ADDR_REG register
+ *  Address value register
+ */
+#define SPI_ADDR_REG(i) (REG_SPI_BASE(i) + 0x4)
+/** SPI_USR_ADDR_VALUE : R/W; bitpos: [31:0]; default: 0;
+ *  Address to slave. Can be configured in CONF state.
+ */
+#define SPI_USR_ADDR_VALUE    0xFFFFFFFFU
+#define SPI_USR_ADDR_VALUE_M  (SPI_USR_ADDR_VALUE_V << SPI_USR_ADDR_VALUE_S)
+#define SPI_USR_ADDR_VALUE_V  0xFFFFFFFFU
+#define SPI_USR_ADDR_VALUE_S  0
+
+/** SPI_CTRL_REG register
+ *  SPI control register
+ */
+#define SPI_CTRL_REG(i) (REG_SPI_BASE(i) + 0x8)
+/** SPI_DUMMY_OUT : R/W; bitpos: [3]; default: 0;
+ *  0: In the dummy phase, the FSPI bus signals are not output. 1: In the dummy phase,
+ *  the FSPI bus signals are output. Can be configured in CONF state.
+ */
+#define SPI_DUMMY_OUT    (BIT(3))
+#define SPI_DUMMY_OUT_M  (SPI_DUMMY_OUT_V << SPI_DUMMY_OUT_S)
+#define SPI_DUMMY_OUT_V  0x00000001U
+#define SPI_DUMMY_OUT_S  3
+/** SPI_FADDR_DUAL : R/W; bitpos: [5]; default: 0;
+ *  Apply 2 signals during addr phase 1:enable 0: disable. Can be configured in CONF
+ *  state.
+ */
+#define SPI_FADDR_DUAL    (BIT(5))
+#define SPI_FADDR_DUAL_M  (SPI_FADDR_DUAL_V << SPI_FADDR_DUAL_S)
+#define SPI_FADDR_DUAL_V  0x00000001U
+#define SPI_FADDR_DUAL_S  5
+/** SPI_FADDR_QUAD : R/W; bitpos: [6]; default: 0;
+ *  Apply 4 signals during addr phase 1:enable 0: disable. Can be configured in CONF
+ *  state.
+ */
+#define SPI_FADDR_QUAD    (BIT(6))
+#define SPI_FADDR_QUAD_M  (SPI_FADDR_QUAD_V << SPI_FADDR_QUAD_S)
+#define SPI_FADDR_QUAD_V  0x00000001U
+#define SPI_FADDR_QUAD_S  6
+/** SPI_FADDR_OCT : R/W; bitpos: [7]; default: 0;
+ *  Apply 8 signals during addr phase 1:enable 0: disable. Can be configured in CONF
+ *  state.
+ */
+//this field is only for GPSPI2
+#define SPI_FADDR_OCT    (BIT(7))
+#define SPI_FADDR_OCT_M  (SPI_FADDR_OCT_V << SPI_FADDR_OCT_S)
+#define SPI_FADDR_OCT_V  0x00000001U
+#define SPI_FADDR_OCT_S  7
+/** SPI_FCMD_DUAL : R/W; bitpos: [8]; default: 0;
+ *  Apply 2 signals during command phase 1:enable 0: disable. Can be configured in CONF
+ *  state.
+ */
+#define SPI_FCMD_DUAL    (BIT(8))
+#define SPI_FCMD_DUAL_M  (SPI_FCMD_DUAL_V << SPI_FCMD_DUAL_S)
+#define SPI_FCMD_DUAL_V  0x00000001U
+#define SPI_FCMD_DUAL_S  8
+/** SPI_FCMD_QUAD : R/W; bitpos: [9]; default: 0;
+ *  Apply 4 signals during command phase 1:enable 0: disable. Can be configured in CONF
+ *  state.
+ */
+#define SPI_FCMD_QUAD    (BIT(9))
+#define SPI_FCMD_QUAD_M  (SPI_FCMD_QUAD_V << SPI_FCMD_QUAD_S)
+#define SPI_FCMD_QUAD_V  0x00000001U
+#define SPI_FCMD_QUAD_S  9
+/** SPI_FCMD_OCT : R/W; bitpos: [10]; default: 0;
+ *  Apply 8 signals during command phase 1:enable 0: disable. Can be configured in CONF
+ *  state.
+ */
+//this field is only for GPSPI2
+#define SPI_FCMD_OCT    (BIT(10))
+#define SPI_FCMD_OCT_M  (SPI_FCMD_OCT_V << SPI_FCMD_OCT_S)
+#define SPI_FCMD_OCT_V  0x00000001U
+#define SPI_FCMD_OCT_S  10
+/** SPI_FREAD_DUAL : R/W; bitpos: [14]; default: 0;
+ *  In the read operations, read-data phase apply 2 signals. 1: enable 0: disable. Can
+ *  be configured in CONF state.
+ */
+#define SPI_FREAD_DUAL    (BIT(14))
+#define SPI_FREAD_DUAL_M  (SPI_FREAD_DUAL_V << SPI_FREAD_DUAL_S)
+#define SPI_FREAD_DUAL_V  0x00000001U
+#define SPI_FREAD_DUAL_S  14
+/** SPI_FREAD_QUAD : R/W; bitpos: [15]; default: 0;
+ *  In the read operations read-data phase apply 4 signals. 1: enable 0: disable.  Can
+ *  be configured in CONF state.
+ */
+#define SPI_FREAD_QUAD    (BIT(15))
+#define SPI_FREAD_QUAD_M  (SPI_FREAD_QUAD_V << SPI_FREAD_QUAD_S)
+#define SPI_FREAD_QUAD_V  0x00000001U
+#define SPI_FREAD_QUAD_S  15
+/** SPI_FREAD_OCT : R/W; bitpos: [16]; default: 0;
+ *  In the read operations read-data phase apply 8 signals. 1: enable 0: disable.  Can
+ *  be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_FREAD_OCT    (BIT(16))
+#define SPI_FREAD_OCT_M  (SPI_FREAD_OCT_V << SPI_FREAD_OCT_S)
+#define SPI_FREAD_OCT_V  0x00000001U
+#define SPI_FREAD_OCT_S  16
+/** SPI_Q_POL : R/W; bitpos: [18]; default: 1;
+ *  The bit is used to set MISO line polarity, 1: high 0, low. Can be configured in
+ *  CONF state.
+ */
+#define SPI_Q_POL    (BIT(18))
+#define SPI_Q_POL_M  (SPI_Q_POL_V << SPI_Q_POL_S)
+#define SPI_Q_POL_V  0x00000001U
+#define SPI_Q_POL_S  18
+/** SPI_D_POL : R/W; bitpos: [19]; default: 1;
+ *  The bit is used to set MOSI line polarity, 1: high 0, low. Can be configured in
+ *  CONF state.
+ */
+#define SPI_D_POL    (BIT(19))
+#define SPI_D_POL_M  (SPI_D_POL_V << SPI_D_POL_S)
+#define SPI_D_POL_V  0x00000001U
+#define SPI_D_POL_S  19
+/** SPI_HOLD_POL : R/W; bitpos: [20]; default: 1;
+ *  SPI_HOLD output value when SPI is idle. 1: output high, 0: output low. Can be
+ *  configured in CONF state.
+ */
+#define SPI_HOLD_POL    (BIT(20))
+#define SPI_HOLD_POL_M  (SPI_HOLD_POL_V << SPI_HOLD_POL_S)
+#define SPI_HOLD_POL_V  0x00000001U
+#define SPI_HOLD_POL_S  20
+/** SPI_WP_POL : R/W; bitpos: [21]; default: 1;
+ *  Write protect signal output when SPI is idle.  1: output high, 0: output low.  Can
+ *  be configured in CONF state.
+ */
+#define SPI_WP_POL    (BIT(21))
+#define SPI_WP_POL_M  (SPI_WP_POL_V << SPI_WP_POL_S)
+#define SPI_WP_POL_V  0x00000001U
+#define SPI_WP_POL_S  21
+/** SPI_RD_BIT_ORDER : R/W; bitpos: [24:23]; default: 0;
+ *  In read-data (MISO) phase 1: LSB first 0: MSB first. Can be configured in CONF
+ *  state.
+ */
+#define SPI_RD_BIT_ORDER    0x00000003U
+#define SPI_RD_BIT_ORDER_M  (SPI_RD_BIT_ORDER_V << SPI_RD_BIT_ORDER_S)
+#define SPI_RD_BIT_ORDER_V  0x00000003U
+#define SPI_RD_BIT_ORDER_S  23
+/** SPI_WR_BIT_ORDER : R/W; bitpos: [26:25]; default: 0;
+ *  In command address write-data (MOSI) phases 1: LSB first 0: MSB first. Can be
+ *  configured in CONF state.
+ */
+#define SPI_WR_BIT_ORDER    0x00000003U
+#define SPI_WR_BIT_ORDER_M  (SPI_WR_BIT_ORDER_V << SPI_WR_BIT_ORDER_S)
+#define SPI_WR_BIT_ORDER_V  0x00000003U
+#define SPI_WR_BIT_ORDER_S  25
+
+/** SPI_CLOCK_REG register
+ *  SPI clock control register
+ */
+#define SPI_CLOCK_REG(i) (REG_SPI_BASE(i) + 0xc)
+/** SPI_CLKCNT_L : R/W; bitpos: [5:0]; default: 3;
+ *  In the master mode it must be equal to spi_clkcnt_N. In the slave mode it must be
+ *  0. Can be configured in CONF state.
+ */
+#define SPI_CLKCNT_L    0x0000003FU
+#define SPI_CLKCNT_L_M  (SPI_CLKCNT_L_V << SPI_CLKCNT_L_S)
+#define SPI_CLKCNT_L_V  0x0000003FU
+#define SPI_CLKCNT_L_S  0
+/** SPI_CLKCNT_H : R/W; bitpos: [11:6]; default: 1;
+ *  In the master mode it must be floor((spi_clkcnt_N+1)/2-1). In the slave mode it
+ *  must be 0. Can be configured in CONF state.
+ */
+#define SPI_CLKCNT_H    0x0000003FU
+#define SPI_CLKCNT_H_M  (SPI_CLKCNT_H_V << SPI_CLKCNT_H_S)
+#define SPI_CLKCNT_H_V  0x0000003FU
+#define SPI_CLKCNT_H_S  6
+/** SPI_CLKCNT_N : R/W; bitpos: [17:12]; default: 3;
+ *  In the master mode it is the divider of spi_clk. So spi_clk frequency is
+ *  system/(spi_clkdiv_pre+1)/(spi_clkcnt_N+1). Can be configured in CONF state.
+ */
+#define SPI_CLKCNT_N    0x0000003FU
+#define SPI_CLKCNT_N_M  (SPI_CLKCNT_N_V << SPI_CLKCNT_N_S)
+#define SPI_CLKCNT_N_V  0x0000003FU
+#define SPI_CLKCNT_N_S  12
+/** SPI_CLKDIV_PRE : R/W; bitpos: [21:18]; default: 0;
+ *  In the master mode it is pre-divider of spi_clk.  Can be configured in CONF state.
+ */
+#define SPI_CLKDIV_PRE    0x0000000FU
+#define SPI_CLKDIV_PRE_M  (SPI_CLKDIV_PRE_V << SPI_CLKDIV_PRE_S)
+#define SPI_CLKDIV_PRE_V  0x0000000FU
+#define SPI_CLKDIV_PRE_S  18
+/** SPI_CLK_EQU_SYSCLK : R/W; bitpos: [31]; default: 1;
+ *  In the master mode 1: spi_clk is equal to system 0: spi_clk is divided from system
+ *  clock. Can be configured in CONF state.
+ */
+#define SPI_CLK_EQU_SYSCLK    (BIT(31))
+#define SPI_CLK_EQU_SYSCLK_M  (SPI_CLK_EQU_SYSCLK_V << SPI_CLK_EQU_SYSCLK_S)
+#define SPI_CLK_EQU_SYSCLK_V  0x00000001U
+#define SPI_CLK_EQU_SYSCLK_S  31
+
+/** SPI_USER_REG register
+ *  SPI USER control register
+ */
+#define SPI_USER_REG(i) (REG_SPI_BASE(i) + 0x10)
+/** SPI_DOUTDIN : R/W; bitpos: [0]; default: 0;
+ *  Set the bit to enable full duplex communication. 1: enable 0: disable. Can be
+ *  configured in CONF state.
+ */
+#define SPI_DOUTDIN    (BIT(0))
+#define SPI_DOUTDIN_M  (SPI_DOUTDIN_V << SPI_DOUTDIN_S)
+#define SPI_DOUTDIN_V  0x00000001U
+#define SPI_DOUTDIN_S  0
+/** SPI_QPI_MODE : R/W/SS/SC; bitpos: [3]; default: 0;
+ *  Both for master mode and slave mode. 1: spi controller is in QPI mode. 0: others.
+ *  Can be configured in CONF state.
+ */
+#define SPI_QPI_MODE    (BIT(3))
+#define SPI_QPI_MODE_M  (SPI_QPI_MODE_V << SPI_QPI_MODE_S)
+#define SPI_QPI_MODE_V  0x00000001U
+#define SPI_QPI_MODE_S  3
+/** SPI_OPI_MODE : R/W; bitpos: [4]; default: 0;
+ *  Just for master mode. 1: spi controller is in OPI mode (all in 8-b-m). 0: others.
+ *  Can be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_OPI_MODE    (BIT(4))
+#define SPI_OPI_MODE_M  (SPI_OPI_MODE_V << SPI_OPI_MODE_S)
+#define SPI_OPI_MODE_V  0x00000001U
+#define SPI_OPI_MODE_S  4
+/** SPI_TSCK_I_EDGE : R/W; bitpos: [5]; default: 0;
+ *  In the slave mode, this bit can be used to change the polarity of tsck. 0: tsck =
+ *  spi_ck_i. 1:tsck = !spi_ck_i.
+ */
+#define SPI_TSCK_I_EDGE    (BIT(5))
+#define SPI_TSCK_I_EDGE_M  (SPI_TSCK_I_EDGE_V << SPI_TSCK_I_EDGE_S)
+#define SPI_TSCK_I_EDGE_V  0x00000001U
+#define SPI_TSCK_I_EDGE_S  5
+/** SPI_CS_HOLD : R/W; bitpos: [6]; default: 1;
+ *  spi cs keep low when spi is in  done  phase. 1: enable 0: disable. Can be
+ *  configured in CONF state.
+ */
+#define SPI_CS_HOLD    (BIT(6))
+#define SPI_CS_HOLD_M  (SPI_CS_HOLD_V << SPI_CS_HOLD_S)
+#define SPI_CS_HOLD_V  0x00000001U
+#define SPI_CS_HOLD_S  6
+/** SPI_CS_SETUP : R/W; bitpos: [7]; default: 1;
+ *  spi cs is enable when spi is in  prepare  phase. 1: enable 0: disable. Can be
+ *  configured in CONF state.
+ */
+#define SPI_CS_SETUP    (BIT(7))
+#define SPI_CS_SETUP_M  (SPI_CS_SETUP_V << SPI_CS_SETUP_S)
+#define SPI_CS_SETUP_V  0x00000001U
+#define SPI_CS_SETUP_S  7
+/** SPI_RSCK_I_EDGE : R/W; bitpos: [8]; default: 0;
+ *  In the slave mode, this bit can be used to change the polarity of rsck. 0: rsck =
+ *  !spi_ck_i. 1:rsck = spi_ck_i.
+ */
+#define SPI_RSCK_I_EDGE    (BIT(8))
+#define SPI_RSCK_I_EDGE_M  (SPI_RSCK_I_EDGE_V << SPI_RSCK_I_EDGE_S)
+#define SPI_RSCK_I_EDGE_V  0x00000001U
+#define SPI_RSCK_I_EDGE_S  8
+/** SPI_CK_OUT_EDGE : R/W; bitpos: [9]; default: 0;
+ *  the bit combined with spi_mosi_delay_mode bits to set mosi signal delay mode. Can
+ *  be configured in CONF state.
+ */
+#define SPI_CK_OUT_EDGE    (BIT(9))
+#define SPI_CK_OUT_EDGE_M  (SPI_CK_OUT_EDGE_V << SPI_CK_OUT_EDGE_S)
+#define SPI_CK_OUT_EDGE_V  0x00000001U
+#define SPI_CK_OUT_EDGE_S  9
+/** SPI_FWRITE_DUAL : R/W; bitpos: [12]; default: 0;
+ *  In the write operations read-data phase apply 2 signals. Can be configured in CONF
+ *  state.
+ */
+#define SPI_FWRITE_DUAL    (BIT(12))
+#define SPI_FWRITE_DUAL_M  (SPI_FWRITE_DUAL_V << SPI_FWRITE_DUAL_S)
+#define SPI_FWRITE_DUAL_V  0x00000001U
+#define SPI_FWRITE_DUAL_S  12
+/** SPI_FWRITE_QUAD : R/W; bitpos: [13]; default: 0;
+ *  In the write operations read-data phase apply 4 signals. Can be configured in CONF
+ *  state.
+ */
+#define SPI_FWRITE_QUAD    (BIT(13))
+#define SPI_FWRITE_QUAD_M  (SPI_FWRITE_QUAD_V << SPI_FWRITE_QUAD_S)
+#define SPI_FWRITE_QUAD_V  0x00000001U
+#define SPI_FWRITE_QUAD_S  13
+/** SPI_FWRITE_OCT : R/W; bitpos: [14]; default: 0;
+ *  In the write operations read-data phase apply 8 signals. Can be configured in CONF
+ *  state.
+ */
+//this field is only for GPSPI2
+#define SPI_FWRITE_OCT    (BIT(14))
+#define SPI_FWRITE_OCT_M  (SPI_FWRITE_OCT_V << SPI_FWRITE_OCT_S)
+#define SPI_FWRITE_OCT_V  0x00000001U
+#define SPI_FWRITE_OCT_S  14
+/** SPI_USR_CONF_NXT : R/W; bitpos: [15]; default: 0;
+ *  1: Enable the DMA CONF phase of next seg-trans operation, which means seg-trans
+ *  will continue. 0: The seg-trans will end after the current SPI seg-trans or this is
+ *  not seg-trans mode. Can be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_USR_CONF_NXT    (BIT(15))
+#define SPI_USR_CONF_NXT_M  (SPI_USR_CONF_NXT_V << SPI_USR_CONF_NXT_S)
+#define SPI_USR_CONF_NXT_V  0x00000001U
+#define SPI_USR_CONF_NXT_S  15
+/** SPI_SIO : R/W; bitpos: [17]; default: 0;
+ *  Set the bit to enable 3-line half duplex communication mosi and miso signals share
+ *  the same pin. 1: enable 0: disable. Can be configured in CONF state.
+ */
+#define SPI_SIO    (BIT(17))
+#define SPI_SIO_M  (SPI_SIO_V << SPI_SIO_S)
+#define SPI_SIO_V  0x00000001U
+#define SPI_SIO_S  17
+/** SPI_USR_MISO_HIGHPART : R/W; bitpos: [24]; default: 0;
+ *  read-data phase only access to high-part of the buffer spi_w8~spi_w15. 1: enable 0:
+ *  disable. Can be configured in CONF state.
+ */
+#define SPI_USR_MISO_HIGHPART    (BIT(24))
+#define SPI_USR_MISO_HIGHPART_M  (SPI_USR_MISO_HIGHPART_V << SPI_USR_MISO_HIGHPART_S)
+#define SPI_USR_MISO_HIGHPART_V  0x00000001U
+#define SPI_USR_MISO_HIGHPART_S  24
+/** SPI_USR_MOSI_HIGHPART : R/W; bitpos: [25]; default: 0;
+ *  write-data phase only access to high-part of the buffer spi_w8~spi_w15. 1: enable
+ *  0: disable.  Can be configured in CONF state.
+ */
+#define SPI_USR_MOSI_HIGHPART    (BIT(25))
+#define SPI_USR_MOSI_HIGHPART_M  (SPI_USR_MOSI_HIGHPART_V << SPI_USR_MOSI_HIGHPART_S)
+#define SPI_USR_MOSI_HIGHPART_V  0x00000001U
+#define SPI_USR_MOSI_HIGHPART_S  25
+/** SPI_USR_DUMMY_IDLE : R/W; bitpos: [26]; default: 0;
+ *  spi clock is disable in dummy phase when the bit is enable. Can be configured in
+ *  CONF state.
+ */
+#define SPI_USR_DUMMY_IDLE    (BIT(26))
+#define SPI_USR_DUMMY_IDLE_M  (SPI_USR_DUMMY_IDLE_V << SPI_USR_DUMMY_IDLE_S)
+#define SPI_USR_DUMMY_IDLE_V  0x00000001U
+#define SPI_USR_DUMMY_IDLE_S  26
+/** SPI_USR_MOSI : R/W; bitpos: [27]; default: 0;
+ *  This bit enable the write-data phase of an operation. Can be configured in CONF
+ *  state.
+ */
+#define SPI_USR_MOSI    (BIT(27))
+#define SPI_USR_MOSI_M  (SPI_USR_MOSI_V << SPI_USR_MOSI_S)
+#define SPI_USR_MOSI_V  0x00000001U
+#define SPI_USR_MOSI_S  27
+/** SPI_USR_MISO : R/W; bitpos: [28]; default: 0;
+ *  This bit enable the read-data phase of an operation. Can be configured in CONF
+ *  state.
+ */
+#define SPI_USR_MISO    (BIT(28))
+#define SPI_USR_MISO_M  (SPI_USR_MISO_V << SPI_USR_MISO_S)
+#define SPI_USR_MISO_V  0x00000001U
+#define SPI_USR_MISO_S  28
+/** SPI_USR_DUMMY : R/W; bitpos: [29]; default: 0;
+ *  This bit enable the dummy phase of an operation. Can be configured in CONF state.
+ */
+#define SPI_USR_DUMMY    (BIT(29))
+#define SPI_USR_DUMMY_M  (SPI_USR_DUMMY_V << SPI_USR_DUMMY_S)
+#define SPI_USR_DUMMY_V  0x00000001U
+#define SPI_USR_DUMMY_S  29
+/** SPI_USR_ADDR : R/W; bitpos: [30]; default: 0;
+ *  This bit enable the address phase of an operation. Can be configured in CONF state.
+ */
+#define SPI_USR_ADDR    (BIT(30))
+#define SPI_USR_ADDR_M  (SPI_USR_ADDR_V << SPI_USR_ADDR_S)
+#define SPI_USR_ADDR_V  0x00000001U
+#define SPI_USR_ADDR_S  30
+/** SPI_USR_COMMAND : R/W; bitpos: [31]; default: 1;
+ *  This bit enable the command phase of an operation. Can be configured in CONF state.
+ */
+#define SPI_USR_COMMAND    (BIT(31))
+#define SPI_USR_COMMAND_M  (SPI_USR_COMMAND_V << SPI_USR_COMMAND_S)
+#define SPI_USR_COMMAND_V  0x00000001U
+#define SPI_USR_COMMAND_S  31
+
+/** SPI_USER1_REG register
+ *  SPI USER control register 1
+ */
+#define SPI_USER1_REG(i) (REG_SPI_BASE(i) + 0x14)
+/** SPI_USR_DUMMY_CYCLELEN : R/W; bitpos: [7:0]; default: 7;
+ *  The length in spi_clk cycles of dummy phase. The register value shall be
+ *  (cycle_num-1). Can be configured in CONF state.
+ */
+#define SPI_USR_DUMMY_CYCLELEN    0x000000FFU
+#define SPI_USR_DUMMY_CYCLELEN_M  (SPI_USR_DUMMY_CYCLELEN_V << SPI_USR_DUMMY_CYCLELEN_S)
+#define SPI_USR_DUMMY_CYCLELEN_V  0x000000FFU
+#define SPI_USR_DUMMY_CYCLELEN_S  0
+/** SPI_MST_WFULL_ERR_END_EN : R/W; bitpos: [16]; default: 1;
+ *  1: SPI transfer is ended when SPI RX AFIFO wfull error is valid in GP-SPI master
+ *  FD/HD-mode. 0: SPI transfer is not ended when SPI RX AFIFO wfull error is valid in
+ *  GP-SPI master FD/HD-mode.
+ */
+#define SPI_MST_WFULL_ERR_END_EN    (BIT(16))
+#define SPI_MST_WFULL_ERR_END_EN_M  (SPI_MST_WFULL_ERR_END_EN_V << SPI_MST_WFULL_ERR_END_EN_S)
+#define SPI_MST_WFULL_ERR_END_EN_V  0x00000001U
+#define SPI_MST_WFULL_ERR_END_EN_S  16
+/** SPI_CS_SETUP_TIME : R/W; bitpos: [21:17]; default: 0;
+ *  (cycles+1) of prepare phase by spi clock this bits are combined with spi_cs_setup
+ *  bit. Can be configured in CONF state.
+ */
+#define SPI_CS_SETUP_TIME    0x0000001FU
+#define SPI_CS_SETUP_TIME_M  (SPI_CS_SETUP_TIME_V << SPI_CS_SETUP_TIME_S)
+#define SPI_CS_SETUP_TIME_V  0x0000001FU
+#define SPI_CS_SETUP_TIME_S  17
+/** SPI_CS_HOLD_TIME : R/W; bitpos: [26:22]; default: 1;
+ *  delay cycles of cs pin by spi clock this bits are combined with spi_cs_hold bit.
+ *  Can be configured in CONF state.
+ */
+#define SPI_CS_HOLD_TIME    0x0000001FU
+#define SPI_CS_HOLD_TIME_M  (SPI_CS_HOLD_TIME_V << SPI_CS_HOLD_TIME_S)
+#define SPI_CS_HOLD_TIME_V  0x0000001FU
+#define SPI_CS_HOLD_TIME_S  22
+/** SPI_USR_ADDR_BITLEN : R/W; bitpos: [31:27]; default: 23;
+ *  The length in bits of address phase. The register value shall be (bit_num-1). Can
+ *  be configured in CONF state.
+ */
+#define SPI_USR_ADDR_BITLEN    0x0000001FU
+#define SPI_USR_ADDR_BITLEN_M  (SPI_USR_ADDR_BITLEN_V << SPI_USR_ADDR_BITLEN_S)
+#define SPI_USR_ADDR_BITLEN_V  0x0000001FU
+#define SPI_USR_ADDR_BITLEN_S  27
+
+/** SPI_USER2_REG register
+ *  SPI USER control register 2
+ */
+#define SPI_USER2_REG(i) (REG_SPI_BASE(i) + 0x18)
+/** SPI_USR_COMMAND_VALUE : R/W; bitpos: [15:0]; default: 0;
+ *  The value of  command. Can be configured in CONF state.
+ */
+#define SPI_USR_COMMAND_VALUE    0x0000FFFFU
+#define SPI_USR_COMMAND_VALUE_M  (SPI_USR_COMMAND_VALUE_V << SPI_USR_COMMAND_VALUE_S)
+#define SPI_USR_COMMAND_VALUE_V  0x0000FFFFU
+#define SPI_USR_COMMAND_VALUE_S  0
+/** SPI_MST_REMPTY_ERR_END_EN : R/W; bitpos: [27]; default: 1;
+ *  1: SPI transfer is ended when SPI TX AFIFO read empty error is valid in GP-SPI
+ *  master FD/HD-mode. 0: SPI transfer is not ended when SPI TX AFIFO read empty error
+ *  is valid in GP-SPI master FD/HD-mode.
+ */
+#define SPI_MST_REMPTY_ERR_END_EN    (BIT(27))
+#define SPI_MST_REMPTY_ERR_END_EN_M  (SPI_MST_REMPTY_ERR_END_EN_V << SPI_MST_REMPTY_ERR_END_EN_S)
+#define SPI_MST_REMPTY_ERR_END_EN_V  0x00000001U
+#define SPI_MST_REMPTY_ERR_END_EN_S  27
+/** SPI_USR_COMMAND_BITLEN : R/W; bitpos: [31:28]; default: 7;
+ *  The length in bits of command phase. The register value shall be (bit_num-1). Can
+ *  be configured in CONF state.
+ */
+#define SPI_USR_COMMAND_BITLEN    0x0000000FU
+#define SPI_USR_COMMAND_BITLEN_M  (SPI_USR_COMMAND_BITLEN_V << SPI_USR_COMMAND_BITLEN_S)
+#define SPI_USR_COMMAND_BITLEN_V  0x0000000FU
+#define SPI_USR_COMMAND_BITLEN_S  28
+
+/** SPI_MS_DLEN_REG register
+ *  SPI data bit length control register
+ */
+#define SPI_MS_DLEN_REG(i) (REG_SPI_BASE(i) + 0x1c)
+/** SPI_MS_DATA_BITLEN : R/W; bitpos: [17:0]; default: 0;
+ *  The value of these bits is the configured SPI transmission data bit length in
+ *  master mode DMA controlled transfer or CPU controlled transfer. The value is also
+ *  the configured bit length in slave mode DMA RX controlled transfer. The register
+ *  value shall be (bit_num-1). Can be configured in CONF state.
+ */
+#define SPI_MS_DATA_BITLEN    0x0003FFFFU
+#define SPI_MS_DATA_BITLEN_M  (SPI_MS_DATA_BITLEN_V << SPI_MS_DATA_BITLEN_S)
+#define SPI_MS_DATA_BITLEN_V  0x0003FFFFU
+#define SPI_MS_DATA_BITLEN_S  0
+
+/** SPI_MISC_REG register
+ *  SPI misc register
+ */
+#define SPI_MISC_REG(i) (REG_SPI_BASE(i) + 0x20)
+/** SPI_CS0_DIS : R/W; bitpos: [0]; default: 0;
+ *  SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Can
+ *  be configured in CONF state.
+ */
+#define SPI_CS0_DIS    (BIT(0))
+#define SPI_CS0_DIS_M  (SPI_CS0_DIS_V << SPI_CS0_DIS_S)
+#define SPI_CS0_DIS_V  0x00000001U
+#define SPI_CS0_DIS_S  0
+/** SPI_CS1_DIS : R/W; bitpos: [1]; default: 1;
+ *  SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Can
+ *  be configured in CONF state.
+ */
+#define SPI_CS1_DIS    (BIT(1))
+#define SPI_CS1_DIS_M  (SPI_CS1_DIS_V << SPI_CS1_DIS_S)
+#define SPI_CS1_DIS_V  0x00000001U
+#define SPI_CS1_DIS_S  1
+/** SPI_CS2_DIS : R/W; bitpos: [2]; default: 1;
+ *  SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Can
+ *  be configured in CONF state.
+ */
+#define SPI_CS2_DIS    (BIT(2))
+#define SPI_CS2_DIS_M  (SPI_CS2_DIS_V << SPI_CS2_DIS_S)
+#define SPI_CS2_DIS_V  0x00000001U
+#define SPI_CS2_DIS_S  2
+/** SPI_CS3_DIS : R/W; bitpos: [3]; default: 1;
+ *  SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Can
+ *  be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_CS3_DIS    (BIT(3))
+#define SPI_CS3_DIS_M  (SPI_CS3_DIS_V << SPI_CS3_DIS_S)
+#define SPI_CS3_DIS_V  0x00000001U
+#define SPI_CS3_DIS_S  3
+/** SPI_CS4_DIS : R/W; bitpos: [4]; default: 1;
+ *  SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Can
+ *  be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_CS4_DIS    (BIT(4))
+#define SPI_CS4_DIS_M  (SPI_CS4_DIS_V << SPI_CS4_DIS_S)
+#define SPI_CS4_DIS_V  0x00000001U
+#define SPI_CS4_DIS_S  4
+/** SPI_CS5_DIS : R/W; bitpos: [5]; default: 1;
+ *  SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n pin. Can
+ *  be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_CS5_DIS    (BIT(5))
+#define SPI_CS5_DIS_M  (SPI_CS5_DIS_V << SPI_CS5_DIS_S)
+#define SPI_CS5_DIS_V  0x00000001U
+#define SPI_CS5_DIS_S  5
+/** SPI_CK_DIS : R/W; bitpos: [6]; default: 0;
+ *  1: spi clk out disable,  0: spi clk out enable. Can be configured in CONF state.
+ */
+#define SPI_CK_DIS    (BIT(6))
+#define SPI_CK_DIS_M  (SPI_CK_DIS_V << SPI_CK_DIS_S)
+#define SPI_CK_DIS_V  0x00000001U
+#define SPI_CK_DIS_S  6
+/** SPI_MASTER_CS_POL : R/W; bitpos: [12:7]; default: 0;
+ *  In the master mode the bits are the polarity of spi cs line, the value is
+ *  equivalent to spi_cs ^ spi_master_cs_pol. Can be configured in CONF state.
+ */
+//This field for GPSPI3 is only 3-bit-width
+#define SPI_MASTER_CS_POL    0x0000003FU
+#define SPI_MASTER_CS_POL_M  (SPI_MASTER_CS_POL_V << SPI_MASTER_CS_POL_S)
+#define SPI_MASTER_CS_POL_V  0x0000003FU
+#define SPI_MASTER_CS_POL_S  7
+/** SPI_CLK_DATA_DTR_EN : R/W; bitpos: [16]; default: 0;
+ *  1: SPI master DTR mode is applied to SPI clk, data and spi_dqs.  0: SPI master DTR
+ *  mode is  only applied to spi_dqs. This bit should be used with bit 17/18/19.
+ */
+//this field is only for GPSPI2
+#define SPI_CLK_DATA_DTR_EN    (BIT(16))
+#define SPI_CLK_DATA_DTR_EN_M  (SPI_CLK_DATA_DTR_EN_V << SPI_CLK_DATA_DTR_EN_S)
+#define SPI_CLK_DATA_DTR_EN_V  0x00000001U
+#define SPI_CLK_DATA_DTR_EN_S  16
+/** SPI_DATA_DTR_EN : R/W; bitpos: [17]; default: 0;
+ *  1: SPI clk and data of SPI_DOUT and SPI_DIN state are in DTR mode, including master
+ *  1/2/4/8-bm.  0:  SPI clk and data of SPI_DOUT and SPI_DIN state are in STR mode.
+ *  Can be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_DATA_DTR_EN    (BIT(17))
+#define SPI_DATA_DTR_EN_M  (SPI_DATA_DTR_EN_V << SPI_DATA_DTR_EN_S)
+#define SPI_DATA_DTR_EN_V  0x00000001U
+#define SPI_DATA_DTR_EN_S  17
+/** SPI_ADDR_DTR_EN : R/W; bitpos: [18]; default: 0;
+ *  1: SPI clk and data of SPI_SEND_ADDR state are in DTR mode, including master
+ *  1/2/4/8-bm.  0:  SPI clk and data of SPI_SEND_ADDR state are in STR mode. Can be
+ *  configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_ADDR_DTR_EN    (BIT(18))
+#define SPI_ADDR_DTR_EN_M  (SPI_ADDR_DTR_EN_V << SPI_ADDR_DTR_EN_S)
+#define SPI_ADDR_DTR_EN_V  0x00000001U
+#define SPI_ADDR_DTR_EN_S  18
+/** SPI_CMD_DTR_EN : R/W; bitpos: [19]; default: 0;
+ *  1: SPI clk and data of SPI_SEND_CMD state are in DTR mode, including master
+ *  1/2/4/8-bm. 0:  SPI clk and data of SPI_SEND_CMD state are in STR mode. Can be
+ *  configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_CMD_DTR_EN    (BIT(19))
+#define SPI_CMD_DTR_EN_M  (SPI_CMD_DTR_EN_V << SPI_CMD_DTR_EN_S)
+#define SPI_CMD_DTR_EN_V  0x00000001U
+#define SPI_CMD_DTR_EN_S  19
+/** SPI_SLAVE_CS_POL : R/W; bitpos: [23]; default: 0;
+ *  spi slave input cs polarity select. 1: inv  0: not change. Can be configured in
+ *  CONF state.
+ */
+#define SPI_SLAVE_CS_POL    (BIT(23))
+#define SPI_SLAVE_CS_POL_M  (SPI_SLAVE_CS_POL_V << SPI_SLAVE_CS_POL_S)
+#define SPI_SLAVE_CS_POL_V  0x00000001U
+#define SPI_SLAVE_CS_POL_S  23
+/** SPI_DQS_IDLE_EDGE : R/W; bitpos: [24]; default: 0;
+ *  The default value of spi_dqs. Can be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_DQS_IDLE_EDGE    (BIT(24))
+#define SPI_DQS_IDLE_EDGE_M  (SPI_DQS_IDLE_EDGE_V << SPI_DQS_IDLE_EDGE_S)
+#define SPI_DQS_IDLE_EDGE_V  0x00000001U
+#define SPI_DQS_IDLE_EDGE_S  24
+/** SPI_CK_IDLE_EDGE : R/W; bitpos: [29]; default: 0;
+ *  1: spi clk line is high when idle     0: spi clk line is low when idle. Can be
+ *  configured in CONF state.
+ */
+#define SPI_CK_IDLE_EDGE    (BIT(29))
+#define SPI_CK_IDLE_EDGE_M  (SPI_CK_IDLE_EDGE_V << SPI_CK_IDLE_EDGE_S)
+#define SPI_CK_IDLE_EDGE_V  0x00000001U
+#define SPI_CK_IDLE_EDGE_S  29
+/** SPI_CS_KEEP_ACTIVE : R/W; bitpos: [30]; default: 0;
+ *  spi cs line keep low when the bit is set. Can be configured in CONF state.
+ */
+#define SPI_CS_KEEP_ACTIVE    (BIT(30))
+#define SPI_CS_KEEP_ACTIVE_M  (SPI_CS_KEEP_ACTIVE_V << SPI_CS_KEEP_ACTIVE_S)
+#define SPI_CS_KEEP_ACTIVE_V  0x00000001U
+#define SPI_CS_KEEP_ACTIVE_S  30
+/** SPI_QUAD_DIN_PIN_SWAP : R/W; bitpos: [31]; default: 0;
+ *  1: SPI quad input swap enable, swap FSPID with FSPIQ, swap FSPIWP with FSPIHD. 0:
+ *  spi quad input swap disable. Can be configured in CONF state.
+ */
+#define SPI_QUAD_DIN_PIN_SWAP    (BIT(31))
+#define SPI_QUAD_DIN_PIN_SWAP_M  (SPI_QUAD_DIN_PIN_SWAP_V << SPI_QUAD_DIN_PIN_SWAP_S)
+#define SPI_QUAD_DIN_PIN_SWAP_V  0x00000001U
+#define SPI_QUAD_DIN_PIN_SWAP_S  31
+
+/** SPI_DIN_MODE_REG register
+ *  SPI input delay mode configuration
+ */
+#define SPI_DIN_MODE_REG(i) (REG_SPI_BASE(i) + 0x24)
+/** SPI_DIN0_MODE : R/W; bitpos: [1:0]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: input without delayed,
+ *  1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3: input
+ *  with the spi_clk. Can be configured in CONF state.
+ */
+#define SPI_DIN0_MODE    0x00000003U
+#define SPI_DIN0_MODE_M  (SPI_DIN0_MODE_V << SPI_DIN0_MODE_S)
+#define SPI_DIN0_MODE_V  0x00000003U
+#define SPI_DIN0_MODE_S  0
+/** SPI_DIN1_MODE : R/W; bitpos: [3:2]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: input without delayed,
+ *  1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3: input
+ *  with the spi_clk. Can be configured in CONF state.
+ */
+#define SPI_DIN1_MODE    0x00000003U
+#define SPI_DIN1_MODE_M  (SPI_DIN1_MODE_V << SPI_DIN1_MODE_S)
+#define SPI_DIN1_MODE_V  0x00000003U
+#define SPI_DIN1_MODE_S  2
+/** SPI_DIN2_MODE : R/W; bitpos: [5:4]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: input without delayed,
+ *  1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3: input
+ *  with the spi_clk. Can be configured in CONF state.
+ */
+#define SPI_DIN2_MODE    0x00000003U
+#define SPI_DIN2_MODE_M  (SPI_DIN2_MODE_V << SPI_DIN2_MODE_S)
+#define SPI_DIN2_MODE_V  0x00000003U
+#define SPI_DIN2_MODE_S  4
+/** SPI_DIN3_MODE : R/W; bitpos: [7:6]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: input without delayed,
+ *  1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3: input
+ *  with the spi_clk. Can be configured in CONF state.
+ */
+#define SPI_DIN3_MODE    0x00000003U
+#define SPI_DIN3_MODE_M  (SPI_DIN3_MODE_V << SPI_DIN3_MODE_S)
+#define SPI_DIN3_MODE_V  0x00000003U
+#define SPI_DIN3_MODE_S  6
+/** SPI_DIN4_MODE : R/W; bitpos: [9:8]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: input without delayed,
+ *  1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3: input
+ *  with the spi_clk. Can be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_DIN4_MODE    0x00000003U
+#define SPI_DIN4_MODE_M  (SPI_DIN4_MODE_V << SPI_DIN4_MODE_S)
+#define SPI_DIN4_MODE_V  0x00000003U
+#define SPI_DIN4_MODE_S  8
+/** SPI_DIN5_MODE : R/W; bitpos: [11:10]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: input without delayed,
+ *  1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3: input
+ *  with the spi_clk. Can be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_DIN5_MODE    0x00000003U
+#define SPI_DIN5_MODE_M  (SPI_DIN5_MODE_V << SPI_DIN5_MODE_S)
+#define SPI_DIN5_MODE_V  0x00000003U
+#define SPI_DIN5_MODE_S  10
+/** SPI_DIN6_MODE : R/W; bitpos: [13:12]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: input without delayed,
+ *  1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3: input
+ *  with the spi_clk. Can be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_DIN6_MODE    0x00000003U
+#define SPI_DIN6_MODE_M  (SPI_DIN6_MODE_V << SPI_DIN6_MODE_S)
+#define SPI_DIN6_MODE_V  0x00000003U
+#define SPI_DIN6_MODE_S  12
+/** SPI_DIN7_MODE : R/W; bitpos: [15:14]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: input without delayed,
+ *  1: input with the posedge of clk_apb,2 input with the negedge of clk_apb, 3: input
+ *  with the spi_clk. Can be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_DIN7_MODE    0x00000003U
+#define SPI_DIN7_MODE_M  (SPI_DIN7_MODE_V << SPI_DIN7_MODE_S)
+#define SPI_DIN7_MODE_V  0x00000003U
+#define SPI_DIN7_MODE_S  14
+/** SPI_TIMING_HCLK_ACTIVE : R/W; bitpos: [16]; default: 0;
+ *  1:enable hclk in SPI input timing module.  0: disable it. Can be configured in CONF
+ *  state.
+ */
+#define SPI_TIMING_HCLK_ACTIVE    (BIT(16))
+#define SPI_TIMING_HCLK_ACTIVE_M  (SPI_TIMING_HCLK_ACTIVE_V << SPI_TIMING_HCLK_ACTIVE_S)
+#define SPI_TIMING_HCLK_ACTIVE_V  0x00000001U
+#define SPI_TIMING_HCLK_ACTIVE_S  16
+
+/** SPI_DIN_NUM_REG register
+ *  SPI input delay number configuration
+ */
+#define SPI_DIN_NUM_REG(i) (REG_SPI_BASE(i) + 0x28)
+/** SPI_DIN0_NUM : R/W; bitpos: [1:0]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...  Can be configured in CONF state.
+ */
+#define SPI_DIN0_NUM    0x00000003U
+#define SPI_DIN0_NUM_M  (SPI_DIN0_NUM_V << SPI_DIN0_NUM_S)
+#define SPI_DIN0_NUM_V  0x00000003U
+#define SPI_DIN0_NUM_S  0
+/** SPI_DIN1_NUM : R/W; bitpos: [3:2]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...  Can be configured in CONF state.
+ */
+#define SPI_DIN1_NUM    0x00000003U
+#define SPI_DIN1_NUM_M  (SPI_DIN1_NUM_V << SPI_DIN1_NUM_S)
+#define SPI_DIN1_NUM_V  0x00000003U
+#define SPI_DIN1_NUM_S  2
+/** SPI_DIN2_NUM : R/W; bitpos: [5:4]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...  Can be configured in CONF state.
+ */
+#define SPI_DIN2_NUM    0x00000003U
+#define SPI_DIN2_NUM_M  (SPI_DIN2_NUM_V << SPI_DIN2_NUM_S)
+#define SPI_DIN2_NUM_V  0x00000003U
+#define SPI_DIN2_NUM_S  4
+/** SPI_DIN3_NUM : R/W; bitpos: [7:6]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...  Can be configured in CONF state.
+ */
+#define SPI_DIN3_NUM    0x00000003U
+#define SPI_DIN3_NUM_M  (SPI_DIN3_NUM_V << SPI_DIN3_NUM_S)
+#define SPI_DIN3_NUM_V  0x00000003U
+#define SPI_DIN3_NUM_S  6
+/** SPI_DIN4_NUM : R/W; bitpos: [9:8]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...  Can be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_DIN4_NUM    0x00000003U
+#define SPI_DIN4_NUM_M  (SPI_DIN4_NUM_V << SPI_DIN4_NUM_S)
+#define SPI_DIN4_NUM_V  0x00000003U
+#define SPI_DIN4_NUM_S  8
+/** SPI_DIN5_NUM : R/W; bitpos: [11:10]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...  Can be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_DIN5_NUM    0x00000003U
+#define SPI_DIN5_NUM_M  (SPI_DIN5_NUM_V << SPI_DIN5_NUM_S)
+#define SPI_DIN5_NUM_V  0x00000003U
+#define SPI_DIN5_NUM_S  10
+/** SPI_DIN6_NUM : R/W; bitpos: [13:12]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...  Can be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_DIN6_NUM    0x00000003U
+#define SPI_DIN6_NUM_M  (SPI_DIN6_NUM_V << SPI_DIN6_NUM_S)
+#define SPI_DIN6_NUM_V  0x00000003U
+#define SPI_DIN6_NUM_S  12
+/** SPI_DIN7_NUM : R/W; bitpos: [15:14]; default: 0;
+ *  the input signals are delayed by SPI module clock cycles, 0: delayed by 1 cycle, 1:
+ *  delayed by 2 cycles,...  Can be configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_DIN7_NUM    0x00000003U
+#define SPI_DIN7_NUM_M  (SPI_DIN7_NUM_V << SPI_DIN7_NUM_S)
+#define SPI_DIN7_NUM_V  0x00000003U
+#define SPI_DIN7_NUM_S  14
+
+/** SPI_DOUT_MODE_REG register
+ *  SPI output delay mode configuration
+ */
+#define SPI_DOUT_MODE_REG(i) (REG_SPI_BASE(i) + 0x2c)
+/** SPI_DOUT0_MODE : R/W; bitpos: [0]; default: 0;
+ *  The output signal $n is delayed by the SPI module clock, 0: output without delayed,
+ *  1: output delay for a SPI module clock cycle at its negative edge. Can be
+ *  configured in CONF state.
+ */
+#define SPI_DOUT0_MODE    (BIT(0))
+#define SPI_DOUT0_MODE_M  (SPI_DOUT0_MODE_V << SPI_DOUT0_MODE_S)
+#define SPI_DOUT0_MODE_V  0x00000001U
+#define SPI_DOUT0_MODE_S  0
+/** SPI_DOUT1_MODE : R/W; bitpos: [1]; default: 0;
+ *  The output signal $n is delayed by the SPI module clock, 0: output without delayed,
+ *  1: output delay for a SPI module clock cycle at its negative edge. Can be
+ *  configured in CONF state.
+ */
+#define SPI_DOUT1_MODE    (BIT(1))
+#define SPI_DOUT1_MODE_M  (SPI_DOUT1_MODE_V << SPI_DOUT1_MODE_S)
+#define SPI_DOUT1_MODE_V  0x00000001U
+#define SPI_DOUT1_MODE_S  1
+/** SPI_DOUT2_MODE : R/W; bitpos: [2]; default: 0;
+ *  The output signal $n is delayed by the SPI module clock, 0: output without delayed,
+ *  1: output delay for a SPI module clock cycle at its negative edge. Can be
+ *  configured in CONF state.
+ */
+#define SPI_DOUT2_MODE    (BIT(2))
+#define SPI_DOUT2_MODE_M  (SPI_DOUT2_MODE_V << SPI_DOUT2_MODE_S)
+#define SPI_DOUT2_MODE_V  0x00000001U
+#define SPI_DOUT2_MODE_S  2
+/** SPI_DOUT3_MODE : R/W; bitpos: [3]; default: 0;
+ *  The output signal $n is delayed by the SPI module clock, 0: output without delayed,
+ *  1: output delay for a SPI module clock cycle at its negative edge. Can be
+ *  configured in CONF state.
+ */
+#define SPI_DOUT3_MODE    (BIT(3))
+#define SPI_DOUT3_MODE_M  (SPI_DOUT3_MODE_V << SPI_DOUT3_MODE_S)
+#define SPI_DOUT3_MODE_V  0x00000001U
+#define SPI_DOUT3_MODE_S  3
+/** SPI_DOUT4_MODE : R/W; bitpos: [4]; default: 0;
+ *  The output signal $n is delayed by the SPI module clock, 0: output without delayed,
+ *  1: output delay for a SPI module clock cycle at its negative edge. Can be
+ *  configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_DOUT4_MODE    (BIT(4))
+#define SPI_DOUT4_MODE_M  (SPI_DOUT4_MODE_V << SPI_DOUT4_MODE_S)
+#define SPI_DOUT4_MODE_V  0x00000001U
+#define SPI_DOUT4_MODE_S  4
+/** SPI_DOUT5_MODE : R/W; bitpos: [5]; default: 0;
+ *  The output signal $n is delayed by the SPI module clock, 0: output without delayed,
+ *  1: output delay for a SPI module clock cycle at its negative edge. Can be
+ *  configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_DOUT5_MODE    (BIT(5))
+#define SPI_DOUT5_MODE_M  (SPI_DOUT5_MODE_V << SPI_DOUT5_MODE_S)
+#define SPI_DOUT5_MODE_V  0x00000001U
+#define SPI_DOUT5_MODE_S  5
+/** SPI_DOUT6_MODE : R/W; bitpos: [6]; default: 0;
+ *  The output signal $n is delayed by the SPI module clock, 0: output without delayed,
+ *  1: output delay for a SPI module clock cycle at its negative edge. Can be
+ *  configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_DOUT6_MODE    (BIT(6))
+#define SPI_DOUT6_MODE_M  (SPI_DOUT6_MODE_V << SPI_DOUT6_MODE_S)
+#define SPI_DOUT6_MODE_V  0x00000001U
+#define SPI_DOUT6_MODE_S  6
+/** SPI_DOUT7_MODE : R/W; bitpos: [7]; default: 0;
+ *  The output signal $n is delayed by the SPI module clock, 0: output without delayed,
+ *  1: output delay for a SPI module clock cycle at its negative edge. Can be
+ *  configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_DOUT7_MODE    (BIT(7))
+#define SPI_DOUT7_MODE_M  (SPI_DOUT7_MODE_V << SPI_DOUT7_MODE_S)
+#define SPI_DOUT7_MODE_V  0x00000001U
+#define SPI_DOUT7_MODE_S  7
+/** SPI_D_DQS_MODE : R/W; bitpos: [8]; default: 0;
+ *  The output signal SPI_DQS is delayed by the SPI module clock, 0: output without
+ *  delayed, 1: output delay for a SPI module clock cycle at its negative edge. Can be
+ *  configured in CONF state.
+ */
+//this field is only for GPSPI2
+#define SPI_D_DQS_MODE    (BIT(8))
+#define SPI_D_DQS_MODE_M  (SPI_D_DQS_MODE_V << SPI_D_DQS_MODE_S)
+#define SPI_D_DQS_MODE_V  0x00000001U
+#define SPI_D_DQS_MODE_S  8
+
+/** SPI_DMA_CONF_REG register
+ *  SPI DMA control register
+ */
+#define SPI_DMA_CONF_REG(i) (REG_SPI_BASE(i) + 0x30)
+/** SPI_DMA_OUTFIFO_EMPTY : RO; bitpos: [0]; default: 1;
+ *  Records the status of DMA TX FIFO. 1: DMA TX FIFO is not ready for sending data. 0:
+ *  DMA TX FIFO is ready for sending data.
+ */
+#define SPI_DMA_OUTFIFO_EMPTY    (BIT(0))
+#define SPI_DMA_OUTFIFO_EMPTY_M  (SPI_DMA_OUTFIFO_EMPTY_V << SPI_DMA_OUTFIFO_EMPTY_S)
+#define SPI_DMA_OUTFIFO_EMPTY_V  0x00000001U
+#define SPI_DMA_OUTFIFO_EMPTY_S  0
+/** SPI_DMA_INFIFO_FULL : RO; bitpos: [1]; default: 1;
+ *  Records the status of DMA RX FIFO. 1: DMA RX FIFO is not ready for receiving data.
+ *  0: DMA RX FIFO is ready for receiving data.
+ */
+#define SPI_DMA_INFIFO_FULL    (BIT(1))
+#define SPI_DMA_INFIFO_FULL_M  (SPI_DMA_INFIFO_FULL_V << SPI_DMA_INFIFO_FULL_S)
+#define SPI_DMA_INFIFO_FULL_V  0x00000001U
+#define SPI_DMA_INFIFO_FULL_S  1
+/** SPI_DMA_SLV_SEG_TRANS_EN : R/W; bitpos: [18]; default: 0;
+ *  Enable dma segment transfer in spi dma half slave mode. 1: enable. 0: disable.
+ */
+#define SPI_DMA_SLV_SEG_TRANS_EN    (BIT(18))
+#define SPI_DMA_SLV_SEG_TRANS_EN_M  (SPI_DMA_SLV_SEG_TRANS_EN_V << SPI_DMA_SLV_SEG_TRANS_EN_S)
+#define SPI_DMA_SLV_SEG_TRANS_EN_V  0x00000001U
+#define SPI_DMA_SLV_SEG_TRANS_EN_S  18
+/** SPI_SLV_RX_SEG_TRANS_CLR_EN : R/W; bitpos: [19]; default: 0;
+ *  1: spi_dma_infifo_full_vld is cleared by spi slave cmd 5. 0:
+ *  spi_dma_infifo_full_vld is cleared by spi_trans_done.
+ */
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN    (BIT(19))
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN_M  (SPI_SLV_RX_SEG_TRANS_CLR_EN_V << SPI_SLV_RX_SEG_TRANS_CLR_EN_S)
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN_V  0x00000001U
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN_S  19
+/** SPI_SLV_TX_SEG_TRANS_CLR_EN : R/W; bitpos: [20]; default: 0;
+ *  1: spi_dma_outfifo_empty_vld is cleared by spi slave cmd 6. 0:
+ *  spi_dma_outfifo_empty_vld is cleared by spi_trans_done.
+ */
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN    (BIT(20))
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN_M  (SPI_SLV_TX_SEG_TRANS_CLR_EN_V << SPI_SLV_TX_SEG_TRANS_CLR_EN_S)
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN_V  0x00000001U
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN_S  20
+/** SPI_RX_EOF_EN : R/W; bitpos: [21]; default: 0;
+ *  1: spi_dma_inlink_eof is set when the number of dma pushed data bytes is equal to
+ *  the value of spi_slv/mst_dma_rd_bytelen[19:0] in spi dma transition.  0:
+ *  spi_dma_inlink_eof is set by spi_trans_done in non-seg-trans or
+ *  spi_dma_seg_trans_done in seg-trans.
+ */
+#define SPI_RX_EOF_EN    (BIT(21))
+#define SPI_RX_EOF_EN_M  (SPI_RX_EOF_EN_V << SPI_RX_EOF_EN_S)
+#define SPI_RX_EOF_EN_V  0x00000001U
+#define SPI_RX_EOF_EN_S  21
+/** SPI_DMA_RX_ENA : R/W; bitpos: [27]; default: 0;
+ *  Set this bit to enable SPI DMA controlled receive data mode.
+ */
+#define SPI_DMA_RX_ENA    (BIT(27))
+#define SPI_DMA_RX_ENA_M  (SPI_DMA_RX_ENA_V << SPI_DMA_RX_ENA_S)
+#define SPI_DMA_RX_ENA_V  0x00000001U
+#define SPI_DMA_RX_ENA_S  27
+/** SPI_DMA_TX_ENA : R/W; bitpos: [28]; default: 0;
+ *  Set this bit to enable SPI DMA controlled send data mode.
+ */
+#define SPI_DMA_TX_ENA    (BIT(28))
+#define SPI_DMA_TX_ENA_M  (SPI_DMA_TX_ENA_V << SPI_DMA_TX_ENA_S)
+#define SPI_DMA_TX_ENA_V  0x00000001U
+#define SPI_DMA_TX_ENA_S  28
+/** SPI_RX_AFIFO_RST : WT; bitpos: [29]; default: 0;
+ *  Set this bit to reset RX AFIFO, which is used to receive data in SPI master and
+ *  slave mode transfer.
+ */
+#define SPI_RX_AFIFO_RST    (BIT(29))
+#define SPI_RX_AFIFO_RST_M  (SPI_RX_AFIFO_RST_V << SPI_RX_AFIFO_RST_S)
+#define SPI_RX_AFIFO_RST_V  0x00000001U
+#define SPI_RX_AFIFO_RST_S  29
+/** SPI_BUF_AFIFO_RST : WT; bitpos: [30]; default: 0;
+ *  Set this bit to reset BUF TX AFIFO, which is used send data out in SPI slave CPU
+ *  controlled mode transfer and master mode transfer.
+ */
+#define SPI_BUF_AFIFO_RST    (BIT(30))
+#define SPI_BUF_AFIFO_RST_M  (SPI_BUF_AFIFO_RST_V << SPI_BUF_AFIFO_RST_S)
+#define SPI_BUF_AFIFO_RST_V  0x00000001U
+#define SPI_BUF_AFIFO_RST_S  30
+/** SPI_DMA_AFIFO_RST : WT; bitpos: [31]; default: 0;
+ *  Set this bit to reset DMA TX AFIFO, which is used to send data out in SPI slave DMA
+ *  controlled mode transfer.
+ */
+#define SPI_DMA_AFIFO_RST    (BIT(31))
+#define SPI_DMA_AFIFO_RST_M  (SPI_DMA_AFIFO_RST_V << SPI_DMA_AFIFO_RST_S)
+#define SPI_DMA_AFIFO_RST_V  0x00000001U
+#define SPI_DMA_AFIFO_RST_S  31
+
+/** SPI_DMA_INT_ENA_REG register
+ *  SPI interrupt enable register
+ */
+#define SPI_DMA_INT_ENA_REG(i) (REG_SPI_BASE(i) + 0x34)
+/** SPI_DMA_INFIFO_FULL_ERR_INT_ENA : R/W; bitpos: [0]; default: 0;
+ *  The enable bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt.
+ */
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA_M  (SPI_DMA_INFIFO_FULL_ERR_INT_ENA_V << SPI_DMA_INFIFO_FULL_ERR_INT_ENA_S)
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA_V  0x00000001U
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA_S  0
+/** SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA : R/W; bitpos: [1]; default: 0;
+ *  The enable bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt.
+ */
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_M  (SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_V << SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_S)
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_V  0x00000001U
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_S  1
+/** SPI_SLV_EX_QPI_INT_ENA : R/W; bitpos: [2]; default: 0;
+ *  The enable bit for SPI slave Ex_QPI interrupt.
+ */
+#define SPI_SLV_EX_QPI_INT_ENA    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_ENA_M  (SPI_SLV_EX_QPI_INT_ENA_V << SPI_SLV_EX_QPI_INT_ENA_S)
+#define SPI_SLV_EX_QPI_INT_ENA_V  0x00000001U
+#define SPI_SLV_EX_QPI_INT_ENA_S  2
+/** SPI_SLV_EN_QPI_INT_ENA : R/W; bitpos: [3]; default: 0;
+ *  The enable bit for SPI slave En_QPI interrupt.
+ */
+#define SPI_SLV_EN_QPI_INT_ENA    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_ENA_M  (SPI_SLV_EN_QPI_INT_ENA_V << SPI_SLV_EN_QPI_INT_ENA_S)
+#define SPI_SLV_EN_QPI_INT_ENA_V  0x00000001U
+#define SPI_SLV_EN_QPI_INT_ENA_S  3
+/** SPI_SLV_CMD7_INT_ENA : R/W; bitpos: [4]; default: 0;
+ *  The enable bit for SPI slave CMD7 interrupt.
+ */
+#define SPI_SLV_CMD7_INT_ENA    (BIT(4))
+#define SPI_SLV_CMD7_INT_ENA_M  (SPI_SLV_CMD7_INT_ENA_V << SPI_SLV_CMD7_INT_ENA_S)
+#define SPI_SLV_CMD7_INT_ENA_V  0x00000001U
+#define SPI_SLV_CMD7_INT_ENA_S  4
+/** SPI_SLV_CMD8_INT_ENA : R/W; bitpos: [5]; default: 0;
+ *  The enable bit for SPI slave CMD8 interrupt.
+ */
+#define SPI_SLV_CMD8_INT_ENA    (BIT(5))
+#define SPI_SLV_CMD8_INT_ENA_M  (SPI_SLV_CMD8_INT_ENA_V << SPI_SLV_CMD8_INT_ENA_S)
+#define SPI_SLV_CMD8_INT_ENA_V  0x00000001U
+#define SPI_SLV_CMD8_INT_ENA_S  5
+/** SPI_SLV_CMD9_INT_ENA : R/W; bitpos: [6]; default: 0;
+ *  The enable bit for SPI slave CMD9 interrupt.
+ */
+#define SPI_SLV_CMD9_INT_ENA    (BIT(6))
+#define SPI_SLV_CMD9_INT_ENA_M  (SPI_SLV_CMD9_INT_ENA_V << SPI_SLV_CMD9_INT_ENA_S)
+#define SPI_SLV_CMD9_INT_ENA_V  0x00000001U
+#define SPI_SLV_CMD9_INT_ENA_S  6
+/** SPI_SLV_CMDA_INT_ENA : R/W; bitpos: [7]; default: 0;
+ *  The enable bit for SPI slave CMDA interrupt.
+ */
+#define SPI_SLV_CMDA_INT_ENA    (BIT(7))
+#define SPI_SLV_CMDA_INT_ENA_M  (SPI_SLV_CMDA_INT_ENA_V << SPI_SLV_CMDA_INT_ENA_S)
+#define SPI_SLV_CMDA_INT_ENA_V  0x00000001U
+#define SPI_SLV_CMDA_INT_ENA_S  7
+/** SPI_SLV_RD_DMA_DONE_INT_ENA : R/W; bitpos: [8]; default: 0;
+ *  The enable bit for SPI_SLV_RD_DMA_DONE_INT interrupt.
+ */
+#define SPI_SLV_RD_DMA_DONE_INT_ENA    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_ENA_M  (SPI_SLV_RD_DMA_DONE_INT_ENA_V << SPI_SLV_RD_DMA_DONE_INT_ENA_S)
+#define SPI_SLV_RD_DMA_DONE_INT_ENA_V  0x00000001U
+#define SPI_SLV_RD_DMA_DONE_INT_ENA_S  8
+/** SPI_SLV_WR_DMA_DONE_INT_ENA : R/W; bitpos: [9]; default: 0;
+ *  The enable bit for SPI_SLV_WR_DMA_DONE_INT interrupt.
+ */
+#define SPI_SLV_WR_DMA_DONE_INT_ENA    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_ENA_M  (SPI_SLV_WR_DMA_DONE_INT_ENA_V << SPI_SLV_WR_DMA_DONE_INT_ENA_S)
+#define SPI_SLV_WR_DMA_DONE_INT_ENA_V  0x00000001U
+#define SPI_SLV_WR_DMA_DONE_INT_ENA_S  9
+/** SPI_SLV_RD_BUF_DONE_INT_ENA : R/W; bitpos: [10]; default: 0;
+ *  The enable bit for SPI_SLV_RD_BUF_DONE_INT interrupt.
+ */
+#define SPI_SLV_RD_BUF_DONE_INT_ENA    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_ENA_M  (SPI_SLV_RD_BUF_DONE_INT_ENA_V << SPI_SLV_RD_BUF_DONE_INT_ENA_S)
+#define SPI_SLV_RD_BUF_DONE_INT_ENA_V  0x00000001U
+#define SPI_SLV_RD_BUF_DONE_INT_ENA_S  10
+/** SPI_SLV_WR_BUF_DONE_INT_ENA : R/W; bitpos: [11]; default: 0;
+ *  The enable bit for SPI_SLV_WR_BUF_DONE_INT interrupt.
+ */
+#define SPI_SLV_WR_BUF_DONE_INT_ENA    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_ENA_M  (SPI_SLV_WR_BUF_DONE_INT_ENA_V << SPI_SLV_WR_BUF_DONE_INT_ENA_S)
+#define SPI_SLV_WR_BUF_DONE_INT_ENA_V  0x00000001U
+#define SPI_SLV_WR_BUF_DONE_INT_ENA_S  11
+/** SPI_TRANS_DONE_INT_ENA : R/W; bitpos: [12]; default: 0;
+ *  The enable bit for SPI_TRANS_DONE_INT interrupt.
+ */
+#define SPI_TRANS_DONE_INT_ENA    (BIT(12))
+#define SPI_TRANS_DONE_INT_ENA_M  (SPI_TRANS_DONE_INT_ENA_V << SPI_TRANS_DONE_INT_ENA_S)
+#define SPI_TRANS_DONE_INT_ENA_V  0x00000001U
+#define SPI_TRANS_DONE_INT_ENA_S  12
+/** SPI_DMA_SEG_TRANS_DONE_INT_ENA : R/W; bitpos: [13]; default: 0;
+ *  The enable bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt.
+ */
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA_M  (SPI_DMA_SEG_TRANS_DONE_INT_ENA_V << SPI_DMA_SEG_TRANS_DONE_INT_ENA_S)
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA_V  0x00000001U
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA_S  13
+/** SPI_SEG_MAGIC_ERR_INT_ENA : R/W; bitpos: [14]; default: 0;
+ *  The enable bit for SPI_SEG_MAGIC_ERR_INT interrupt.
+ */
+//this field is only for GPSPI2
+#define SPI_SEG_MAGIC_ERR_INT_ENA    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_ENA_M  (SPI_SEG_MAGIC_ERR_INT_ENA_V << SPI_SEG_MAGIC_ERR_INT_ENA_S)
+#define SPI_SEG_MAGIC_ERR_INT_ENA_V  0x00000001U
+#define SPI_SEG_MAGIC_ERR_INT_ENA_S  14
+/** SPI_SLV_BUF_ADDR_ERR_INT_ENA : R/W; bitpos: [15]; default: 0;
+ *  The enable bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt.
+ */
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA_M  (SPI_SLV_BUF_ADDR_ERR_INT_ENA_V << SPI_SLV_BUF_ADDR_ERR_INT_ENA_S)
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA_V  0x00000001U
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA_S  15
+/** SPI_SLV_CMD_ERR_INT_ENA : R/W; bitpos: [16]; default: 0;
+ *  The enable bit for SPI_SLV_CMD_ERR_INT interrupt.
+ */
+#define SPI_SLV_CMD_ERR_INT_ENA    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_ENA_M  (SPI_SLV_CMD_ERR_INT_ENA_V << SPI_SLV_CMD_ERR_INT_ENA_S)
+#define SPI_SLV_CMD_ERR_INT_ENA_V  0x00000001U
+#define SPI_SLV_CMD_ERR_INT_ENA_S  16
+/** SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA : R/W; bitpos: [17]; default: 0;
+ *  The enable bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt.
+ */
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_M  (SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_V << SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_S)
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_V  0x00000001U
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_S  17
+/** SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA : R/W; bitpos: [18]; default: 0;
+ *  The enable bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt.
+ */
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_M  (SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_V << SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_S)
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_V  0x00000001U
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_S  18
+/** SPI_APP2_INT_ENA : R/W; bitpos: [19]; default: 0;
+ *  The enable bit for SPI_APP2_INT interrupt.
+ */
+#define SPI_APP2_INT_ENA    (BIT(19))
+#define SPI_APP2_INT_ENA_M  (SPI_APP2_INT_ENA_V << SPI_APP2_INT_ENA_S)
+#define SPI_APP2_INT_ENA_V  0x00000001U
+#define SPI_APP2_INT_ENA_S  19
+/** SPI_APP1_INT_ENA : R/W; bitpos: [20]; default: 0;
+ *  The enable bit for SPI_APP1_INT interrupt.
+ */
+#define SPI_APP1_INT_ENA    (BIT(20))
+#define SPI_APP1_INT_ENA_M  (SPI_APP1_INT_ENA_V << SPI_APP1_INT_ENA_S)
+#define SPI_APP1_INT_ENA_V  0x00000001U
+#define SPI_APP1_INT_ENA_S  20
+
+/** SPI_DMA_INT_CLR_REG register
+ *  SPI interrupt clear register
+ */
+#define SPI_DMA_INT_CLR_REG(i) (REG_SPI_BASE(i) + 0x38)
+/** SPI_DMA_INFIFO_FULL_ERR_INT_CLR : WT; bitpos: [0]; default: 0;
+ *  The clear bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt.
+ */
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR_M  (SPI_DMA_INFIFO_FULL_ERR_INT_CLR_V << SPI_DMA_INFIFO_FULL_ERR_INT_CLR_S)
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR_V  0x00000001U
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR_S  0
+/** SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR : WT; bitpos: [1]; default: 0;
+ *  The clear bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt.
+ */
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_M  (SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_V << SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_S)
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_V  0x00000001U
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_S  1
+/** SPI_SLV_EX_QPI_INT_CLR : WT; bitpos: [2]; default: 0;
+ *  The clear bit for SPI slave Ex_QPI interrupt.
+ */
+#define SPI_SLV_EX_QPI_INT_CLR    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_CLR_M  (SPI_SLV_EX_QPI_INT_CLR_V << SPI_SLV_EX_QPI_INT_CLR_S)
+#define SPI_SLV_EX_QPI_INT_CLR_V  0x00000001U
+#define SPI_SLV_EX_QPI_INT_CLR_S  2
+/** SPI_SLV_EN_QPI_INT_CLR : WT; bitpos: [3]; default: 0;
+ *  The clear bit for SPI slave En_QPI interrupt.
+ */
+#define SPI_SLV_EN_QPI_INT_CLR    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_CLR_M  (SPI_SLV_EN_QPI_INT_CLR_V << SPI_SLV_EN_QPI_INT_CLR_S)
+#define SPI_SLV_EN_QPI_INT_CLR_V  0x00000001U
+#define SPI_SLV_EN_QPI_INT_CLR_S  3
+/** SPI_SLV_CMD7_INT_CLR : WT; bitpos: [4]; default: 0;
+ *  The clear bit for SPI slave CMD7 interrupt.
+ */
+#define SPI_SLV_CMD7_INT_CLR    (BIT(4))
+#define SPI_SLV_CMD7_INT_CLR_M  (SPI_SLV_CMD7_INT_CLR_V << SPI_SLV_CMD7_INT_CLR_S)
+#define SPI_SLV_CMD7_INT_CLR_V  0x00000001U
+#define SPI_SLV_CMD7_INT_CLR_S  4
+/** SPI_SLV_CMD8_INT_CLR : WT; bitpos: [5]; default: 0;
+ *  The clear bit for SPI slave CMD8 interrupt.
+ */
+#define SPI_SLV_CMD8_INT_CLR    (BIT(5))
+#define SPI_SLV_CMD8_INT_CLR_M  (SPI_SLV_CMD8_INT_CLR_V << SPI_SLV_CMD8_INT_CLR_S)
+#define SPI_SLV_CMD8_INT_CLR_V  0x00000001U
+#define SPI_SLV_CMD8_INT_CLR_S  5
+/** SPI_SLV_CMD9_INT_CLR : WT; bitpos: [6]; default: 0;
+ *  The clear bit for SPI slave CMD9 interrupt.
+ */
+#define SPI_SLV_CMD9_INT_CLR    (BIT(6))
+#define SPI_SLV_CMD9_INT_CLR_M  (SPI_SLV_CMD9_INT_CLR_V << SPI_SLV_CMD9_INT_CLR_S)
+#define SPI_SLV_CMD9_INT_CLR_V  0x00000001U
+#define SPI_SLV_CMD9_INT_CLR_S  6
+/** SPI_SLV_CMDA_INT_CLR : WT; bitpos: [7]; default: 0;
+ *  The clear bit for SPI slave CMDA interrupt.
+ */
+#define SPI_SLV_CMDA_INT_CLR    (BIT(7))
+#define SPI_SLV_CMDA_INT_CLR_M  (SPI_SLV_CMDA_INT_CLR_V << SPI_SLV_CMDA_INT_CLR_S)
+#define SPI_SLV_CMDA_INT_CLR_V  0x00000001U
+#define SPI_SLV_CMDA_INT_CLR_S  7
+/** SPI_SLV_RD_DMA_DONE_INT_CLR : WT; bitpos: [8]; default: 0;
+ *  The clear bit for SPI_SLV_RD_DMA_DONE_INT interrupt.
+ */
+#define SPI_SLV_RD_DMA_DONE_INT_CLR    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_CLR_M  (SPI_SLV_RD_DMA_DONE_INT_CLR_V << SPI_SLV_RD_DMA_DONE_INT_CLR_S)
+#define SPI_SLV_RD_DMA_DONE_INT_CLR_V  0x00000001U
+#define SPI_SLV_RD_DMA_DONE_INT_CLR_S  8
+/** SPI_SLV_WR_DMA_DONE_INT_CLR : WT; bitpos: [9]; default: 0;
+ *  The clear bit for SPI_SLV_WR_DMA_DONE_INT interrupt.
+ */
+#define SPI_SLV_WR_DMA_DONE_INT_CLR    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_CLR_M  (SPI_SLV_WR_DMA_DONE_INT_CLR_V << SPI_SLV_WR_DMA_DONE_INT_CLR_S)
+#define SPI_SLV_WR_DMA_DONE_INT_CLR_V  0x00000001U
+#define SPI_SLV_WR_DMA_DONE_INT_CLR_S  9
+/** SPI_SLV_RD_BUF_DONE_INT_CLR : WT; bitpos: [10]; default: 0;
+ *  The clear bit for SPI_SLV_RD_BUF_DONE_INT interrupt.
+ */
+#define SPI_SLV_RD_BUF_DONE_INT_CLR    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_CLR_M  (SPI_SLV_RD_BUF_DONE_INT_CLR_V << SPI_SLV_RD_BUF_DONE_INT_CLR_S)
+#define SPI_SLV_RD_BUF_DONE_INT_CLR_V  0x00000001U
+#define SPI_SLV_RD_BUF_DONE_INT_CLR_S  10
+/** SPI_SLV_WR_BUF_DONE_INT_CLR : WT; bitpos: [11]; default: 0;
+ *  The clear bit for SPI_SLV_WR_BUF_DONE_INT interrupt.
+ */
+#define SPI_SLV_WR_BUF_DONE_INT_CLR    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_CLR_M  (SPI_SLV_WR_BUF_DONE_INT_CLR_V << SPI_SLV_WR_BUF_DONE_INT_CLR_S)
+#define SPI_SLV_WR_BUF_DONE_INT_CLR_V  0x00000001U
+#define SPI_SLV_WR_BUF_DONE_INT_CLR_S  11
+/** SPI_TRANS_DONE_INT_CLR : WT; bitpos: [12]; default: 0;
+ *  The clear bit for SPI_TRANS_DONE_INT interrupt.
+ */
+#define SPI_TRANS_DONE_INT_CLR    (BIT(12))
+#define SPI_TRANS_DONE_INT_CLR_M  (SPI_TRANS_DONE_INT_CLR_V << SPI_TRANS_DONE_INT_CLR_S)
+#define SPI_TRANS_DONE_INT_CLR_V  0x00000001U
+#define SPI_TRANS_DONE_INT_CLR_S  12
+/** SPI_DMA_SEG_TRANS_DONE_INT_CLR : WT; bitpos: [13]; default: 0;
+ *  The clear bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt.
+ */
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR_M  (SPI_DMA_SEG_TRANS_DONE_INT_CLR_V << SPI_DMA_SEG_TRANS_DONE_INT_CLR_S)
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR_V  0x00000001U
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR_S  13
+/** SPI_SEG_MAGIC_ERR_INT_CLR : WT; bitpos: [14]; default: 0;
+ *  The clear bit for SPI_SEG_MAGIC_ERR_INT interrupt.
+ */
+//this field is only for GPSPI2
+#define SPI_SEG_MAGIC_ERR_INT_CLR    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_CLR_M  (SPI_SEG_MAGIC_ERR_INT_CLR_V << SPI_SEG_MAGIC_ERR_INT_CLR_S)
+#define SPI_SEG_MAGIC_ERR_INT_CLR_V  0x00000001U
+#define SPI_SEG_MAGIC_ERR_INT_CLR_S  14
+/** SPI_SLV_BUF_ADDR_ERR_INT_CLR : WT; bitpos: [15]; default: 0;
+ *  The clear bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt.
+ */
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR_M  (SPI_SLV_BUF_ADDR_ERR_INT_CLR_V << SPI_SLV_BUF_ADDR_ERR_INT_CLR_S)
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR_V  0x00000001U
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR_S  15
+/** SPI_SLV_CMD_ERR_INT_CLR : WT; bitpos: [16]; default: 0;
+ *  The clear bit for SPI_SLV_CMD_ERR_INT interrupt.
+ */
+#define SPI_SLV_CMD_ERR_INT_CLR    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_CLR_M  (SPI_SLV_CMD_ERR_INT_CLR_V << SPI_SLV_CMD_ERR_INT_CLR_S)
+#define SPI_SLV_CMD_ERR_INT_CLR_V  0x00000001U
+#define SPI_SLV_CMD_ERR_INT_CLR_S  16
+/** SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR : WT; bitpos: [17]; default: 0;
+ *  The clear bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt.
+ */
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_M  (SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_V << SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_S)
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_V  0x00000001U
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_S  17
+/** SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR : WT; bitpos: [18]; default: 0;
+ *  The clear bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt.
+ */
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_M  (SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_V << SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_S)
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_V  0x00000001U
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_S  18
+/** SPI_APP2_INT_CLR : WT; bitpos: [19]; default: 0;
+ *  The clear bit for SPI_APP2_INT interrupt.
+ */
+#define SPI_APP2_INT_CLR    (BIT(19))
+#define SPI_APP2_INT_CLR_M  (SPI_APP2_INT_CLR_V << SPI_APP2_INT_CLR_S)
+#define SPI_APP2_INT_CLR_V  0x00000001U
+#define SPI_APP2_INT_CLR_S  19
+/** SPI_APP1_INT_CLR : WT; bitpos: [20]; default: 0;
+ *  The clear bit for SPI_APP1_INT interrupt.
+ */
+#define SPI_APP1_INT_CLR    (BIT(20))
+#define SPI_APP1_INT_CLR_M  (SPI_APP1_INT_CLR_V << SPI_APP1_INT_CLR_S)
+#define SPI_APP1_INT_CLR_V  0x00000001U
+#define SPI_APP1_INT_CLR_S  20
+
+/** SPI_DMA_INT_RAW_REG register
+ *  SPI interrupt raw register
+ */
+#define SPI_DMA_INT_RAW_REG(i) (REG_SPI_BASE(i) + 0x3c)
+/** SPI_DMA_INFIFO_FULL_ERR_INT_RAW : R/WTC/SS; bitpos: [0]; default: 0;
+ *  1: The current data rate of DMA Rx is smaller than that of SPI, which will lose the
+ *  receive data.  0: Others.
+ */
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW_M  (SPI_DMA_INFIFO_FULL_ERR_INT_RAW_V << SPI_DMA_INFIFO_FULL_ERR_INT_RAW_S)
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW_V  0x00000001U
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW_S  0
+/** SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW : R/WTC/SS; bitpos: [1]; default: 0;
+ *  1: The current data rate of DMA TX is smaller than that of SPI. SPI will stop in
+ *  master mode and send out all 0 in slave mode.  0: Others.
+ */
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_M  (SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_V << SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_S)
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_V  0x00000001U
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_S  1
+/** SPI_SLV_EX_QPI_INT_RAW : R/WTC/SS; bitpos: [2]; default: 0;
+ *  The raw bit for SPI slave Ex_QPI interrupt. 1: SPI slave mode Ex_QPI transmission
+ *  is ended. 0: Others.
+ */
+#define SPI_SLV_EX_QPI_INT_RAW    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_RAW_M  (SPI_SLV_EX_QPI_INT_RAW_V << SPI_SLV_EX_QPI_INT_RAW_S)
+#define SPI_SLV_EX_QPI_INT_RAW_V  0x00000001U
+#define SPI_SLV_EX_QPI_INT_RAW_S  2
+/** SPI_SLV_EN_QPI_INT_RAW : R/WTC/SS; bitpos: [3]; default: 0;
+ *  The raw bit for SPI slave En_QPI interrupt. 1: SPI slave mode En_QPI transmission
+ *  is ended. 0: Others.
+ */
+#define SPI_SLV_EN_QPI_INT_RAW    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_RAW_M  (SPI_SLV_EN_QPI_INT_RAW_V << SPI_SLV_EN_QPI_INT_RAW_S)
+#define SPI_SLV_EN_QPI_INT_RAW_V  0x00000001U
+#define SPI_SLV_EN_QPI_INT_RAW_S  3
+/** SPI_SLV_CMD7_INT_RAW : R/WTC/SS; bitpos: [4]; default: 0;
+ *  The raw bit for SPI slave CMD7 interrupt. 1: SPI slave mode CMD7 transmission is
+ *  ended. 0: Others.
+ */
+#define SPI_SLV_CMD7_INT_RAW    (BIT(4))
+#define SPI_SLV_CMD7_INT_RAW_M  (SPI_SLV_CMD7_INT_RAW_V << SPI_SLV_CMD7_INT_RAW_S)
+#define SPI_SLV_CMD7_INT_RAW_V  0x00000001U
+#define SPI_SLV_CMD7_INT_RAW_S  4
+/** SPI_SLV_CMD8_INT_RAW : R/WTC/SS; bitpos: [5]; default: 0;
+ *  The raw bit for SPI slave CMD8 interrupt. 1: SPI slave mode CMD8 transmission is
+ *  ended. 0: Others.
+ */
+#define SPI_SLV_CMD8_INT_RAW    (BIT(5))
+#define SPI_SLV_CMD8_INT_RAW_M  (SPI_SLV_CMD8_INT_RAW_V << SPI_SLV_CMD8_INT_RAW_S)
+#define SPI_SLV_CMD8_INT_RAW_V  0x00000001U
+#define SPI_SLV_CMD8_INT_RAW_S  5
+/** SPI_SLV_CMD9_INT_RAW : R/WTC/SS; bitpos: [6]; default: 0;
+ *  The raw bit for SPI slave CMD9 interrupt. 1: SPI slave mode CMD9 transmission is
+ *  ended. 0: Others.
+ */
+#define SPI_SLV_CMD9_INT_RAW    (BIT(6))
+#define SPI_SLV_CMD9_INT_RAW_M  (SPI_SLV_CMD9_INT_RAW_V << SPI_SLV_CMD9_INT_RAW_S)
+#define SPI_SLV_CMD9_INT_RAW_V  0x00000001U
+#define SPI_SLV_CMD9_INT_RAW_S  6
+/** SPI_SLV_CMDA_INT_RAW : R/WTC/SS; bitpos: [7]; default: 0;
+ *  The raw bit for SPI slave CMDA interrupt. 1: SPI slave mode CMDA transmission is
+ *  ended. 0: Others.
+ */
+#define SPI_SLV_CMDA_INT_RAW    (BIT(7))
+#define SPI_SLV_CMDA_INT_RAW_M  (SPI_SLV_CMDA_INT_RAW_V << SPI_SLV_CMDA_INT_RAW_S)
+#define SPI_SLV_CMDA_INT_RAW_V  0x00000001U
+#define SPI_SLV_CMDA_INT_RAW_S  7
+/** SPI_SLV_RD_DMA_DONE_INT_RAW : R/WTC/SS; bitpos: [8]; default: 0;
+ *  The raw bit for SPI_SLV_RD_DMA_DONE_INT interrupt. 1: SPI slave mode Rd_DMA
+ *  transmission is ended. 0: Others.
+ */
+#define SPI_SLV_RD_DMA_DONE_INT_RAW    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_RAW_M  (SPI_SLV_RD_DMA_DONE_INT_RAW_V << SPI_SLV_RD_DMA_DONE_INT_RAW_S)
+#define SPI_SLV_RD_DMA_DONE_INT_RAW_V  0x00000001U
+#define SPI_SLV_RD_DMA_DONE_INT_RAW_S  8
+/** SPI_SLV_WR_DMA_DONE_INT_RAW : R/WTC/SS; bitpos: [9]; default: 0;
+ *  The raw bit for SPI_SLV_WR_DMA_DONE_INT interrupt. 1: SPI slave mode Wr_DMA
+ *  transmission is ended. 0: Others.
+ */
+#define SPI_SLV_WR_DMA_DONE_INT_RAW    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_RAW_M  (SPI_SLV_WR_DMA_DONE_INT_RAW_V << SPI_SLV_WR_DMA_DONE_INT_RAW_S)
+#define SPI_SLV_WR_DMA_DONE_INT_RAW_V  0x00000001U
+#define SPI_SLV_WR_DMA_DONE_INT_RAW_S  9
+/** SPI_SLV_RD_BUF_DONE_INT_RAW : R/WTC/SS; bitpos: [10]; default: 0;
+ *  The raw bit for SPI_SLV_RD_BUF_DONE_INT interrupt. 1: SPI slave mode Rd_BUF
+ *  transmission is ended. 0: Others.
+ */
+#define SPI_SLV_RD_BUF_DONE_INT_RAW    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_RAW_M  (SPI_SLV_RD_BUF_DONE_INT_RAW_V << SPI_SLV_RD_BUF_DONE_INT_RAW_S)
+#define SPI_SLV_RD_BUF_DONE_INT_RAW_V  0x00000001U
+#define SPI_SLV_RD_BUF_DONE_INT_RAW_S  10
+/** SPI_SLV_WR_BUF_DONE_INT_RAW : R/WTC/SS; bitpos: [11]; default: 0;
+ *  The raw bit for SPI_SLV_WR_BUF_DONE_INT interrupt. 1: SPI slave mode Wr_BUF
+ *  transmission is ended. 0: Others.
+ */
+#define SPI_SLV_WR_BUF_DONE_INT_RAW    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_RAW_M  (SPI_SLV_WR_BUF_DONE_INT_RAW_V << SPI_SLV_WR_BUF_DONE_INT_RAW_S)
+#define SPI_SLV_WR_BUF_DONE_INT_RAW_V  0x00000001U
+#define SPI_SLV_WR_BUF_DONE_INT_RAW_S  11
+/** SPI_TRANS_DONE_INT_RAW : R/WTC/SS; bitpos: [12]; default: 0;
+ *  The raw bit for SPI_TRANS_DONE_INT interrupt. 1: SPI master mode transmission is
+ *  ended. 0: others.
+ */
+#define SPI_TRANS_DONE_INT_RAW    (BIT(12))
+#define SPI_TRANS_DONE_INT_RAW_M  (SPI_TRANS_DONE_INT_RAW_V << SPI_TRANS_DONE_INT_RAW_S)
+#define SPI_TRANS_DONE_INT_RAW_V  0x00000001U
+#define SPI_TRANS_DONE_INT_RAW_S  12
+/** SPI_DMA_SEG_TRANS_DONE_INT_RAW : R/WTC/SS; bitpos: [13]; default: 0;
+ *  The raw bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt. 1:  spi master DMA
+ *  full-duplex/half-duplex seg-conf-trans ends or slave half-duplex seg-trans ends.
+ *  And data has been pushed to corresponding memory.  0:  seg-conf-trans or seg-trans
+ *  is not ended or not occurred.
+ */
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW_M  (SPI_DMA_SEG_TRANS_DONE_INT_RAW_V << SPI_DMA_SEG_TRANS_DONE_INT_RAW_S)
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW_V  0x00000001U
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW_S  13
+/** SPI_SEG_MAGIC_ERR_INT_RAW : R/WTC/SS; bitpos: [14]; default: 0;
+ *  The raw bit for SPI_SEG_MAGIC_ERR_INT interrupt. 1: The magic value in CONF buffer
+ *  is error in the DMA seg-conf-trans. 0: others.
+ */
+//this field is only for GPSPI2
+#define SPI_SEG_MAGIC_ERR_INT_RAW    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_RAW_M  (SPI_SEG_MAGIC_ERR_INT_RAW_V << SPI_SEG_MAGIC_ERR_INT_RAW_S)
+#define SPI_SEG_MAGIC_ERR_INT_RAW_V  0x00000001U
+#define SPI_SEG_MAGIC_ERR_INT_RAW_S  14
+/** SPI_SLV_BUF_ADDR_ERR_INT_RAW : R/WTC/SS; bitpos: [15]; default: 0;
+ *  The raw bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt. 1: The accessing data address
+ *  of the current SPI slave mode CPU controlled FD, Wr_BUF or Rd_BUF transmission is
+ *  bigger than 63. 0: Others.
+ */
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW_M  (SPI_SLV_BUF_ADDR_ERR_INT_RAW_V << SPI_SLV_BUF_ADDR_ERR_INT_RAW_S)
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW_V  0x00000001U
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW_S  15
+/** SPI_SLV_CMD_ERR_INT_RAW : R/WTC/SS; bitpos: [16]; default: 0;
+ *  The raw bit for SPI_SLV_CMD_ERR_INT interrupt. 1: The slave command value in the
+ *  current SPI slave HD mode transmission is not supported. 0: Others.
+ */
+#define SPI_SLV_CMD_ERR_INT_RAW    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_RAW_M  (SPI_SLV_CMD_ERR_INT_RAW_V << SPI_SLV_CMD_ERR_INT_RAW_S)
+#define SPI_SLV_CMD_ERR_INT_RAW_V  0x00000001U
+#define SPI_SLV_CMD_ERR_INT_RAW_S  16
+/** SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW : R/WTC/SS; bitpos: [17]; default: 0;
+ *  The raw bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt. 1: There is a RX AFIFO
+ *  write-full error when SPI inputs data in master mode. 0: Others.
+ */
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_M  (SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_V << SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_S)
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_V  0x00000001U
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_S  17
+/** SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW : R/WTC/SS; bitpos: [18]; default: 0;
+ *  The raw bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt. 1: There is a TX BUF
+ *  AFIFO read-empty error when SPI outputs data in master mode. 0: Others.
+ */
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_M  (SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_V << SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_S)
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_V  0x00000001U
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_S  18
+/** SPI_APP2_INT_RAW : R/WTC/SS; bitpos: [19]; default: 0;
+ *  The raw bit for SPI_APP2_INT interrupt. The value is only controlled by software.
+ */
+#define SPI_APP2_INT_RAW    (BIT(19))
+#define SPI_APP2_INT_RAW_M  (SPI_APP2_INT_RAW_V << SPI_APP2_INT_RAW_S)
+#define SPI_APP2_INT_RAW_V  0x00000001U
+#define SPI_APP2_INT_RAW_S  19
+/** SPI_APP1_INT_RAW : R/WTC/SS; bitpos: [20]; default: 0;
+ *  The raw bit for SPI_APP1_INT interrupt. The value is only controlled by software.
+ */
+#define SPI_APP1_INT_RAW    (BIT(20))
+#define SPI_APP1_INT_RAW_M  (SPI_APP1_INT_RAW_V << SPI_APP1_INT_RAW_S)
+#define SPI_APP1_INT_RAW_V  0x00000001U
+#define SPI_APP1_INT_RAW_S  20
+
+/** SPI_DMA_INT_ST_REG register
+ *  SPI interrupt status register
+ */
+#define SPI_DMA_INT_ST_REG(i) (REG_SPI_BASE(i) + 0x40)
+/** SPI_DMA_INFIFO_FULL_ERR_INT_ST : RO; bitpos: [0]; default: 0;
+ *  The status bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt.
+ */
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST_M  (SPI_DMA_INFIFO_FULL_ERR_INT_ST_V << SPI_DMA_INFIFO_FULL_ERR_INT_ST_S)
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST_V  0x00000001U
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST_S  0
+/** SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST : RO; bitpos: [1]; default: 0;
+ *  The status bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt.
+ */
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_M  (SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_V << SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_S)
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_V  0x00000001U
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_S  1
+/** SPI_SLV_EX_QPI_INT_ST : RO; bitpos: [2]; default: 0;
+ *  The status bit for SPI slave Ex_QPI interrupt.
+ */
+#define SPI_SLV_EX_QPI_INT_ST    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_ST_M  (SPI_SLV_EX_QPI_INT_ST_V << SPI_SLV_EX_QPI_INT_ST_S)
+#define SPI_SLV_EX_QPI_INT_ST_V  0x00000001U
+#define SPI_SLV_EX_QPI_INT_ST_S  2
+/** SPI_SLV_EN_QPI_INT_ST : RO; bitpos: [3]; default: 0;
+ *  The status bit for SPI slave En_QPI interrupt.
+ */
+#define SPI_SLV_EN_QPI_INT_ST    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_ST_M  (SPI_SLV_EN_QPI_INT_ST_V << SPI_SLV_EN_QPI_INT_ST_S)
+#define SPI_SLV_EN_QPI_INT_ST_V  0x00000001U
+#define SPI_SLV_EN_QPI_INT_ST_S  3
+/** SPI_SLV_CMD7_INT_ST : RO; bitpos: [4]; default: 0;
+ *  The status bit for SPI slave CMD7 interrupt.
+ */
+#define SPI_SLV_CMD7_INT_ST    (BIT(4))
+#define SPI_SLV_CMD7_INT_ST_M  (SPI_SLV_CMD7_INT_ST_V << SPI_SLV_CMD7_INT_ST_S)
+#define SPI_SLV_CMD7_INT_ST_V  0x00000001U
+#define SPI_SLV_CMD7_INT_ST_S  4
+/** SPI_SLV_CMD8_INT_ST : RO; bitpos: [5]; default: 0;
+ *  The status bit for SPI slave CMD8 interrupt.
+ */
+#define SPI_SLV_CMD8_INT_ST    (BIT(5))
+#define SPI_SLV_CMD8_INT_ST_M  (SPI_SLV_CMD8_INT_ST_V << SPI_SLV_CMD8_INT_ST_S)
+#define SPI_SLV_CMD8_INT_ST_V  0x00000001U
+#define SPI_SLV_CMD8_INT_ST_S  5
+/** SPI_SLV_CMD9_INT_ST : RO; bitpos: [6]; default: 0;
+ *  The status bit for SPI slave CMD9 interrupt.
+ */
+#define SPI_SLV_CMD9_INT_ST    (BIT(6))
+#define SPI_SLV_CMD9_INT_ST_M  (SPI_SLV_CMD9_INT_ST_V << SPI_SLV_CMD9_INT_ST_S)
+#define SPI_SLV_CMD9_INT_ST_V  0x00000001U
+#define SPI_SLV_CMD9_INT_ST_S  6
+/** SPI_SLV_CMDA_INT_ST : RO; bitpos: [7]; default: 0;
+ *  The status bit for SPI slave CMDA interrupt.
+ */
+#define SPI_SLV_CMDA_INT_ST    (BIT(7))
+#define SPI_SLV_CMDA_INT_ST_M  (SPI_SLV_CMDA_INT_ST_V << SPI_SLV_CMDA_INT_ST_S)
+#define SPI_SLV_CMDA_INT_ST_V  0x00000001U
+#define SPI_SLV_CMDA_INT_ST_S  7
+/** SPI_SLV_RD_DMA_DONE_INT_ST : RO; bitpos: [8]; default: 0;
+ *  The status bit for SPI_SLV_RD_DMA_DONE_INT interrupt.
+ */
+#define SPI_SLV_RD_DMA_DONE_INT_ST    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_ST_M  (SPI_SLV_RD_DMA_DONE_INT_ST_V << SPI_SLV_RD_DMA_DONE_INT_ST_S)
+#define SPI_SLV_RD_DMA_DONE_INT_ST_V  0x00000001U
+#define SPI_SLV_RD_DMA_DONE_INT_ST_S  8
+/** SPI_SLV_WR_DMA_DONE_INT_ST : RO; bitpos: [9]; default: 0;
+ *  The status bit for SPI_SLV_WR_DMA_DONE_INT interrupt.
+ */
+#define SPI_SLV_WR_DMA_DONE_INT_ST    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_ST_M  (SPI_SLV_WR_DMA_DONE_INT_ST_V << SPI_SLV_WR_DMA_DONE_INT_ST_S)
+#define SPI_SLV_WR_DMA_DONE_INT_ST_V  0x00000001U
+#define SPI_SLV_WR_DMA_DONE_INT_ST_S  9
+/** SPI_SLV_RD_BUF_DONE_INT_ST : RO; bitpos: [10]; default: 0;
+ *  The status bit for SPI_SLV_RD_BUF_DONE_INT interrupt.
+ */
+#define SPI_SLV_RD_BUF_DONE_INT_ST    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_ST_M  (SPI_SLV_RD_BUF_DONE_INT_ST_V << SPI_SLV_RD_BUF_DONE_INT_ST_S)
+#define SPI_SLV_RD_BUF_DONE_INT_ST_V  0x00000001U
+#define SPI_SLV_RD_BUF_DONE_INT_ST_S  10
+/** SPI_SLV_WR_BUF_DONE_INT_ST : RO; bitpos: [11]; default: 0;
+ *  The status bit for SPI_SLV_WR_BUF_DONE_INT interrupt.
+ */
+#define SPI_SLV_WR_BUF_DONE_INT_ST    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_ST_M  (SPI_SLV_WR_BUF_DONE_INT_ST_V << SPI_SLV_WR_BUF_DONE_INT_ST_S)
+#define SPI_SLV_WR_BUF_DONE_INT_ST_V  0x00000001U
+#define SPI_SLV_WR_BUF_DONE_INT_ST_S  11
+/** SPI_TRANS_DONE_INT_ST : RO; bitpos: [12]; default: 0;
+ *  The status bit for SPI_TRANS_DONE_INT interrupt.
+ */
+#define SPI_TRANS_DONE_INT_ST    (BIT(12))
+#define SPI_TRANS_DONE_INT_ST_M  (SPI_TRANS_DONE_INT_ST_V << SPI_TRANS_DONE_INT_ST_S)
+#define SPI_TRANS_DONE_INT_ST_V  0x00000001U
+#define SPI_TRANS_DONE_INT_ST_S  12
+/** SPI_DMA_SEG_TRANS_DONE_INT_ST : RO; bitpos: [13]; default: 0;
+ *  The status bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt.
+ */
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST_M  (SPI_DMA_SEG_TRANS_DONE_INT_ST_V << SPI_DMA_SEG_TRANS_DONE_INT_ST_S)
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST_V  0x00000001U
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST_S  13
+/** SPI_SEG_MAGIC_ERR_INT_ST : RO; bitpos: [14]; default: 0;
+ *  The status bit for SPI_SEG_MAGIC_ERR_INT interrupt.
+ */
+//this field is only for GPSPI2
+#define SPI_SEG_MAGIC_ERR_INT_ST    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_ST_M  (SPI_SEG_MAGIC_ERR_INT_ST_V << SPI_SEG_MAGIC_ERR_INT_ST_S)
+#define SPI_SEG_MAGIC_ERR_INT_ST_V  0x00000001U
+#define SPI_SEG_MAGIC_ERR_INT_ST_S  14
+/** SPI_SLV_BUF_ADDR_ERR_INT_ST : RO; bitpos: [15]; default: 0;
+ *  The status bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt.
+ */
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST_M  (SPI_SLV_BUF_ADDR_ERR_INT_ST_V << SPI_SLV_BUF_ADDR_ERR_INT_ST_S)
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST_V  0x00000001U
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST_S  15
+/** SPI_SLV_CMD_ERR_INT_ST : RO; bitpos: [16]; default: 0;
+ *  The status bit for SPI_SLV_CMD_ERR_INT interrupt.
+ */
+#define SPI_SLV_CMD_ERR_INT_ST    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_ST_M  (SPI_SLV_CMD_ERR_INT_ST_V << SPI_SLV_CMD_ERR_INT_ST_S)
+#define SPI_SLV_CMD_ERR_INT_ST_V  0x00000001U
+#define SPI_SLV_CMD_ERR_INT_ST_S  16
+/** SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST : RO; bitpos: [17]; default: 0;
+ *  The status bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt.
+ */
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_M  (SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_V << SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_S)
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_V  0x00000001U
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_S  17
+/** SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST : RO; bitpos: [18]; default: 0;
+ *  The status bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt.
+ */
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_M  (SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_V << SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_S)
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_V  0x00000001U
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_S  18
+/** SPI_APP2_INT_ST : RO; bitpos: [19]; default: 0;
+ *  The status bit for SPI_APP2_INT interrupt.
+ */
+#define SPI_APP2_INT_ST    (BIT(19))
+#define SPI_APP2_INT_ST_M  (SPI_APP2_INT_ST_V << SPI_APP2_INT_ST_S)
+#define SPI_APP2_INT_ST_V  0x00000001U
+#define SPI_APP2_INT_ST_S  19
+/** SPI_APP1_INT_ST : RO; bitpos: [20]; default: 0;
+ *  The status bit for SPI_APP1_INT interrupt.
+ */
+#define SPI_APP1_INT_ST    (BIT(20))
+#define SPI_APP1_INT_ST_M  (SPI_APP1_INT_ST_V << SPI_APP1_INT_ST_S)
+#define SPI_APP1_INT_ST_V  0x00000001U
+#define SPI_APP1_INT_ST_S  20
+
+/** SPI_DMA_INT_SET_REG register
+ *  SPI interrupt software set register
+ */
+#define SPI_DMA_INT_SET_REG(i) (REG_SPI_BASE(i) + 0x44)
+/** SPI_DMA_INFIFO_FULL_ERR_INT_SET : WT; bitpos: [0]; default: 0;
+ *  The software set bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt.
+ */
+#define SPI_DMA_INFIFO_FULL_ERR_INT_SET    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_SET_M  (SPI_DMA_INFIFO_FULL_ERR_INT_SET_V << SPI_DMA_INFIFO_FULL_ERR_INT_SET_S)
+#define SPI_DMA_INFIFO_FULL_ERR_INT_SET_V  0x00000001U
+#define SPI_DMA_INFIFO_FULL_ERR_INT_SET_S  0
+/** SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET : WT; bitpos: [1]; default: 0;
+ *  The software set bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt.
+ */
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET_M  (SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET_V << SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET_S)
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET_V  0x00000001U
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_SET_S  1
+/** SPI_SLV_EX_QPI_INT_SET : WT; bitpos: [2]; default: 0;
+ *  The software set bit for SPI slave Ex_QPI interrupt.
+ */
+#define SPI_SLV_EX_QPI_INT_SET    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_SET_M  (SPI_SLV_EX_QPI_INT_SET_V << SPI_SLV_EX_QPI_INT_SET_S)
+#define SPI_SLV_EX_QPI_INT_SET_V  0x00000001U
+#define SPI_SLV_EX_QPI_INT_SET_S  2
+/** SPI_SLV_EN_QPI_INT_SET : WT; bitpos: [3]; default: 0;
+ *  The software set bit for SPI slave En_QPI interrupt.
+ */
+#define SPI_SLV_EN_QPI_INT_SET    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_SET_M  (SPI_SLV_EN_QPI_INT_SET_V << SPI_SLV_EN_QPI_INT_SET_S)
+#define SPI_SLV_EN_QPI_INT_SET_V  0x00000001U
+#define SPI_SLV_EN_QPI_INT_SET_S  3
+/** SPI_SLV_CMD7_INT_SET : WT; bitpos: [4]; default: 0;
+ *  The software set bit for SPI slave CMD7 interrupt.
+ */
+#define SPI_SLV_CMD7_INT_SET    (BIT(4))
+#define SPI_SLV_CMD7_INT_SET_M  (SPI_SLV_CMD7_INT_SET_V << SPI_SLV_CMD7_INT_SET_S)
+#define SPI_SLV_CMD7_INT_SET_V  0x00000001U
+#define SPI_SLV_CMD7_INT_SET_S  4
+/** SPI_SLV_CMD8_INT_SET : WT; bitpos: [5]; default: 0;
+ *  The software set bit for SPI slave CMD8 interrupt.
+ */
+#define SPI_SLV_CMD8_INT_SET    (BIT(5))
+#define SPI_SLV_CMD8_INT_SET_M  (SPI_SLV_CMD8_INT_SET_V << SPI_SLV_CMD8_INT_SET_S)
+#define SPI_SLV_CMD8_INT_SET_V  0x00000001U
+#define SPI_SLV_CMD8_INT_SET_S  5
+/** SPI_SLV_CMD9_INT_SET : WT; bitpos: [6]; default: 0;
+ *  The software set bit for SPI slave CMD9 interrupt.
+ */
+#define SPI_SLV_CMD9_INT_SET    (BIT(6))
+#define SPI_SLV_CMD9_INT_SET_M  (SPI_SLV_CMD9_INT_SET_V << SPI_SLV_CMD9_INT_SET_S)
+#define SPI_SLV_CMD9_INT_SET_V  0x00000001U
+#define SPI_SLV_CMD9_INT_SET_S  6
+/** SPI_SLV_CMDA_INT_SET : WT; bitpos: [7]; default: 0;
+ *  The software set bit for SPI slave CMDA interrupt.
+ */
+#define SPI_SLV_CMDA_INT_SET    (BIT(7))
+#define SPI_SLV_CMDA_INT_SET_M  (SPI_SLV_CMDA_INT_SET_V << SPI_SLV_CMDA_INT_SET_S)
+#define SPI_SLV_CMDA_INT_SET_V  0x00000001U
+#define SPI_SLV_CMDA_INT_SET_S  7
+/** SPI_SLV_RD_DMA_DONE_INT_SET : WT; bitpos: [8]; default: 0;
+ *  The software set bit for SPI_SLV_RD_DMA_DONE_INT interrupt.
+ */
+#define SPI_SLV_RD_DMA_DONE_INT_SET    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_SET_M  (SPI_SLV_RD_DMA_DONE_INT_SET_V << SPI_SLV_RD_DMA_DONE_INT_SET_S)
+#define SPI_SLV_RD_DMA_DONE_INT_SET_V  0x00000001U
+#define SPI_SLV_RD_DMA_DONE_INT_SET_S  8
+/** SPI_SLV_WR_DMA_DONE_INT_SET : WT; bitpos: [9]; default: 0;
+ *  The software set bit for SPI_SLV_WR_DMA_DONE_INT interrupt.
+ */
+#define SPI_SLV_WR_DMA_DONE_INT_SET    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_SET_M  (SPI_SLV_WR_DMA_DONE_INT_SET_V << SPI_SLV_WR_DMA_DONE_INT_SET_S)
+#define SPI_SLV_WR_DMA_DONE_INT_SET_V  0x00000001U
+#define SPI_SLV_WR_DMA_DONE_INT_SET_S  9
+/** SPI_SLV_RD_BUF_DONE_INT_SET : WT; bitpos: [10]; default: 0;
+ *  The software set bit for SPI_SLV_RD_BUF_DONE_INT interrupt.
+ */
+#define SPI_SLV_RD_BUF_DONE_INT_SET    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_SET_M  (SPI_SLV_RD_BUF_DONE_INT_SET_V << SPI_SLV_RD_BUF_DONE_INT_SET_S)
+#define SPI_SLV_RD_BUF_DONE_INT_SET_V  0x00000001U
+#define SPI_SLV_RD_BUF_DONE_INT_SET_S  10
+/** SPI_SLV_WR_BUF_DONE_INT_SET : WT; bitpos: [11]; default: 0;
+ *  The software set bit for SPI_SLV_WR_BUF_DONE_INT interrupt.
+ */
+#define SPI_SLV_WR_BUF_DONE_INT_SET    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_SET_M  (SPI_SLV_WR_BUF_DONE_INT_SET_V << SPI_SLV_WR_BUF_DONE_INT_SET_S)
+#define SPI_SLV_WR_BUF_DONE_INT_SET_V  0x00000001U
+#define SPI_SLV_WR_BUF_DONE_INT_SET_S  11
+/** SPI_TRANS_DONE_INT_SET : WT; bitpos: [12]; default: 0;
+ *  The software set bit for SPI_TRANS_DONE_INT interrupt.
+ */
+#define SPI_TRANS_DONE_INT_SET    (BIT(12))
+#define SPI_TRANS_DONE_INT_SET_M  (SPI_TRANS_DONE_INT_SET_V << SPI_TRANS_DONE_INT_SET_S)
+#define SPI_TRANS_DONE_INT_SET_V  0x00000001U
+#define SPI_TRANS_DONE_INT_SET_S  12
+/** SPI_DMA_SEG_TRANS_DONE_INT_SET : WT; bitpos: [13]; default: 0;
+ *  The software set bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt.
+ */
+#define SPI_DMA_SEG_TRANS_DONE_INT_SET    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_SET_M  (SPI_DMA_SEG_TRANS_DONE_INT_SET_V << SPI_DMA_SEG_TRANS_DONE_INT_SET_S)
+#define SPI_DMA_SEG_TRANS_DONE_INT_SET_V  0x00000001U
+#define SPI_DMA_SEG_TRANS_DONE_INT_SET_S  13
+/** SPI_SEG_MAGIC_ERR_INT_SET : WT; bitpos: [14]; default: 0;
+ *  The software set bit for SPI_SEG_MAGIC_ERR_INT interrupt.
+ */
+//this field is only for GPSPI2
+#define SPI_SEG_MAGIC_ERR_INT_SET    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_SET_M  (SPI_SEG_MAGIC_ERR_INT_SET_V << SPI_SEG_MAGIC_ERR_INT_SET_S)
+#define SPI_SEG_MAGIC_ERR_INT_SET_V  0x00000001U
+#define SPI_SEG_MAGIC_ERR_INT_SET_S  14
+/** SPI_SLV_BUF_ADDR_ERR_INT_SET : WT; bitpos: [15]; default: 0;
+ *  The software set bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt.
+ */
+#define SPI_SLV_BUF_ADDR_ERR_INT_SET    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_SET_M  (SPI_SLV_BUF_ADDR_ERR_INT_SET_V << SPI_SLV_BUF_ADDR_ERR_INT_SET_S)
+#define SPI_SLV_BUF_ADDR_ERR_INT_SET_V  0x00000001U
+#define SPI_SLV_BUF_ADDR_ERR_INT_SET_S  15
+/** SPI_SLV_CMD_ERR_INT_SET : WT; bitpos: [16]; default: 0;
+ *  The software set bit for SPI_SLV_CMD_ERR_INT interrupt.
+ */
+#define SPI_SLV_CMD_ERR_INT_SET    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_SET_M  (SPI_SLV_CMD_ERR_INT_SET_V << SPI_SLV_CMD_ERR_INT_SET_S)
+#define SPI_SLV_CMD_ERR_INT_SET_V  0x00000001U
+#define SPI_SLV_CMD_ERR_INT_SET_S  16
+/** SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET : WT; bitpos: [17]; default: 0;
+ *  The software set bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt.
+ */
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET_M  (SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET_V << SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET_S)
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET_V  0x00000001U
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_SET_S  17
+/** SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET : WT; bitpos: [18]; default: 0;
+ *  The software set bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt.
+ */
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET_M  (SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET_V << SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET_S)
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET_V  0x00000001U
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_SET_S  18
+/** SPI_APP2_INT_SET : WT; bitpos: [19]; default: 0;
+ *  The software set bit for SPI_APP2_INT interrupt.
+ */
+#define SPI_APP2_INT_SET    (BIT(19))
+#define SPI_APP2_INT_SET_M  (SPI_APP2_INT_SET_V << SPI_APP2_INT_SET_S)
+#define SPI_APP2_INT_SET_V  0x00000001U
+#define SPI_APP2_INT_SET_S  19
+/** SPI_APP1_INT_SET : WT; bitpos: [20]; default: 0;
+ *  The software set bit for SPI_APP1_INT interrupt.
+ */
+#define SPI_APP1_INT_SET    (BIT(20))
+#define SPI_APP1_INT_SET_M  (SPI_APP1_INT_SET_V << SPI_APP1_INT_SET_S)
+#define SPI_APP1_INT_SET_V  0x00000001U
+#define SPI_APP1_INT_SET_S  20
+
+/** SPI_W0_REG register
+ *  SPI CPU-controlled buffer0
+ */
+#define SPI_W0_REG(i) (REG_SPI_BASE(i) + 0x98)
+/** SPI_BUF0 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF0    0xFFFFFFFFU
+#define SPI_BUF0_M  (SPI_BUF0_V << SPI_BUF0_S)
+#define SPI_BUF0_V  0xFFFFFFFFU
+#define SPI_BUF0_S  0
+
+/** SPI_W1_REG register
+ *  SPI CPU-controlled buffer1
+ */
+#define SPI_W1_REG(i) (REG_SPI_BASE(i) + 0x9c)
+/** SPI_BUF1 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF1    0xFFFFFFFFU
+#define SPI_BUF1_M  (SPI_BUF1_V << SPI_BUF1_S)
+#define SPI_BUF1_V  0xFFFFFFFFU
+#define SPI_BUF1_S  0
+
+/** SPI_W2_REG register
+ *  SPI CPU-controlled buffer2
+ */
+#define SPI_W2_REG(i) (REG_SPI_BASE(i) + 0xa0)
+/** SPI_BUF2 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF2    0xFFFFFFFFU
+#define SPI_BUF2_M  (SPI_BUF2_V << SPI_BUF2_S)
+#define SPI_BUF2_V  0xFFFFFFFFU
+#define SPI_BUF2_S  0
+
+/** SPI_W3_REG register
+ *  SPI CPU-controlled buffer3
+ */
+#define SPI_W3_REG(i) (REG_SPI_BASE(i) + 0xa4)
+/** SPI_BUF3 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF3    0xFFFFFFFFU
+#define SPI_BUF3_M  (SPI_BUF3_V << SPI_BUF3_S)
+#define SPI_BUF3_V  0xFFFFFFFFU
+#define SPI_BUF3_S  0
+
+/** SPI_W4_REG register
+ *  SPI CPU-controlled buffer4
+ */
+#define SPI_W4_REG(i) (REG_SPI_BASE(i) + 0xa8)
+/** SPI_BUF4 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF4    0xFFFFFFFFU
+#define SPI_BUF4_M  (SPI_BUF4_V << SPI_BUF4_S)
+#define SPI_BUF4_V  0xFFFFFFFFU
+#define SPI_BUF4_S  0
+
+/** SPI_W5_REG register
+ *  SPI CPU-controlled buffer5
+ */
+#define SPI_W5_REG(i) (REG_SPI_BASE(i) + 0xac)
+/** SPI_BUF5 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF5    0xFFFFFFFFU
+#define SPI_BUF5_M  (SPI_BUF5_V << SPI_BUF5_S)
+#define SPI_BUF5_V  0xFFFFFFFFU
+#define SPI_BUF5_S  0
+
+/** SPI_W6_REG register
+ *  SPI CPU-controlled buffer6
+ */
+#define SPI_W6_REG(i) (REG_SPI_BASE(i) + 0xb0)
+/** SPI_BUF6 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF6    0xFFFFFFFFU
+#define SPI_BUF6_M  (SPI_BUF6_V << SPI_BUF6_S)
+#define SPI_BUF6_V  0xFFFFFFFFU
+#define SPI_BUF6_S  0
+
+/** SPI_W7_REG register
+ *  SPI CPU-controlled buffer7
+ */
+#define SPI_W7_REG(i) (REG_SPI_BASE(i) + 0xb4)
+/** SPI_BUF7 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF7    0xFFFFFFFFU
+#define SPI_BUF7_M  (SPI_BUF7_V << SPI_BUF7_S)
+#define SPI_BUF7_V  0xFFFFFFFFU
+#define SPI_BUF7_S  0
+
+/** SPI_W8_REG register
+ *  SPI CPU-controlled buffer8
+ */
+#define SPI_W8_REG(i) (REG_SPI_BASE(i) + 0xb8)
+/** SPI_BUF8 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF8    0xFFFFFFFFU
+#define SPI_BUF8_M  (SPI_BUF8_V << SPI_BUF8_S)
+#define SPI_BUF8_V  0xFFFFFFFFU
+#define SPI_BUF8_S  0
+
+/** SPI_W9_REG register
+ *  SPI CPU-controlled buffer9
+ */
+#define SPI_W9_REG(i) (REG_SPI_BASE(i) + 0xbc)
+/** SPI_BUF9 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF9    0xFFFFFFFFU
+#define SPI_BUF9_M  (SPI_BUF9_V << SPI_BUF9_S)
+#define SPI_BUF9_V  0xFFFFFFFFU
+#define SPI_BUF9_S  0
+
+/** SPI_W10_REG register
+ *  SPI CPU-controlled buffer10
+ */
+#define SPI_W10_REG(i) (REG_SPI_BASE(i) + 0xc0)
+/** SPI_BUF10 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF10    0xFFFFFFFFU
+#define SPI_BUF10_M  (SPI_BUF10_V << SPI_BUF10_S)
+#define SPI_BUF10_V  0xFFFFFFFFU
+#define SPI_BUF10_S  0
+
+/** SPI_W11_REG register
+ *  SPI CPU-controlled buffer11
+ */
+#define SPI_W11_REG(i) (REG_SPI_BASE(i) + 0xc4)
+/** SPI_BUF11 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF11    0xFFFFFFFFU
+#define SPI_BUF11_M  (SPI_BUF11_V << SPI_BUF11_S)
+#define SPI_BUF11_V  0xFFFFFFFFU
+#define SPI_BUF11_S  0
+
+/** SPI_W12_REG register
+ *  SPI CPU-controlled buffer12
+ */
+#define SPI_W12_REG(i) (REG_SPI_BASE(i) + 0xc8)
+/** SPI_BUF12 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF12    0xFFFFFFFFU
+#define SPI_BUF12_M  (SPI_BUF12_V << SPI_BUF12_S)
+#define SPI_BUF12_V  0xFFFFFFFFU
+#define SPI_BUF12_S  0
+
+/** SPI_W13_REG register
+ *  SPI CPU-controlled buffer13
+ */
+#define SPI_W13_REG(i) (REG_SPI_BASE(i) + 0xcc)
+/** SPI_BUF13 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF13    0xFFFFFFFFU
+#define SPI_BUF13_M  (SPI_BUF13_V << SPI_BUF13_S)
+#define SPI_BUF13_V  0xFFFFFFFFU
+#define SPI_BUF13_S  0
+
+/** SPI_W14_REG register
+ *  SPI CPU-controlled buffer14
+ */
+#define SPI_W14_REG(i) (REG_SPI_BASE(i) + 0xd0)
+/** SPI_BUF14 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF14    0xFFFFFFFFU
+#define SPI_BUF14_M  (SPI_BUF14_V << SPI_BUF14_S)
+#define SPI_BUF14_V  0xFFFFFFFFU
+#define SPI_BUF14_S  0
+
+/** SPI_W15_REG register
+ *  SPI CPU-controlled buffer15
+ */
+#define SPI_W15_REG(i) (REG_SPI_BASE(i) + 0xd4)
+/** SPI_BUF15 : R/W/SS; bitpos: [31:0]; default: 0;
+ *  data buffer
+ */
+#define SPI_BUF15    0xFFFFFFFFU
+#define SPI_BUF15_M  (SPI_BUF15_V << SPI_BUF15_S)
+#define SPI_BUF15_V  0xFFFFFFFFU
+#define SPI_BUF15_S  0
+
+/** SPI_SLAVE_REG register
+ *  SPI slave control register
+ */
+#define SPI_SLAVE_REG(i) (REG_SPI_BASE(i) + 0xe0)
+/** SPI_CLK_MODE : R/W; bitpos: [1:0]; default: 0;
+ *  SPI clock mode bits. 0: SPI clock is off when CS inactive 1: SPI clock is delayed
+ *  one cycle after CS inactive 2: SPI clock is delayed two cycles after CS inactive 3:
+ *  SPI clock is always on. Can be configured in CONF state.
+ */
+#define SPI_CLK_MODE    0x00000003U
+#define SPI_CLK_MODE_M  (SPI_CLK_MODE_V << SPI_CLK_MODE_S)
+#define SPI_CLK_MODE_V  0x00000003U
+#define SPI_CLK_MODE_S  0
+/** SPI_CLK_MODE_13 : R/W; bitpos: [2]; default: 0;
+ *  {CPOL, CPHA},1: support spi clk mode 1 and 3, first edge output data B[0]/B[7].  0:
+ *  support spi clk mode 0 and 2, first edge output data B[1]/B[6].
+ */
+#define SPI_CLK_MODE_13    (BIT(2))
+#define SPI_CLK_MODE_13_M  (SPI_CLK_MODE_13_V << SPI_CLK_MODE_13_S)
+#define SPI_CLK_MODE_13_V  0x00000001U
+#define SPI_CLK_MODE_13_S  2
+/** SPI_RSCK_DATA_OUT : R/W; bitpos: [3]; default: 0;
+ *  It saves half a cycle when tsck is the same as rsck. 1: output data at rsck posedge
+ *  0: output data at tsck posedge
+ */
+#define SPI_RSCK_DATA_OUT    (BIT(3))
+#define SPI_RSCK_DATA_OUT_M  (SPI_RSCK_DATA_OUT_V << SPI_RSCK_DATA_OUT_S)
+#define SPI_RSCK_DATA_OUT_V  0x00000001U
+#define SPI_RSCK_DATA_OUT_S  3
+/** SPI_SLV_RDDMA_BITLEN_EN : R/W; bitpos: [8]; default: 0;
+ *  1: SPI_SLV_DATA_BITLEN stores data bit length of master-read-slave data length in
+ *  DMA controlled mode(Rd_DMA). 0: others
+ */
+#define SPI_SLV_RDDMA_BITLEN_EN    (BIT(8))
+#define SPI_SLV_RDDMA_BITLEN_EN_M  (SPI_SLV_RDDMA_BITLEN_EN_V << SPI_SLV_RDDMA_BITLEN_EN_S)
+#define SPI_SLV_RDDMA_BITLEN_EN_V  0x00000001U
+#define SPI_SLV_RDDMA_BITLEN_EN_S  8
+/** SPI_SLV_WRDMA_BITLEN_EN : R/W; bitpos: [9]; default: 0;
+ *  1: SPI_SLV_DATA_BITLEN stores data bit length of master-write-to-slave data length
+ *  in DMA controlled mode(Wr_DMA). 0: others
+ */
+#define SPI_SLV_WRDMA_BITLEN_EN    (BIT(9))
+#define SPI_SLV_WRDMA_BITLEN_EN_M  (SPI_SLV_WRDMA_BITLEN_EN_V << SPI_SLV_WRDMA_BITLEN_EN_S)
+#define SPI_SLV_WRDMA_BITLEN_EN_V  0x00000001U
+#define SPI_SLV_WRDMA_BITLEN_EN_S  9
+/** SPI_SLV_RDBUF_BITLEN_EN : R/W; bitpos: [10]; default: 0;
+ *  1: SPI_SLV_DATA_BITLEN stores data bit length of master-read-slave data length in
+ *  CPU controlled mode(Rd_BUF). 0: others
+ */
+#define SPI_SLV_RDBUF_BITLEN_EN    (BIT(10))
+#define SPI_SLV_RDBUF_BITLEN_EN_M  (SPI_SLV_RDBUF_BITLEN_EN_V << SPI_SLV_RDBUF_BITLEN_EN_S)
+#define SPI_SLV_RDBUF_BITLEN_EN_V  0x00000001U
+#define SPI_SLV_RDBUF_BITLEN_EN_S  10
+/** SPI_SLV_WRBUF_BITLEN_EN : R/W; bitpos: [11]; default: 0;
+ *  1: SPI_SLV_DATA_BITLEN stores data bit length of master-write-to-slave data length
+ *  in CPU controlled mode(Wr_BUF). 0: others
+ */
+#define SPI_SLV_WRBUF_BITLEN_EN    (BIT(11))
+#define SPI_SLV_WRBUF_BITLEN_EN_M  (SPI_SLV_WRBUF_BITLEN_EN_V << SPI_SLV_WRBUF_BITLEN_EN_S)
+#define SPI_SLV_WRBUF_BITLEN_EN_V  0x00000001U
+#define SPI_SLV_WRBUF_BITLEN_EN_S  11
+/** SPI_SLV_LAST_BYTE_STRB : R/SS; bitpos: [19:12]; default: 0;
+ *  Represents the effective bit of the last received data byte in SPI slave FD and HD
+ *  mode.
+ */
+#define SPI_SLV_LAST_BYTE_STRB    0x000000FFU
+#define SPI_SLV_LAST_BYTE_STRB_M  (SPI_SLV_LAST_BYTE_STRB_V << SPI_SLV_LAST_BYTE_STRB_S)
+#define SPI_SLV_LAST_BYTE_STRB_V  0x000000FFU
+#define SPI_SLV_LAST_BYTE_STRB_S  12
+/** SPI_DMA_SEG_MAGIC_VALUE : R/W; bitpos: [25:22]; default: 10;
+ *  The magic value of BM table in master DMA seg-trans.
+ */
+//this field is only for GPSPI2
+#define SPI_DMA_SEG_MAGIC_VALUE    0x0000000FU
+#define SPI_DMA_SEG_MAGIC_VALUE_M  (SPI_DMA_SEG_MAGIC_VALUE_V << SPI_DMA_SEG_MAGIC_VALUE_S)
+#define SPI_DMA_SEG_MAGIC_VALUE_V  0x0000000FU
+#define SPI_DMA_SEG_MAGIC_VALUE_S  22
+/** SPI_SLAVE_MODE : R/W; bitpos: [26]; default: 0;
+ *  Set SPI work mode. 1: slave mode 0: master mode.
+ */
+#define SPI_SLAVE_MODE    (BIT(26))
+#define SPI_SLAVE_MODE_M  (SPI_SLAVE_MODE_V << SPI_SLAVE_MODE_S)
+#define SPI_SLAVE_MODE_V  0x00000001U
+#define SPI_SLAVE_MODE_S  26
+/** SPI_SOFT_RESET : WT; bitpos: [27]; default: 0;
+ *  Software reset enable, reset the spi clock line cs line and data lines. Can be
+ *  configured in CONF state.
+ */
+#define SPI_SOFT_RESET    (BIT(27))
+#define SPI_SOFT_RESET_M  (SPI_SOFT_RESET_V << SPI_SOFT_RESET_S)
+#define SPI_SOFT_RESET_V  0x00000001U
+#define SPI_SOFT_RESET_S  27
+/** SPI_USR_CONF : R/W; bitpos: [28]; default: 0;
+ *  1: Enable the DMA CONF phase of current seg-trans operation, which means seg-trans
+ *  will start. 0: This is not seg-trans mode.
+ */
+//this field is only for GPSPI2
+#define SPI_USR_CONF    (BIT(28))
+#define SPI_USR_CONF_M  (SPI_USR_CONF_V << SPI_USR_CONF_S)
+#define SPI_USR_CONF_V  0x00000001U
+#define SPI_USR_CONF_S  28
+/** SPI_MST_FD_WAIT_DMA_TX_DATA : R/W; bitpos: [29]; default: 0;
+ *  In master full-duplex mode, 1: GP-SPI will wait DMA TX data is ready before
+ *  starting SPI transfer. 0: GP-SPI does not wait DMA TX data before starting SPI
+ *  transfer.
+ */
+#define SPI_MST_FD_WAIT_DMA_TX_DATA    (BIT(29))
+#define SPI_MST_FD_WAIT_DMA_TX_DATA_M  (SPI_MST_FD_WAIT_DMA_TX_DATA_V << SPI_MST_FD_WAIT_DMA_TX_DATA_S)
+#define SPI_MST_FD_WAIT_DMA_TX_DATA_V  0x00000001U
+#define SPI_MST_FD_WAIT_DMA_TX_DATA_S  29
+
+/** SPI_SLAVE1_REG register
+ *  SPI slave control register 1
+ */
+#define SPI_SLAVE1_REG(i) (REG_SPI_BASE(i) + 0xe4)
+/** SPI_SLV_DATA_BITLEN : R/W/SS; bitpos: [17:0]; default: 0;
+ *  The transferred data bit length in SPI slave FD and HD mode.
+ */
+#define SPI_SLV_DATA_BITLEN    0x0003FFFFU
+#define SPI_SLV_DATA_BITLEN_M  (SPI_SLV_DATA_BITLEN_V << SPI_SLV_DATA_BITLEN_S)
+#define SPI_SLV_DATA_BITLEN_V  0x0003FFFFU
+#define SPI_SLV_DATA_BITLEN_S  0
+/** SPI_SLV_LAST_COMMAND : R/W/SS; bitpos: [25:18]; default: 0;
+ *  In the slave mode it is the value of command.
+ */
+#define SPI_SLV_LAST_COMMAND    0x000000FFU
+#define SPI_SLV_LAST_COMMAND_M  (SPI_SLV_LAST_COMMAND_V << SPI_SLV_LAST_COMMAND_S)
+#define SPI_SLV_LAST_COMMAND_V  0x000000FFU
+#define SPI_SLV_LAST_COMMAND_S  18
+/** SPI_SLV_LAST_ADDR : R/W/SS; bitpos: [31:26]; default: 0;
+ *  In the slave mode it is the value of address.
+ */
+#define SPI_SLV_LAST_ADDR    0x0000003FU
+#define SPI_SLV_LAST_ADDR_M  (SPI_SLV_LAST_ADDR_V << SPI_SLV_LAST_ADDR_S)
+#define SPI_SLV_LAST_ADDR_V  0x0000003FU
+#define SPI_SLV_LAST_ADDR_S  26
+
+/** SPI_CLK_GATE_REG register
+ *  SPI module clock and register clock control
+ */
+#define SPI_CLK_GATE_REG(i) (REG_SPI_BASE(i) + 0xe8)
+/** SPI_CLK_EN : R/W; bitpos: [0]; default: 0;
+ *  Set this bit to enable clk gate
+ */
+#define SPI_CLK_EN    (BIT(0))
+#define SPI_CLK_EN_M  (SPI_CLK_EN_V << SPI_CLK_EN_S)
+#define SPI_CLK_EN_V  0x00000001U
+#define SPI_CLK_EN_S  0
+/** SPI_MST_CLK_ACTIVE : R/W; bitpos: [1]; default: 0;
+ *  Set this bit to power on the SPI module clock.
+ */
+#define SPI_MST_CLK_ACTIVE    (BIT(1))
+#define SPI_MST_CLK_ACTIVE_M  (SPI_MST_CLK_ACTIVE_V << SPI_MST_CLK_ACTIVE_S)
+#define SPI_MST_CLK_ACTIVE_V  0x00000001U
+#define SPI_MST_CLK_ACTIVE_S  1
+/** SPI_MST_CLK_SEL : R/W; bitpos: [2]; default: 0;
+ *  This bit is used to select SPI module clock source in master mode. 1: PLL_CLK_80M.
+ *  0: XTAL CLK.
+ */
+#define SPI_MST_CLK_SEL    (BIT(2))
+#define SPI_MST_CLK_SEL_M  (SPI_MST_CLK_SEL_V << SPI_MST_CLK_SEL_S)
+#define SPI_MST_CLK_SEL_V  0x00000001U
+#define SPI_MST_CLK_SEL_S  2
+
+/** SPI_DATE_REG register
+ *  Version control
+ */
+#define SPI_DATE_REG(i) (REG_SPI_BASE(i) + 0xf0)
+/** SPI_DATE : R/W; bitpos: [27:0]; default: 35680770;
+ *  SPI register version.
+ */
+#define SPI_DATE    0x0FFFFFFFU
+#define SPI_DATE_M  (SPI_DATE_V << SPI_DATE_S)
+#define SPI_DATE_V  0x0FFFFFFFU
+#define SPI_DATE_S  0
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/target/esp32p4/src/spi.c
+++ b/src/target/esp32p4/src/spi.c
@@ -1,0 +1,238 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * SPI (download boot) transport for the ESP32-P4 flasher stub.
+ *
+ * GP-SPI2 slave + AXI-DMA (channel 0) are left configured by the ROM download
+ * boot; the driver only arms the DMA and drives the shared W0..W3 handshake
+ * registers.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <esp-stub-lib/bit_utils.h>
+#include <esp-stub-lib/err.h>
+#include <esp-stub-lib/soc_utils.h>
+
+#include <target/cache.h>
+#include <target/spi.h>
+
+#include <private/helpers.h>
+#include <private/spi_slave_protocol.h>
+
+#include <soc/axi_dma_reg.h>
+#include <soc/interrupt_core0_reg.h>
+#include <soc/spi_reg.h>
+
+#define SPI_SLV_HOST        2 /* GP-SPI2 */
+
+#define SPI_SLV_REG_VER     SPI_W0_REG(SPI_SLV_HOST)
+#define SPI_SLV_REG_RXSTA   SPI_W1_REG(SPI_SLV_HOST)
+#define SPI_SLV_REG_TXSTA   SPI_W2_REG(SPI_SLV_HOST)
+#define SPI_SLV_REG_CMD     SPI_W3_REG(SPI_SLV_HOST)
+
+/* Host WRDMA writes to us (RX); host RDDMA reads from us (TX). */
+#define SPI_SLV_RX_DONE     SPI_SLV_WR_DMA_DONE_INT_RAW
+#define SPI_SLV_RX_DONE_CLR SPI_SLV_WR_DMA_DONE_INT_CLR
+#define SPI_SLV_TX_DONE     SPI_SLV_RD_DMA_DONE_INT_RAW
+#define SPI_SLV_TX_DONE_CLR SPI_SLV_RD_DMA_DONE_INT_CLR
+
+/* DMA descriptor (ROM lldesc_spi_s layout); P4 needs it 8-byte aligned. */
+typedef struct __attribute__((aligned(8))) lldesc_spi_s {
+    volatile uint32_t size : 12, length : 12, offset : 5, sosf : 1, eof : 1, owner : 1;
+    volatile uint8_t *buf;
+    struct lldesc_spi_s *next;
+    uint32_t pad_to_8byte;
+} lldesc_spi_t;
+
+#define LLDESC_SPI_MAX_BUFFER_SIZE (4096U - 4U)
+#define LLDESC_SPI_SIZE_MASK       0xFFFU
+
+/* Chain sized to cover FRAME_BUFFER_SIZE (0x4107). */
+#define SPI_SLV_RX_DESC_COUNT      5U
+#define SPI_SLV_RX_MAX_LEN         (SPI_SLV_RX_DESC_COUNT * LLDESC_SPI_MAX_BUFFER_SIZE)
+
+static lldesc_spi_t dmadesc_tx;
+static lldesc_spi_t dmadesc_rx[SPI_SLV_RX_DESC_COUNT];
+
+extern void esp_rom_software_reset_cpu(uint32_t);
+
+static uint32_t s_seq_rx;
+static uint32_t s_seq_tx;
+static volatile bool s_rx_armed;
+
+/* Saved so tx_frame() can re-arm RX after a TX rewrites SPI_DMA_CONF. */
+static uint8_t *s_rx_buf;
+static uint32_t s_rx_len;
+
+bool stub_target_spi_is_active(void)
+{
+    if (!(READ_PERI_REG(SPI_SLAVE_REG(SPI_SLV_HOST)) & SPI_SLAVE_MODE)) {
+        return false;
+    }
+    uint32_t cmd = READ_PERI_REG(SPI_SLV_REG_CMD) & 0xFFU;
+    return (cmd == SPI_SLV_CMD_READY) || (cmd == SPI_SLV_CMD_DONE);
+}
+
+void stub_target_spi_init(void)
+{
+    /* Unroute the ROM's SPI2 ISR so it can't race our polled handshake. */
+    WRITE_PERI_REG(INTERRUPT_CORE0_SPI2_INT_MAP_REG, 0);
+
+    /* ROM download boot leaves CMD = DONE; the host's stub-connect handshake
+     * busy-waits for IDLE, so this reset is required. */
+    WRITE_PERI_REG(SPI_SLV_REG_CMD, SPI_SLV_CMD_IDLE);
+
+    s_seq_rx = SPI_SLV_STATE_INIT;
+    s_seq_tx = SPI_SLV_STATE_INIT;
+    s_rx_armed = false;
+}
+
+/* Split buf into <=4092-byte descriptors and (re)start the RX inlink. */
+static void spi_slv_rxdma_arm(uint8_t *buf, uint32_t len)
+{
+    uint32_t remaining = len;
+    uint8_t *buf_pos = buf;
+    uint32_t desc_idx = 0;
+    while (remaining) {
+        uint32_t chunk = (remaining > LLDESC_SPI_MAX_BUFFER_SIZE) ? LLDESC_SPI_MAX_BUFFER_SIZE : remaining;
+        uint32_t aligned_len = (chunk + 3U) & ~3U; /* 4-byte DMA granularity */
+        dmadesc_rx[desc_idx].size = aligned_len & LLDESC_SPI_SIZE_MASK;
+        dmadesc_rx[desc_idx].length = aligned_len & LLDESC_SPI_SIZE_MASK;
+        dmadesc_rx[desc_idx].buf = buf_pos;
+        dmadesc_rx[desc_idx].sosf = 0;
+        dmadesc_rx[desc_idx].owner = 1;
+        if (remaining <= chunk) {
+            dmadesc_rx[desc_idx].eof = 1;
+            dmadesc_rx[desc_idx].next = NULL;
+        } else {
+            dmadesc_rx[desc_idx].eof = 0;
+            dmadesc_rx[desc_idx].next = &dmadesc_rx[desc_idx + 1];
+        }
+        remaining -= chunk;
+        buf_pos += chunk;
+        desc_idx++;
+    }
+    stub_target_cache_writeback_addr((uint32_t)(uintptr_t)dmadesc_rx, desc_idx * sizeof(dmadesc_rx[0]));
+
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_RX_DONE_CLR);
+    SET_PERI_REG_MASK(AXI_DMA_IN_CONF0_CH0_REG, AXI_DMA_IN_RST_CH0);
+    CLEAR_PERI_REG_MASK(AXI_DMA_IN_CONF0_CH0_REG, AXI_DMA_IN_RST_CH0);
+    WRITE_PERI_REG(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_AFIFO_RST | SPI_BUF_AFIFO_RST | SPI_RX_AFIFO_RST);
+    SET_PERI_REG_MASK(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_RX_ENA);
+    WRITE_PERI_REG(AXI_DMA_IN_LINK2_CH0_REG, (uint32_t)(uintptr_t)dmadesc_rx);
+    /* Clear a stale dscr_err/underflow, else the inlink never runs. */
+    WRITE_PERI_REG(AXI_DMA_IN_INT_CLR_CH0_REG,
+                   AXI_DMA_IN_DSCR_ERR_CH0_INT_CLR | AXI_DMA_INFIFO_L1_UDF_CH0_INT_CLR |
+                       AXI_DMA_INFIFO_L2_UDF_CH0_INT_CLR | AXI_DMA_INFIFO_L3_UDF_CH0_INT_CLR);
+    SET_PERI_REG_MASK(AXI_DMA_IN_LINK1_CH0_REG, AXI_DMA_INLINK_START_CH0);
+}
+
+int stub_target_spi_rearm(uint8_t *buf, size_t max_size)
+{
+    if (s_rx_armed) {
+        return STUB_LIB_OK;
+    }
+    if (buf == NULL || max_size == 0) {
+        return STUB_LIB_ERR_INVALID_ARG;
+    }
+
+    if (max_size > SPI_SLV_RX_MAX_LEN) {
+        max_size = SPI_SLV_RX_MAX_LEN;
+    }
+
+    spi_slv_rxdma_arm(buf, (uint32_t)max_size);
+    s_rx_buf = buf;
+    s_rx_len = (uint32_t)max_size;
+
+    s_seq_rx ^= SPI_SLV_STA_TOGGLE;
+    uint32_t rxsta = s_seq_rx | ((uint32_t)max_size << SPI_SLV_STA_LEN_SHIFT);
+    s_seq_rx &= ~SPI_SLV_STA_INIT;
+    WRITE_PERI_REG(SPI_SLV_REG_RXSTA, rxsta);
+
+    s_rx_armed = true;
+    return STUB_LIB_OK;
+}
+
+static void spi_slv_service_cmd(void)
+{
+    uint32_t cmd = READ_PERI_REG(SPI_SLV_REG_CMD) & 0xFFU;
+    switch (cmd) {
+    case SPI_SLV_CMD_READY:
+        WRITE_PERI_REG(SPI_SLV_REG_CMD, SPI_SLV_CMD_READY);
+        break;
+    case SPI_SLV_CMD_REBOOT:
+        esp_rom_software_reset_cpu(0);
+        break;
+    default:
+        break;
+    }
+}
+
+bool stub_target_spi_take_rx_frame(size_t *out_len)
+{
+    spi_slv_service_cmd();
+
+    if (!(READ_PERI_REG(SPI_DMA_INT_RAW_REG(SPI_SLV_HOST)) & SPI_SLV_RX_DONE)) {
+        return false;
+    }
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_RX_DONE_CLR);
+
+    /* Stub runs from cached L2MEM; drop stale lines so we read the DMA'd bytes. */
+    if (s_rx_buf != NULL) {
+        stub_target_cache_invalidate_addr((uint32_t)(uintptr_t)s_rx_buf, s_rx_len);
+    }
+
+    if (out_len) {
+        uint32_t bitlen = READ_PERI_REG(SPI_SLAVE1_REG(SPI_SLV_HOST)) & SPI_SLV_DATA_BITLEN;
+        *out_len = bitlen / 8U;
+    }
+
+    s_rx_armed = false;
+    return true;
+}
+
+int stub_target_spi_tx_frame(const void *data, size_t len)
+{
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_TX_DONE_CLR);
+
+    dmadesc_tx.size = (uint32_t)len & LLDESC_SPI_SIZE_MASK;
+    dmadesc_tx.length = (uint32_t)len & LLDESC_SPI_SIZE_MASK;
+    dmadesc_tx.buf = (uint8_t *)data;
+    dmadesc_tx.sosf = 0;
+    dmadesc_tx.eof = 1;
+    dmadesc_tx.owner = 1;
+    dmadesc_tx.next = NULL;
+    stub_target_cache_writeback_addr((uint32_t)(uintptr_t)data, (uint32_t)len);
+    stub_target_cache_writeback_addr((uint32_t)(uintptr_t)&dmadesc_tx, sizeof(dmadesc_tx));
+
+    SET_PERI_REG_MASK(AXI_DMA_OUT_CONF0_CH0_REG, AXI_DMA_OUT_RST_CH0);
+    CLEAR_PERI_REG_MASK(AXI_DMA_OUT_CONF0_CH0_REG, AXI_DMA_OUT_RST_CH0);
+    WRITE_PERI_REG(AXI_DMA_OUT_LINK2_CH0_REG, (uint32_t)(uintptr_t)&dmadesc_tx);
+    SET_PERI_REG_MASK(AXI_DMA_OUT_LINK1_CH0_REG, AXI_DMA_OUTLINK_START_CH0);
+    WRITE_PERI_REG(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_AFIFO_RST | SPI_BUF_AFIFO_RST | SPI_RX_AFIFO_RST);
+    SET_PERI_REG_MASK(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_TX_ENA);
+
+    s_seq_tx ^= SPI_SLV_STA_TOGGLE;
+    uint32_t txsta = s_seq_tx | ((uint32_t)len << SPI_SLV_STA_LEN_SHIFT);
+    s_seq_tx &= ~SPI_SLV_STA_INIT;
+    WRITE_PERI_REG(SPI_SLV_REG_TXSTA, txsta);
+
+    /* Leave TXSTA set until the next frame; clearing it early races the host. */
+    uint64_t timeout_us = SPI_SLV_TX_TIMEOUT_US;
+    int ret = stub_target_wait_reg_bit_set(SPI_DMA_INT_RAW_REG(SPI_SLV_HOST), SPI_SLV_TX_DONE, &timeout_us);
+    if (ret != STUB_LIB_OK) {
+        return STUB_LIB_FAIL;
+    }
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_TX_DONE_CLR);
+
+    /* Enabling TX DMA rewrote SPI_DMA_CONF and disarmed RX DMA; re-arm it. */
+    if (s_rx_armed && s_rx_buf != NULL) {
+        spi_slv_rxdma_arm(s_rx_buf, s_rx_len);
+    }
+    return STUB_LIB_OK;
+}

--- a/src/target/esp32s2/CMakeLists.txt
+++ b/src/target/esp32s2/CMakeLists.txt
@@ -2,6 +2,7 @@ set(srcs
     src/cache.c
     src/flash.c
     src/mmu.c
+    src/spi.c
     src/trax.c
     src/uart.c
     src/security.c

--- a/src/target/esp32s2/include/soc/spi_reg.h
+++ b/src/target/esp32s2/include/soc/spi_reg.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * Minimal ESP32-S2 GP-SPI2 register definitions for the SPI download-boot
+ * transport. Only the registers/fields used by the SPI slave-HD data-plane
+ * driver are included; see the ESP32-S2 TRM "SPI Controller" chapter (and the
+ * full IDF soc/spi_reg.h) for the complete register map. Offsets are relative
+ * to DR_REG_SPI2_BASE and match the canonical IDF definitions.
+ */
+#pragma once
+
+#include <esp-stub-lib/bit_utils.h>
+#include <soc/reg_base.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -------------------------------------------------------------------------
+ * Register offsets (GP-SPI2)
+ * ------------------------------------------------------------------------- */
+#define SPI_SLAVE_REG       (DR_REG_SPI2_BASE + 0x030) /* slave-mode control        */
+#define SPI_SLV_RD_BYTE_REG (DR_REG_SPI2_BASE + 0x040) /* received byte count (RX)  */
+#define SPI_DMA_INT_RAW_REG (DR_REG_SPI2_BASE + 0x05C) /* DMA raw interrupt status  */
+#define SPI_DMA_INT_CLR_REG (DR_REG_SPI2_BASE + 0x064) /* DMA interrupt clear        */
+#define SPI_W0_REG          (DR_REG_SPI2_BASE + 0x098) /* shared reg: VER            */
+#define SPI_W1_REG          (DR_REG_SPI2_BASE + 0x09C) /* shared reg: RXSTA          */
+#define SPI_W2_REG          (DR_REG_SPI2_BASE + 0x0A0) /* shared reg: TXSTA          */
+#define SPI_W3_REG          (DR_REG_SPI2_BASE + 0x0A4) /* shared reg: CMD            */
+
+/* -------------------------------------------------------------------------
+ * Register fields
+ * ------------------------------------------------------------------------- */
+#define SPI_SLAVE_MODE            BIT(30)      /* SPI_SLAVE_REG: peripheral is a slave     */
+#define SPI_SLV_DATA_BYTELEN      0x000FFFFFU  /* SPI_SLV_RD_BYTE_REG[19:0], bytes         */
+#define SPI_IN_SUC_EOF_INT_RAW    BIT(5)       /* SPI_DMA_INT_RAW: WRDMA frame received    */
+#define SPI_OUT_TOTAL_EOF_INT_RAW BIT(8)       /* SPI_DMA_INT_RAW: RDDMA frame copied out  */
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/target/esp32s2/src/spi.c
+++ b/src/target/esp32s2/src/spi.c
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * SPI (download boot) transport for the ESP32-S2 flasher stub.
+ *
+ * GP-SPI2 slave half-duplex + integrated DMA are already set up by the ROM SPI
+ * download boot. The driver reuses that state and the ROM DMA loaders, and only
+ * drives the shared W0..W3 handshake registers (VER/RXSTA/TXSTA/CMD).
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <esp-stub-lib/bit_utils.h>
+#include <esp-stub-lib/err.h>
+#include <esp-stub-lib/soc_utils.h>
+
+#include <target/spi.h>
+
+#include <private/helpers.h>
+#include <private/spi_slave_protocol.h>
+
+#include <soc/reg_base.h>
+#include <soc/spi_reg.h>
+
+#define SPI_SLV_HW        ((void *)DR_REG_SPI2_BASE) /* peripheral base as ROM handle */
+
+#define SPI_SLV_REG_VER   SPI_W0_REG
+#define SPI_SLV_REG_RXSTA SPI_W1_REG
+#define SPI_SLV_REG_TXSTA SPI_W2_REG
+#define SPI_SLV_REG_CMD   SPI_W3_REG
+
+#define SPI_SLV_RX_DONE   SPI_IN_SUC_EOF_INT_RAW    /* WRDMA frame received   */
+#define SPI_SLV_TX_DONE   SPI_OUT_TOTAL_EOF_INT_RAW /* RDDMA frame copied out */
+
+extern void spi_slave_rom_rxdma_load(void *hw, uint8_t *buf, uint32_t len);
+extern void spi_slave_rom_txdma_load(void *hw, const uint8_t *buf, uint32_t len);
+
+extern void esp_rom_software_reset_cpu(uint32_t);
+
+static uint32_t s_seq_rx;
+static uint32_t s_seq_tx;
+static volatile bool s_rx_armed;
+
+bool stub_target_spi_is_active(void)
+{
+    /* Active only if the ROM left GP-SPI2 in slave mode and CMD holds a
+     * download handshake value (READY = host connected, DONE = stub loaded). */
+    if (!(READ_PERI_REG(SPI_SLAVE_REG) & SPI_SLAVE_MODE)) {
+        return false;
+    }
+    uint32_t cmd = READ_PERI_REG(SPI_SLV_REG_CMD) & 0xFFU;
+    return (cmd == SPI_SLV_CMD_READY) || (cmd == SPI_SLV_CMD_DONE);
+}
+
+void stub_target_spi_init(void)
+{
+    /* ROM download boot leaves CMD = DONE; the host's stub-connect handshake
+     * busy-waits for IDLE, so this reset is required. */
+    WRITE_PERI_REG(SPI_SLV_REG_CMD, SPI_SLV_CMD_IDLE);
+
+    s_seq_rx = SPI_SLV_STATE_INIT;
+    s_seq_tx = SPI_SLV_STATE_INIT;
+    s_rx_armed = false;
+}
+
+int stub_target_spi_rearm(uint8_t *buf, size_t max_size)
+{
+    if (s_rx_armed) {
+        return STUB_LIB_OK;
+    }
+    if (buf == NULL || max_size == 0) {
+        return STUB_LIB_ERR_INVALID_ARG;
+    }
+
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG, SPI_SLV_RX_DONE);
+    spi_slave_rom_rxdma_load(SPI_SLV_HW, buf, (uint32_t)max_size);
+
+    s_seq_rx ^= SPI_SLV_STA_TOGGLE;
+    uint32_t rxsta = s_seq_rx | ((uint32_t)max_size << SPI_SLV_STA_LEN_SHIFT);
+    s_seq_rx &= ~SPI_SLV_STA_INIT;
+    WRITE_PERI_REG(SPI_SLV_REG_RXSTA, rxsta);
+
+    s_rx_armed = true;
+    return STUB_LIB_OK;
+}
+
+/* Poll the shared CMD handshake (no ISR). */
+static void spi_slv_service_cmd(void)
+{
+    uint32_t cmd = READ_PERI_REG(SPI_SLV_REG_CMD) & 0xFFU;
+    switch (cmd) {
+    case SPI_SLV_CMD_READY:
+        WRITE_PERI_REG(SPI_SLV_REG_CMD, SPI_SLV_CMD_READY);
+        break;
+    case SPI_SLV_CMD_REBOOT:
+        esp_rom_software_reset_cpu(0);
+        break;
+    default:
+        break;
+    }
+}
+
+bool stub_target_spi_take_rx_frame(size_t *out_len)
+{
+    spi_slv_service_cmd();
+
+    if (!(READ_PERI_REG(SPI_DMA_INT_RAW_REG) & SPI_SLV_RX_DONE)) {
+        return false;
+    }
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG, SPI_SLV_RX_DONE);
+
+    if (out_len) {
+        /* S2 reports the received length directly in bytes. */
+        *out_len = READ_PERI_REG(SPI_SLV_RD_BYTE_REG) & SPI_SLV_DATA_BYTELEN;
+    }
+
+    s_rx_armed = false;
+    return true;
+}
+
+int stub_target_spi_tx_frame(const void *data, size_t len)
+{
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG, SPI_SLV_TX_DONE);
+    spi_slave_rom_txdma_load(SPI_SLV_HW, (const uint8_t *)data, (uint32_t)len);
+
+    s_seq_tx ^= SPI_SLV_STA_TOGGLE;
+    uint32_t txsta = s_seq_tx | ((uint32_t)len << SPI_SLV_STA_LEN_SHIFT);
+    s_seq_tx &= ~SPI_SLV_STA_INIT;
+    WRITE_PERI_REG(SPI_SLV_REG_TXSTA, txsta);
+
+    /* Leave the TXSTA length until the next frame: the host keys off the toggle
+     * bit, and clearing it early races its poll for short frames (e.g. MD5). */
+    uint64_t timeout_us = SPI_SLV_TX_TIMEOUT_US;
+    int ret = stub_target_wait_reg_bit_set(SPI_DMA_INT_RAW_REG, SPI_SLV_TX_DONE, &timeout_us);
+    if (ret != STUB_LIB_OK) {
+        return STUB_LIB_FAIL;
+    }
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG, SPI_SLV_TX_DONE);
+    return STUB_LIB_OK;
+}

--- a/src/target/esp32s3/CMakeLists.txt
+++ b/src/target/esp32s3/CMakeLists.txt
@@ -2,6 +2,7 @@ set(srcs
     src/cache.c
     src/flash.c
     src/mmu.c
+    src/spi.c
     src/trax.c
     src/uart.c
     src/usb_serial_jtag.c

--- a/src/target/esp32s3/src/spi.c
+++ b/src/target/esp32s3/src/spi.c
@@ -1,0 +1,246 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * SPI (download boot) transport for the ESP32-S3 flasher stub.
+ *
+ * GP-SPI2 slave + GDMA (channel 0) are left configured by the ROM download
+ * boot; the driver only arms the DMA and drives the shared W0..W3 handshake
+ * registers.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <esp-stub-lib/bit_utils.h>
+#include <esp-stub-lib/err.h>
+#include <esp-stub-lib/soc_utils.h>
+
+#include <target/spi.h>
+
+#include <private/helpers.h>
+#include <private/spi_slave_protocol.h>
+
+#include <soc/spi_reg.h>
+
+#define SPI_SLV_HOST                   2 /* GP-SPI2, bound to GDMA channel 0 by the ROM */
+
+#define SPI_SLV_REG_VER                SPI_W0_REG(SPI_SLV_HOST)
+#define SPI_SLV_REG_RXSTA              SPI_W1_REG(SPI_SLV_HOST)
+#define SPI_SLV_REG_TXSTA              SPI_W2_REG(SPI_SLV_HOST)
+#define SPI_SLV_REG_CMD                SPI_W3_REG(SPI_SLV_HOST)
+
+/* Host WRDMA writes to us (RX); host RDDMA reads from us (TX). */
+#define SPI_SLV_RX_DONE                SPI_SLV_WR_DMA_DONE_INT_RAW
+#define SPI_SLV_RX_DONE_CLR            SPI_SLV_WR_DMA_DONE_INT_CLR
+#define SPI_SLV_TX_DONE                SPI_SLV_RD_DMA_DONE_INT_RAW
+#define SPI_SLV_TX_DONE_CLR            SPI_SLV_RD_DMA_DONE_INT_CLR
+
+/* GDMA channel-0 registers (from soc/gdma_reg.h); only the few we drive.
+ * S3's GDMA lays each channel out as a contiguous in/out block, so the
+ * offsets differ from the C2/C3 map. */
+#define GDMA_BASE                      0x6003f000U
+#define GDMA_IN_CONF0_CH0_REG          (GDMA_BASE + 0x000U)
+#define GDMA_IN_INT_CLR_CH0_REG        (GDMA_BASE + 0x014U)
+#define GDMA_IN_LINK_CH0_REG           (GDMA_BASE + 0x020U)
+#define GDMA_OUT_CONF0_CH0_REG         (GDMA_BASE + 0x060U)
+#define GDMA_OUT_LINK_CH0_REG          (GDMA_BASE + 0x080U)
+#define GDMA_IN_RST_CH0                (1U << 0)
+#define GDMA_OUT_RST_CH0               (1U << 0)
+#define GDMA_INLINK_ADDR_CH0           0x000FFFFFU
+#define GDMA_INLINK_START_CH0          (1U << 22)
+#define GDMA_OUTLINK_START_CH0         (1U << 21)
+#define GDMA_INFIFO_UDF_L1_CH0_INT_CLR (1U << 7)
+
+/* DMA descriptor (ROM lldesc_spi_t layout, 3 words). */
+typedef struct lldesc_spi_s {
+    volatile uint32_t size : 12, length : 12, offset : 5, sosf : 1, eof : 1, owner : 1;
+    volatile uint8_t *buf;
+    struct lldesc_spi_s *next;
+} lldesc_spi_t;
+
+#define LLDESC_SPI_MAX_BUFFER_SIZE (4096U - 4U)
+#define LLDESC_SPI_SIZE_MASK       0xFFFU
+
+/* Chain sized to cover FRAME_BUFFER_SIZE (0x4107). */
+#define SPI_SLV_RX_DESC_COUNT      5U
+#define SPI_SLV_RX_MAX_LEN         (SPI_SLV_RX_DESC_COUNT * LLDESC_SPI_MAX_BUFFER_SIZE)
+
+static lldesc_spi_t dmadesc_tx;
+static lldesc_spi_t dmadesc_rx[SPI_SLV_RX_DESC_COUNT];
+
+extern void esp_rom_software_reset_cpu(uint32_t);
+
+static uint32_t s_seq_rx;
+static uint32_t s_seq_tx;
+static volatile bool s_rx_armed;
+
+/* Saved so tx_frame() can re-arm RX after a TX rewrites SPI_DMA_CONF. */
+static uint8_t *s_rx_buf;
+static uint32_t s_rx_len;
+
+bool stub_target_spi_is_active(void)
+{
+    if (!(READ_PERI_REG(SPI_SLAVE_REG(SPI_SLV_HOST)) & SPI_SLAVE_MODE)) {
+        return false;
+    }
+    uint32_t cmd = READ_PERI_REG(SPI_SLV_REG_CMD) & 0xFFU;
+    return (cmd == SPI_SLV_CMD_READY) || (cmd == SPI_SLV_CMD_DONE);
+}
+
+void stub_target_spi_init(void)
+{
+    /* Silence the ROM's SPI2 DMA interrupts so they can't race our polling
+     * (RAW status we poll is unaffected). */
+    WRITE_PERI_REG(SPI_DMA_INT_ENA_REG(SPI_SLV_HOST), 0);
+
+    /* ROM download boot leaves CMD = DONE; the host's stub-connect handshake
+     * busy-waits for IDLE, so this reset is required. */
+    WRITE_PERI_REG(SPI_SLV_REG_CMD, SPI_SLV_CMD_IDLE);
+
+    s_seq_rx = SPI_SLV_STATE_INIT;
+    s_seq_tx = SPI_SLV_STATE_INIT;
+    s_rx_armed = false;
+}
+
+/* Split buf into <=4092-byte descriptors and (re)start the RX inlink. */
+static void spi_slv_rxdma_arm(uint8_t *buf, uint32_t len)
+{
+    uint32_t remaining = len;
+    uint8_t *buf_pos = buf;
+    uint32_t desc_idx = 0;
+    while (remaining) {
+        uint32_t chunk = (remaining > LLDESC_SPI_MAX_BUFFER_SIZE) ? LLDESC_SPI_MAX_BUFFER_SIZE : remaining;
+        uint32_t aligned_len = (chunk + 3U) & ~3U; /* RX needs word-aligned length */
+        dmadesc_rx[desc_idx].size = aligned_len & LLDESC_SPI_SIZE_MASK;
+        dmadesc_rx[desc_idx].length = aligned_len & LLDESC_SPI_SIZE_MASK;
+        dmadesc_rx[desc_idx].buf = buf_pos;
+        dmadesc_rx[desc_idx].sosf = 0;
+        dmadesc_rx[desc_idx].owner = 1;
+        if (remaining <= chunk) {
+            dmadesc_rx[desc_idx].eof = 1;
+            dmadesc_rx[desc_idx].next = NULL;
+        } else {
+            dmadesc_rx[desc_idx].eof = 0;
+            dmadesc_rx[desc_idx].next = &dmadesc_rx[desc_idx + 1];
+        }
+        remaining -= chunk;
+        buf_pos += chunk;
+        desc_idx++;
+    }
+
+    /* gdma_ll_rxdma_reset */
+    SET_PERI_REG_MASK(GDMA_IN_CONF0_CH0_REG, GDMA_IN_RST_CH0);
+    CLEAR_PERI_REG_MASK(GDMA_IN_CONF0_CH0_REG, GDMA_IN_RST_CH0);
+    /* spi_ll_rxdma_start */
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_RX_DONE_CLR);
+    WRITE_PERI_REG(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_AFIFO_RST | SPI_BUF_AFIFO_RST | SPI_RX_AFIFO_RST);
+    SET_PERI_REG_MASK(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_RX_ENA);
+    /* gdma_ll_load_rx_link */
+    WRITE_PERI_REG(GDMA_IN_LINK_CH0_REG, (uint32_t)(uintptr_t)dmadesc_rx & GDMA_INLINK_ADDR_CH0);
+    WRITE_PERI_REG(GDMA_IN_INT_CLR_CH0_REG, GDMA_INFIFO_UDF_L1_CH0_INT_CLR);
+    SET_PERI_REG_MASK(GDMA_IN_LINK_CH0_REG, GDMA_INLINK_START_CH0);
+}
+
+int stub_target_spi_rearm(uint8_t *buf, size_t max_size)
+{
+    if (s_rx_armed) {
+        return STUB_LIB_OK;
+    }
+    if (buf == NULL || max_size == 0) {
+        return STUB_LIB_ERR_INVALID_ARG;
+    }
+
+    if (max_size > SPI_SLV_RX_MAX_LEN) {
+        max_size = SPI_SLV_RX_MAX_LEN;
+    }
+
+    spi_slv_rxdma_arm(buf, (uint32_t)max_size);
+    s_rx_buf = buf;
+    s_rx_len = (uint32_t)max_size;
+
+    s_seq_rx ^= SPI_SLV_STA_TOGGLE;
+    uint32_t rxsta = s_seq_rx | ((uint32_t)max_size << SPI_SLV_STA_LEN_SHIFT);
+    s_seq_rx &= ~SPI_SLV_STA_INIT;
+    WRITE_PERI_REG(SPI_SLV_REG_RXSTA, rxsta);
+
+    s_rx_armed = true;
+    return STUB_LIB_OK;
+}
+
+static void spi_slv_service_cmd(void)
+{
+    uint32_t cmd = READ_PERI_REG(SPI_SLV_REG_CMD) & 0xFFU;
+    switch (cmd) {
+    case SPI_SLV_CMD_READY:
+        WRITE_PERI_REG(SPI_SLV_REG_CMD, SPI_SLV_CMD_READY);
+        break;
+    case SPI_SLV_CMD_REBOOT:
+        esp_rom_software_reset_cpu(0);
+        break;
+    default:
+        break;
+    }
+}
+
+bool stub_target_spi_take_rx_frame(size_t *out_len)
+{
+    spi_slv_service_cmd();
+
+    if (!(READ_PERI_REG(SPI_DMA_INT_RAW_REG(SPI_SLV_HOST)) & SPI_SLV_RX_DONE)) {
+        return false;
+    }
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_RX_DONE_CLR);
+
+    if (out_len) {
+        uint32_t bitlen = READ_PERI_REG(SPI_SLAVE1_REG(SPI_SLV_HOST)) & SPI_SLV_DATA_BITLEN;
+        *out_len = bitlen / 8U;
+    }
+
+    s_rx_armed = false;
+    return true;
+}
+
+int stub_target_spi_tx_frame(const void *data, size_t len)
+{
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_TX_DONE_CLR);
+
+    dmadesc_tx.size = (uint32_t)len & LLDESC_SPI_SIZE_MASK;
+    dmadesc_tx.length = (uint32_t)len & LLDESC_SPI_SIZE_MASK;
+    dmadesc_tx.buf = (uint8_t *)data;
+    dmadesc_tx.sosf = 0;
+    dmadesc_tx.eof = 1;
+    dmadesc_tx.owner = 1;
+    dmadesc_tx.next = NULL;
+
+    /* gdma_ll_txdma_reset */
+    SET_PERI_REG_MASK(GDMA_OUT_CONF0_CH0_REG, GDMA_OUT_RST_CH0);
+    CLEAR_PERI_REG_MASK(GDMA_OUT_CONF0_CH0_REG, GDMA_OUT_RST_CH0);
+    /* gdma_ll_load_tx_link */
+    WRITE_PERI_REG(GDMA_OUT_LINK_CH0_REG, (uint32_t)(uintptr_t)&dmadesc_tx & GDMA_INLINK_ADDR_CH0);
+    SET_PERI_REG_MASK(GDMA_OUT_LINK_CH0_REG, GDMA_OUTLINK_START_CH0);
+    /* spi_ll_txdma_start */
+    WRITE_PERI_REG(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_AFIFO_RST | SPI_BUF_AFIFO_RST | SPI_RX_AFIFO_RST);
+    SET_PERI_REG_MASK(SPI_DMA_CONF_REG(SPI_SLV_HOST), SPI_DMA_TX_ENA);
+
+    s_seq_tx ^= SPI_SLV_STA_TOGGLE;
+    uint32_t txsta = s_seq_tx | ((uint32_t)len << SPI_SLV_STA_LEN_SHIFT);
+    s_seq_tx &= ~SPI_SLV_STA_INIT;
+    WRITE_PERI_REG(SPI_SLV_REG_TXSTA, txsta);
+
+    /* Leave TXSTA set until the next frame; clearing it early races the host. */
+    uint64_t timeout_us = SPI_SLV_TX_TIMEOUT_US;
+    int ret = stub_target_wait_reg_bit_set(SPI_DMA_INT_RAW_REG(SPI_SLV_HOST), SPI_SLV_TX_DONE, &timeout_us);
+    if (ret != STUB_LIB_OK) {
+        return STUB_LIB_FAIL;
+    }
+    WRITE_PERI_REG(SPI_DMA_INT_CLR_REG(SPI_SLV_HOST), SPI_SLV_TX_DONE_CLR);
+
+    /* Enabling TX DMA rewrote SPI_DMA_CONF and disarmed RX DMA; re-arm it. */
+    if (s_rx_armed && s_rx_buf != NULL) {
+        spi_slv_rxdma_arm(s_rx_buf, s_rx_len);
+    }
+    return STUB_LIB_OK;
+}


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

  - Adds a SPI slave (download-boot) transport to esp-stub-lib, so a stub can talk to the host over the ESP SPI-slave download interface in addition to the existing UART, USB-OTG, USB-Serial/JTAG, and SDIO paths. The public API in `include/esp-stub-lib/spi.h` exposes the usual transport surface: `stub_lib_spi_is_active`, `_init`, `_take_rx_frame`, `_rearm`, and `_tx_frame`.
  - Structures the driver as a thin, target-agnostic wrapper (`src/spi.c`) that validates arguments (non-NULL, non-zero length, 4-byte DMA alignment, TX size limit) and delegates to weak per-target hooks. Each target drives the ROM's shared W0..W3 handshake registers (VER / RXSTA / TXSTA / CMD) and offloads the actual receive/transmit DMA to ROM SPI-slave helper routines. The design is fully polled (no interrupts): the command handshake is serviced by polling, receive completion is detected via the DMA-done flag, and a host reboot request is handled through the CMD register.
  - Implements the transport for esp32c2, esp32c3, esp32p4, esp32s2, and esp32s3. Because the ROM SPI-slave helpers are not part of the stock ROM API table, their addresses are PROVIDEd per target in `*.rom.extra.ld`. Targets without an implementation keep the common weak stubs, which simply report SPI as inactive.
  - Keeps the shared protocol constants in a private header that must stay in lockstep with the host-side driver 
  (`esp-serial-flasher/src/protocol_spi.c`), wires `src/spi.c` into the core, common, and per-target CMake builds, and adds a `test_spi` smoke path to the example stub. Most of the +6585 line count is generated SPI register headers (`spi_reg.h`) for c2/c3/p4.

### Speed measurement

<img width="837" height="267" alt="image" src="https://github.com/user-attachments/assets/329c522d-4013-49bc-8ebf-76a309ee7265" />


<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
