### PR TITLE
fix(esp32s31): enable 4-byte flash addressing capability

### DIFF
--- a/src/target/esp32s31/include/soc/soc_caps.h
+++ b/src/target/esp32s31/include/soc/soc_caps.h
@@ -9,3 +9,4 @@
 /*-------------------------- COMMON CAPS ---------------------------------------*/
 #define SOC_UART_HP_NUM             (4)    /*!< HP UART number */
 #define SOC_UART_HAS_SYNC_REG_UPDATE 1
+#define SOC_SPI_FLASH_4B_ADDR_SUPPORTED 1


### PR DESCRIPTION
## Summary
- advertise ESP32-S31 support for 4-byte flash addressing
- enable the generic large-flash path already backed by the S31 ROM command wrapper

## Test plan
- [x] Build the ESP32-S31 flasher stub