### PR TITLE
fix(esp32): detect HSPI flash from strapping pins

### DIFF
--- a/src/target/esp32/src/flash.c
+++ b/src/target/esp32/src/flash.c
@@ -14,11 +14,18 @@
 
 #include <private/rom_flash.h>
 
+#include <soc/reg_base.h>
 #include <soc/spi_mem_compat.h>
 
 extern esp_rom_spiflash_chip_t g_rom_flashchip;
 extern uint32_t esp_rom_efuse_get_flash_gpio_info(void);
 extern uint8_t g_rom_spiflash_dummy_len_plus[];
+
+#define GPIO_STRAP_REG             (DR_REG_GPIO_BASE + 0x38)
+
+/* Boot-mode strap bits [4:2]. 0x08 => GPIO1 (U0TXD) low, HSPI flash mode. */
+#define ESP32_STRAP_BOOT_MODE_MASK 0x1cU
+#define ESP32_STRAP_HSPI_FLASH     0x08U
 
 enum {
     SPI_USER_REG_ID = 0,
@@ -164,6 +171,15 @@ void stub_target_flash_init(void *state, stub_lib_flash_attach_policy_t attach_p
 
     if (attach_policy == STUB_LIB_FLASH_ATTACH_ALWAYS || stub_target_flash_needs_attach()) {
         uint32_t spiconfig = stub_target_flash_get_spiconfig_efuse();
+        /*
+         * Match ROM boot: if eFuse SPI pin config is default (0) and GPIO1
+         * (U0TXD) is strapped low with no other boot mode selected, flash is
+         * on HSPI pins.
+         */
+        uint32_t strapping = REG_READ(GPIO_STRAP_REG);
+        if (spiconfig == 0 && (strapping & ESP32_STRAP_BOOT_MODE_MASK) == ESP32_STRAP_HSPI_FLASH) {
+            spiconfig = 1; /* HSPI flash mode */
+        }
         stub_target_flash_attach(spiconfig, 0);
     } else {
         stub_target_spi_init();


### PR DESCRIPTION
## Summary
- When eFuse SPI pad config is default (`0`) and GPIO strap indicates HSPI flash boot (`(GPIO_STRAP & 0x1c) == 0x08`), attach with `spiconfig = 1`, matching ESP32 ROM boot behavior.
- Without this, some ESP32 modules with flash on HSPI pins hang during stub flash init (RDID busy-wait) and never send the OHAI greeting.

Related to https://github.com/espressif/esptool/issues/1179 (reported there).

## Test plan
- [ ] Build ESP32 stub with this lib change
- [ ] Reproduce on an ESP32 board/module that uses HSPI flash (strap / PICO-style) and confirm stub starts (`Stub flasher running`)
- [ ] Confirm a normal SPI-flash ESP32 still starts as before