### PR TITLE
fix(esp32): initialize CPU clock for all revisions

### DIFF
--- a/src/target/esp32/include/soc/dport_reg.h
+++ b/src/target/esp32/include/soc/dport_reg.h
@@ -10,6 +10,13 @@
 
 #include "reg_base.h"
 
+/* CPU clock configuration */
+#define DPORT_CPU_PER_CONF_REG      (DR_REG_DPORT_BASE + 0x03C)
+#define DPORT_CPUPERIOD_SEL         0x00000003
+#define DPORT_CPUPERIOD_SEL_M       ((DPORT_CPUPERIOD_SEL_V) << (DPORT_CPUPERIOD_SEL_S))
+#define DPORT_CPUPERIOD_SEL_V       0x3
+#define DPORT_CPUPERIOD_SEL_S       0
+
 /* PRO CPU cache control */
 #define DPORT_PRO_CACHE_CTRL_REG    (DR_REG_DPORT_BASE + 0x040)
 #define DPORT_PRO_CACHE_ENABLE      BIT(3)

--- a/src/target/esp32/include/soc/regi2c_bbpll.h
+++ b/src/target/esp32/include/soc/regi2c_bbpll.h
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define I2C_BBPLL                0x66
+#define I2C_BBPLL_HOSTID         4
+
+#define I2C_BBPLL_IR_CAL_DELAY   0
+#define I2C_BBPLL_IR_CAL_EXT_CAP 1
+#define I2C_BBPLL_OC_LREF        2
+#define I2C_BBPLL_OC_DIV_7_0     3
+#define I2C_BBPLL_OC_ENB_FCAL    4
+#define I2C_BBPLL_OC_DCUR        5
+#define I2C_BBPLL_BBADC_DSMP     9
+#define I2C_BBPLL_OC_ENB_VCON    10
+#define I2C_BBPLL_ENDIV5         11
+#define I2C_BBPLL_BBADC_CAL_7_0  12

--- a/src/target/esp32/include/soc/regi2c_defs.h
+++ b/src/target/esp32/include/soc/regi2c_defs.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <esp-stub-lib/bit_utils.h>
+
+/* Analog function control register */
+#define ANA_CONFIG_REG 0x6000E044
+/* Clear to enable BBPLL */
+#define I2C_BBPLL_M    (BIT(17))

--- a/src/target/esp32/include/soc/syscon_reg.h
+++ b/src/target/esp32/include/soc/syscon_reg.h
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include "reg_base.h"
+
+#define SYSCON_PLL_TICK_CONF_REG (DR_REG_SYSCON_BASE + 0x08)

--- a/src/target/esp32/src/clock.c
+++ b/src/target/esp32/src/clock.c
@@ -6,30 +6,112 @@
 
 #include <stdint.h>
 
-#include <soc_utils.h>
+#include <esp-stub-lib/rom_wrappers.h>
+#include <esp-stub-lib/soc_utils.h>
 
 #include <target/clock.h>
 
+#include <soc/dport_reg.h>
 #include <soc/reg_base.h>
+#include <soc/regi2c_bbpll.h>
+#include <soc/regi2c_defs.h>
 #include <soc/rtc_cntl_reg.h>
 #include <soc/soc.h>
-#include <soc/spi_reg.h>
+#include <soc/syscon_reg.h>
 
-#define CPU_FREQ_MHZ 160
+/*
+ * Some ESP32 parts are eFuse-rated for a maximum CPU frequency of 160 MHz.
+ * Keep the stub at 160 MHz so the same binary is safe for every ESP32.
+ */
+#define CPU_FREQ_MHZ                     160
+
+#define CLK_LL_BBPLL_IR_CAL_DELAY_VAL    0x18U
+#define CLK_LL_BBPLL_IR_CAL_EXT_CAP_VAL  0x20U
+#define CLK_LL_BBPLL_OC_ENB_FCAL_VAL     0x9AU
+#define CLK_LL_BBPLL_OC_ENB_VCON_VAL     0x00U
+#define CLK_LL_BBPLL_BBADC_CAL_7_0_VAL   0x00U
+
+#define CLK_LL_BBPLL_ENDIV5_VAL_320M     0x43U
+#define CLK_LL_BBPLL_BBADC_DSMP_VAL_320M 0x84U
 
 extern void esp_rom_set_cpu_ticks_per_us(uint32_t ticks_per_us);
 extern uint32_t esp_rom_get_cpu_ticks_per_us(void);
 extern uint32_t esp_rom_get_detected_xtal_freq(void);
+extern void rom_i2c_writeReg(uint32_t block, uint32_t host_id, uint32_t reg_add, uint32_t data);
 
 static uint32_t s_cpu_freq = 0;
 
+static void stub_esp32_bbpll_write(uint32_t reg, uint32_t value)
+{
+    rom_i2c_writeReg(I2C_BBPLL, I2C_BBPLL_HOSTID, reg, value);
+}
+
+static void stub_esp32_bbpll_configure_320m(uint32_t xtal_freq_mhz)
+{
+    /* Default to the most common 40 MHz XTAL configuration. */
+    uint32_t div_ref = 0U;
+    uint32_t div7_0 = 32U;
+    uint32_t div10_8 = 0U;
+    uint32_t lref = 0U;
+    uint32_t dcur = 6U;
+    uint32_t bw = 3U;
+
+    if (xtal_freq_mhz == 26U) {
+        div_ref = 12U;
+        div7_0 = 224U;
+        div10_8 = 4U;
+        lref = 1U;
+        dcur = 0U;
+        bw = 1U;
+    }
+
+    /* Power up the internal analog-I2C bus and BBPLL. */
+    REG_CLR_BIT(RTC_CNTL_OPTIONS0_REG,
+                RTC_CNTL_BIAS_I2C_FORCE_PD | RTC_CNTL_BB_I2C_FORCE_PD | RTC_CNTL_BBPLL_FORCE_PD |
+                    RTC_CNTL_BBPLL_I2C_FORCE_PD);
+    REG_CLR_BIT(ANA_CONFIG_REG, I2C_BBPLL_M);
+
+    /* Reset and configure BBPLL exactly as ESP-IDF does for a 320 MHz PLL. */
+    stub_esp32_bbpll_write(I2C_BBPLL_IR_CAL_DELAY, CLK_LL_BBPLL_IR_CAL_DELAY_VAL);
+    stub_esp32_bbpll_write(I2C_BBPLL_IR_CAL_EXT_CAP, CLK_LL_BBPLL_IR_CAL_EXT_CAP_VAL);
+    stub_esp32_bbpll_write(I2C_BBPLL_OC_ENB_FCAL, CLK_LL_BBPLL_OC_ENB_FCAL_VAL);
+    stub_esp32_bbpll_write(I2C_BBPLL_OC_ENB_VCON, CLK_LL_BBPLL_OC_ENB_VCON_VAL);
+    stub_esp32_bbpll_write(I2C_BBPLL_BBADC_CAL_7_0, CLK_LL_BBPLL_BBADC_CAL_7_0_VAL);
+    stub_esp32_bbpll_write(I2C_BBPLL_ENDIV5, CLK_LL_BBPLL_ENDIV5_VAL_320M);
+    stub_esp32_bbpll_write(I2C_BBPLL_BBADC_DSMP, CLK_LL_BBPLL_BBADC_DSMP_VAL_320M);
+    stub_esp32_bbpll_write(I2C_BBPLL_OC_LREF, (lref << 7) | (div10_8 << 4) | div_ref);
+    stub_esp32_bbpll_write(I2C_BBPLL_OC_DIV_7_0, div7_0);
+    stub_esp32_bbpll_write(I2C_BBPLL_OC_DCUR, (bw << 6) | dcur);
+
+    stub_lib_delay_us(80U);
+}
+
 void stub_target_clock_init(void)
 {
+    uint32_t xtal_freq_hz = esp_rom_get_detected_xtal_freq();
+    uint32_t xtal_freq_mhz = 40U;
+    if (xtal_freq_hz != 0U && xtal_freq_hz < 30500000U) {
+        xtal_freq_mhz = 26U;
+    }
+
+    /* Reconfigure the PLL while the CPU is still running from XTAL. */
+    REG_SET_FIELD(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_SOC_CLK_SEL, 0U);
+    esp_rom_set_cpu_ticks_per_us(xtal_freq_mhz);
     REG_SET_FIELD(RTC_CNTL_REG, RTC_CNTL_DIG_DBIAS_WAK, RTC_CNTL_DBIAS_1V25);
+    stub_esp32_bbpll_configure_320m(xtal_freq_mhz);
+
+    /* 320 MHz PLL / 2 gives the requested 160 MHz CPU clock. */
+    DPORT_REG_WRITE(DPORT_CPU_PER_CONF_REG, 1U);
+
+    /* REF_TICK stays at 1 MHz and APB is fixed at 80 MHz on the PLL path. */
+    WRITE_PERI_REG(SYSCON_PLL_TICK_CONF_REG, 80U - 1U);
+    uint32_t apb_store = (80U * MHZ) >> 12;
+    WRITE_PERI_REG(RTC_CNTL_STORE5_REG, apb_store | (apb_store << 16));
+
     s_cpu_freq = CPU_FREQ_MHZ * MHZ;
     esp_rom_set_cpu_ticks_per_us(CPU_FREQ_MHZ);
-    WRITE_PERI_REG(SPI_CLOCK_REG(0), 0);
     REG_SET_FIELD(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_SOC_CLK_SEL, 1U);
+    stub_lib_delay_us(30U);
 }
 
 uint32_t stub_target_get_cpu_freq(void)


### PR DESCRIPTION
## Summary
- fully configure and power the 320 MHz BBPLL before switching ESP32 stubs to 160 MHz
- program the CPU divider and synchronize APB/REF_TICK retained clock state
- preserve ROM flash timing instead of forcing SPI0 to 80 MHz
- add the required ESP-IDF-compatible ESP32 register definitions

Some ESP32-D0WD-V3 revisions, including revision v3.0, do not leave all required clock state initialized by ROM. Explicit initialization avoids depending on revision-specific reset state.

## Test plan
- [x] Run pre-commit hooks on all changed files
- [x] Build the ESP32 stub
- [x] Measure the resulting CPU clock at approximately 160 MHz on ESP32-D0WD-V3
- [x] Verify flash communication at 2,000,000 baud
- [x] Verify 1 MiB flash write/read and hash restoration