### PR TITLE
fix(esp32p4): skip ROM flash XPD when PMU latch is already set

### DIFF
--- a/src/target/esp32p4/src/flash.c
+++ b/src/target/esp32p4/src/flash.c
@@ -16,6 +16,7 @@
 #include <target/flash.h>
 
 #include <soc/efuse_reg.h>
+#include <soc/pmu_reg.h>
 #include <soc/spi_mem_compat.h>
 
 /* ECO version from ROM - used to route to correct ROM functions */
@@ -181,14 +182,14 @@ bool stub_target_flash_needs_attach(void)
 
 void stub_target_flash_attach(uint32_t ishspi, bool legacy)
 {
-    if (_rom_eco_version >= 7) {
-        if (REG_GET_FIELD(EFUSE_RD_REPEAT_DATA1_REG, EFUSE_DOWNLOAD_MODE_XPD_ON)) {
-            // If DOWNLOAD_MODE_XPD_ON eFuse is set, ROM powers on the flash chip
-            // inside esp_rom_spiflash_attach.
-            // This power-on sequence cannot run twice, let's skip it.
-            esp_rom_spiflash_boot_attach(ishspi, legacy, true);
-            return;
-        }
+    /* If DOWNLOAD_MODE_XPD_ON eFuse is set, ROM powers on the flash chip
+     * inside esp_rom_spiflash_attach.
+     * This power-on sequence cannot run twice, so skip it when PMU_DATE[1:0]
+     * already force the rail on. */
+    if (_rom_eco_version >= 7 && REG_GET_FIELD(EFUSE_RD_REPEAT_DATA1_REG, EFUSE_DOWNLOAD_MODE_XPD_ON) &&
+        (REG_READ(PMU_DATE_REG) & 0x3) == 0x3) {
+        esp_rom_spiflash_boot_attach(ishspi, legacy, true);
+        return;
     }
     esp_rom_spiflash_attach(ishspi, legacy);
 }


### PR DESCRIPTION
## Summary

On ESP32-P4 ECO7, flash is off by default. When the `DOWNLOAD_MODE_XPD_ON` eFuse is burned, ROM `spi_flash_attach()` is responsible for ramping the flash supply and latching that force-on state in `PMU_DATE[1:0]`.

That analog ramp is one-shot. If it runs again while the latch is still `0b11`, ROM waits forever for a new ramp-done edge (hang), or the rail can glitch.

The current attach path always skipped ROM XPD whenever the eFuse was set:

https://github.com/espressif/esp-stub-lib/blob/master/src/target/esp32p4/src/flash.c

That is correct only when the latch is already on. If the host skipped its own flash power-on (because the eFuse says ROM should do it) and the latch is still clear, nobody powers the flash for this session.

This change keeps the skip when `PMU_DATE[1:0] == 0b11` (`esp_rom_spiflash_boot_attach` for pin/SPI init only). Otherwise it lets ROM run `esp_rom_spiflash_attach()` once so flash actually comes up.

Tested on ECO6, ECO7 XPD OFF and ECO7 XPD ON,