### PR TITLE
feat(esp32s3): initialize CPU clock at 240 MHz

### DIFF
--- a/src/target/esp32s3/include/soc/efuse_reg.h
+++ b/src/target/esp32s3/include/soc/efuse_reg.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: 2021-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <soc/reg_base.h>
+
+#define EFUSE_RD_MAC_SPI_SYS_3_REG   (DR_REG_EFUSE_BASE + 0x50)
+#define EFUSE_RD_MAC_SPI_SYS_4_REG   (DR_REG_EFUSE_BASE + 0x54)
+#define EFUSE_RD_MAC_SPI_SYS_5_REG   (DR_REG_EFUSE_BASE + 0x58)
+#define EFUSE_RD_SYS_PART1_DATA4_REG (DR_REG_EFUSE_BASE + 0x6C)
+
+#define EFUSE_BLK_VERSION_MINOR_V    0x7U
+#define EFUSE_BLK_VERSION_MINOR_S    24
+
+#define EFUSE_BLK_VERSION_MAJOR_V    0x3U
+#define EFUSE_BLK_VERSION_MAJOR_S    0
+
+#define EFUSE_K_RTC_LDO_V            0x7FU
+#define EFUSE_K_RTC_LDO_S            13
+
+#define EFUSE_K_DIG_LDO_V            0x7FU
+#define EFUSE_K_DIG_LDO_S            20
+
+#define EFUSE_V_RTC_DBIAS20_V        0x1FU
+#define EFUSE_V_RTC_DBIAS20_S        27
+
+#define EFUSE_V_RTC_DBIAS20_1_V      0x7U
+#define EFUSE_V_RTC_DBIAS20_1_S      0
+
+#define EFUSE_V_DIG_DBIAS20_V        0xFFU
+#define EFUSE_V_DIG_DBIAS20_S        3
+
+#define EFUSE_DIG_DBIAS_HVT_V        0x1FU
+#define EFUSE_DIG_DBIAS_HVT_S        11

--- a/src/target/esp32s3/include/soc/regi2c_bbpll.h
+++ b/src/target/esp32s3/include/soc/regi2c_bbpll.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define I2C_BBPLL                      0x66
+#define I2C_BBPLL_HOSTID               1
+
+#define I2C_BBPLL_OC_REF_DIV           2
+#define I2C_BBPLL_OC_DCHGP_LSB         4
+#define I2C_BBPLL_OC_DIV_7_0           3
+#define I2C_BBPLL_MODE_HF              4
+
+#define I2C_BBPLL_OC_DR1               5
+#define I2C_BBPLL_OC_DR1_MSB           2
+#define I2C_BBPLL_OC_DR1_LSB           0
+
+#define I2C_BBPLL_OC_DR3               5
+#define I2C_BBPLL_OC_DR3_MSB           6
+#define I2C_BBPLL_OC_DR3_LSB           4
+
+#define I2C_BBPLL_OC_DCUR              6
+#define I2C_BBPLL_OC_DHREF_SEL_LSB     4
+#define I2C_BBPLL_OC_DLREF_SEL_LSB     6
+
+#define I2C_BBPLL_OC_VCO_DBIAS         9
+#define I2C_BBPLL_OC_VCO_DBIAS_MSB     1
+#define I2C_BBPLL_OC_VCO_DBIAS_LSB     0

--- a/src/target/esp32s3/include/soc/regi2c_defs.h
+++ b/src/target/esp32s3/include/soc/regi2c_defs.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#include <esp-stub-lib/bit_utils.h>
+
+#define I2C_MST_ANA_CONF0_REG           0x6000E040
+#define I2C_MST_BBPLL_STOP_FORCE_HIGH   BIT(2)
+#define I2C_MST_BBPLL_STOP_FORCE_LOW    BIT(3)
+#define I2C_MST_BBPLL_CAL_DONE          BIT(24)

--- a/src/target/esp32s3/include/soc/regi2c_dig_reg.h
+++ b/src/target/esp32s3/include/soc/regi2c_dig_reg.h
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: 2021-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
+#pragma once
+
+#define I2C_DIG_REG                  0x6D
+#define I2C_DIG_REG_HOSTID           1
+
+#define I2C_DIG_REG_EXT_RTC_DREG     4
+#define I2C_DIG_REG_EXT_RTC_DREG_MSB 4
+#define I2C_DIG_REG_EXT_RTC_DREG_LSB 0
+
+#define I2C_DIG_REG_EXT_DIG_DREG     6
+#define I2C_DIG_REG_EXT_DIG_DREG_MSB 4
+#define I2C_DIG_REG_EXT_DIG_DREG_LSB 0

--- a/src/target/esp32s3/src/clock.c
+++ b/src/target/esp32s3/src/clock.c
@@ -4,32 +4,246 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+#include <stdbool.h>
 #include <stdint.h>
 
-#include <soc_utils.h>
+#include <esp-stub-lib/rom_wrappers.h>
+#include <esp-stub-lib/soc_utils.h>
 
 #include <target/clock.h>
 
+#include <soc/efuse_reg.h>
+#include <soc/regi2c_bbpll.h>
+#include <soc/regi2c_defs.h>
+#include <soc/regi2c_dig_reg.h>
 #include <soc/rtc_cntl_reg.h>
 #include <soc/soc.h>
 #include <soc/system_reg.h>
 
-#define CPU_FREQ_MHZ 40
+#define CPU_FREQ_MHZ              240
+
+/* ESP-IDF's default bootloader DBIAS values, used when eFuse PVT data is unavailable. */
+#define DIG_DBIAS_240M_DEFAULT    28U
+#define RTC_DBIAS_240M_DEFAULT    28U
+
+/* ESP-IDF's nominal S3 LDO calibration values, scaled by 10000. */
+#define K_RTC_MID_MUL10000        198
+#define K_DIG_MID_MUL10000        211
+#define V_RTC_MID_MUL10000        10181
+#define V_DIG_MID_MUL10000        10841
+#define V_DIG_1V3_MUL10000        13000
+
+#define DBIAS_MIN                 15U
+#define DBIAS_MAX                 31U
+#define DBIAS_RTC_TOLERANCE       250
+#define DBIAS_CALIBRATION_DIVISOR 500
+#define DBIAS_SETTLE_US           40
+
+#define DEFAULT_LDO_SLAVE         0x7U
 
 extern uint32_t esp_rom_get_cpu_ticks_per_us(void);
 extern void esp_rom_set_cpu_ticks_per_us(uint32_t ticks_per_us);
 extern uint32_t esp_rom_get_xtal_freq(void);
 extern uint32_t esp_rom_get_apb_frequency(void);
+extern void esp_rom_regi2c_write(uint8_t block, uint8_t host_id, uint8_t reg_add, uint8_t data);
+extern void
+esp_rom_regi2c_write_mask(uint8_t block, uint8_t host_id, uint8_t reg_add, uint8_t msb, uint8_t lsb, uint8_t data);
 
 static uint32_t s_cpu_freq = 0;
 
+static uint32_t efuse_field(uint32_t reg, uint32_t mask, unsigned shift)
+{
+    return (REG_READ(reg) >> shift) & mask;
+}
+
+static int32_t sign_magnitude(uint32_t value, uint32_t sign_bit, uint32_t magnitude_mask)
+{
+    return (value & sign_bit) ? -(int32_t)(value & magnitude_mask) : (int32_t)value;
+}
+
+static bool has_pvt_dbias_calibration(void)
+{
+    uint32_t major = efuse_field(EFUSE_RD_SYS_PART1_DATA4_REG, EFUSE_BLK_VERSION_MAJOR_V, EFUSE_BLK_VERSION_MAJOR_S);
+    uint32_t minor = efuse_field(EFUSE_RD_MAC_SPI_SYS_3_REG, EFUSE_BLK_VERSION_MINOR_V, EFUSE_BLK_VERSION_MINOR_S);
+
+    /* Keep the same block-version test used by ESP-IDF's rtc_set_stored_dbias(). */
+    return (major <= 1U && minor == 1U) || major > 1U || (major == 1U && minor >= 2U);
+}
+
+static int32_t get_k_rtc_ldo(void)
+{
+    uint32_t raw = efuse_field(EFUSE_RD_MAC_SPI_SYS_4_REG, EFUSE_K_RTC_LDO_V, EFUSE_K_RTC_LDO_S);
+    return sign_magnitude(raw, BIT(6), 0x3FU);
+}
+
+static int32_t get_k_dig_ldo(void)
+{
+    uint32_t raw = efuse_field(EFUSE_RD_MAC_SPI_SYS_4_REG, EFUSE_K_DIG_LDO_V, EFUSE_K_DIG_LDO_S);
+    return sign_magnitude(raw, BIT(6), 0x3FU);
+}
+
+static int32_t get_v_rtc_dbias20(void)
+{
+    uint32_t low = efuse_field(EFUSE_RD_MAC_SPI_SYS_4_REG, EFUSE_V_RTC_DBIAS20_V, EFUSE_V_RTC_DBIAS20_S);
+    uint32_t high = efuse_field(EFUSE_RD_MAC_SPI_SYS_5_REG, EFUSE_V_RTC_DBIAS20_1_V, EFUSE_V_RTC_DBIAS20_1_S);
+    return sign_magnitude((high << 5) | low, BIT(7), 0x7FU);
+}
+
+static int32_t get_v_dig_dbias20(void)
+{
+    uint32_t raw = efuse_field(EFUSE_RD_MAC_SPI_SYS_5_REG, EFUSE_V_DIG_DBIAS20_V, EFUSE_V_DIG_DBIAS20_S);
+    return sign_magnitude(raw, BIT(7), 0x7FU);
+}
+
+static uint32_t get_dig_1v3_dbias(void)
+{
+    int32_t voltage_at_20 = V_DIG_MID_MUL10000 + get_v_dig_dbias20() * 10000 / DBIAS_CALIBRATION_DIVISOR;
+    int32_t slope = K_DIG_MID_MUL10000 + get_k_dig_ldo();
+
+    for (uint32_t dbias = DBIAS_MIN; dbias < DBIAS_MAX; ++dbias) {
+        int32_t voltage = voltage_at_20 + slope * ((int32_t)dbias - 20);
+        if (voltage >= V_DIG_1V3_MUL10000) {
+            return dbias;
+        }
+    }
+    return DBIAS_MAX;
+}
+
+static uint32_t get_rtc_dbias(uint32_t dig_dbias)
+{
+    int32_t rtc_voltage_at_20 = V_RTC_MID_MUL10000 + get_v_rtc_dbias20() * 10000 / DBIAS_CALIBRATION_DIVISOR;
+    int32_t dig_voltage_at_20 = V_DIG_MID_MUL10000 + get_v_dig_dbias20() * 10000 / DBIAS_CALIBRATION_DIVISOR;
+    int32_t rtc_slope = K_RTC_MID_MUL10000 + get_k_rtc_ldo();
+    int32_t dig_slope = K_DIG_MID_MUL10000 + get_k_dig_ldo();
+    int32_t dig_voltage = dig_voltage_at_20 + dig_slope * ((int32_t)dig_dbias - 20);
+
+    for (uint32_t dbias = DBIAS_MIN; dbias < DBIAS_MAX; ++dbias) {
+        int32_t rtc_voltage = rtc_voltage_at_20 + rtc_slope * ((int32_t)dbias - 20);
+        if (rtc_voltage >= dig_voltage - DBIAS_RTC_TOLERANCE) {
+            return dbias;
+        }
+    }
+    return DBIAS_MAX;
+}
+
+static void get_240m_dbias(uint32_t *rtc_dbias, uint32_t *dig_dbias)
+{
+    *rtc_dbias = RTC_DBIAS_240M_DEFAULT;
+    *dig_dbias = DIG_DBIAS_240M_DEFAULT;
+
+    if (!has_pvt_dbias_calibration()) {
+        return;
+    }
+
+    uint32_t hvt = efuse_field(EFUSE_RD_MAC_SPI_SYS_5_REG, EFUSE_DIG_DBIAS_HVT_V, EFUSE_DIG_DBIAS_HVT_S);
+    if (hvt == 0U) {
+        return;
+    }
+
+    *dig_dbias = MIN(get_dig_1v3_dbias(), hvt + 3U);
+    *rtc_dbias = get_rtc_dbias(*dig_dbias);
+}
+
+static void set_regulator_dbias(uint32_t rtc_dbias, uint32_t dig_dbias)
+{
+    esp_rom_regi2c_write_mask(I2C_DIG_REG,
+                              I2C_DIG_REG_HOSTID,
+                              I2C_DIG_REG_EXT_RTC_DREG,
+                              I2C_DIG_REG_EXT_RTC_DREG_MSB,
+                              I2C_DIG_REG_EXT_RTC_DREG_LSB,
+                              (uint8_t)rtc_dbias);
+    esp_rom_regi2c_write_mask(I2C_DIG_REG,
+                              I2C_DIG_REG_HOSTID,
+                              I2C_DIG_REG_EXT_DIG_DREG,
+                              I2C_DIG_REG_EXT_DIG_DREG_MSB,
+                              I2C_DIG_REG_EXT_DIG_DREG_LSB,
+                              (uint8_t)dig_dbias);
+}
+
+static void configure_bbpll(void)
+{
+    uint8_t div_ref = 0;
+    uint8_t div_7_0 = 8;
+    uint8_t dr1 = 0;
+    uint8_t dr3 = 0;
+    uint8_t dchgp = 5;
+    uint8_t dcur = 3;
+
+    if (esp_rom_get_xtal_freq() == 32U) {
+        div_ref = 1;
+        div_7_0 = 26;
+        dr1 = 1;
+        dr3 = 1;
+        dchgp = 4;
+        dcur = 0;
+    }
+
+    REG_CLR_BIT(RTC_CNTL_OPTIONS0_REG,
+                RTC_CNTL_BB_I2C_FORCE_PD | RTC_CNTL_BBPLL_FORCE_PD | RTC_CNTL_BBPLL_I2C_FORCE_PD);
+    REG_SET_FIELD(SYSTEM_CPU_PER_CONF_REG, SYSTEM_PLL_FREQ_SEL, 1U);
+
+    REG_CLR_BIT(I2C_MST_ANA_CONF0_REG, I2C_MST_BBPLL_STOP_FORCE_HIGH);
+    REG_SET_BIT(I2C_MST_ANA_CONF0_REG, I2C_MST_BBPLL_STOP_FORCE_LOW);
+
+    esp_rom_regi2c_write(I2C_BBPLL, I2C_BBPLL_HOSTID, I2C_BBPLL_MODE_HF, 0x6BU);
+    esp_rom_regi2c_write(I2C_BBPLL,
+                         I2C_BBPLL_HOSTID,
+                         I2C_BBPLL_OC_REF_DIV,
+                         (uint8_t)((dchgp << I2C_BBPLL_OC_DCHGP_LSB) | div_ref));
+    esp_rom_regi2c_write(I2C_BBPLL, I2C_BBPLL_HOSTID, I2C_BBPLL_OC_DIV_7_0, div_7_0);
+    esp_rom_regi2c_write_mask(I2C_BBPLL,
+                              I2C_BBPLL_HOSTID,
+                              I2C_BBPLL_OC_DR1,
+                              I2C_BBPLL_OC_DR1_MSB,
+                              I2C_BBPLL_OC_DR1_LSB,
+                              dr1);
+    esp_rom_regi2c_write_mask(I2C_BBPLL,
+                              I2C_BBPLL_HOSTID,
+                              I2C_BBPLL_OC_DR3,
+                              I2C_BBPLL_OC_DR3_MSB,
+                              I2C_BBPLL_OC_DR3_LSB,
+                              dr3);
+    esp_rom_regi2c_write(I2C_BBPLL,
+                         I2C_BBPLL_HOSTID,
+                         I2C_BBPLL_OC_DCUR,
+                         (uint8_t)((1U << I2C_BBPLL_OC_DLREF_SEL_LSB) | (3U << I2C_BBPLL_OC_DHREF_SEL_LSB) | dcur));
+    esp_rom_regi2c_write_mask(I2C_BBPLL,
+                              I2C_BBPLL_HOSTID,
+                              I2C_BBPLL_OC_VCO_DBIAS,
+                              I2C_BBPLL_OC_VCO_DBIAS_MSB,
+                              I2C_BBPLL_OC_VCO_DBIAS_LSB,
+                              3U);
+
+    while (REG_GET_BIT(I2C_MST_ANA_CONF0_REG, I2C_MST_BBPLL_CAL_DONE) == 0U) {
+    }
+    stub_lib_delay_us(10);
+    REG_CLR_BIT(I2C_MST_ANA_CONF0_REG, I2C_MST_BBPLL_STOP_FORCE_LOW);
+    REG_SET_BIT(I2C_MST_ANA_CONF0_REG, I2C_MST_BBPLL_STOP_FORCE_HIGH);
+}
+
 void stub_target_clock_init(void)
 {
-    // TODO: Increase DBIAS voltage before clock increase,
-    // not that simple for esp32s3 as ESP-IDF reads it from eFuse.
-    // Without it there were stability issues.
-    // https://github.com/espressif/esptool/issues/832, https://github.com/espressif/esptool/issues/808
+    uint32_t rtc_dbias;
+    uint32_t dig_dbias;
+
+    /* Raise the regulator voltage before enabling or switching to the BBPLL. */
+    get_240m_dbias(&rtc_dbias, &dig_dbias);
+    set_regulator_dbias(rtc_dbias, dig_dbias);
+    stub_lib_delay_us(DBIAS_SETTLE_US);
+
+    if (REG_GET_FIELD(SYSTEM_SYSCLK_CONF_REG, SYSTEM_SOC_CLK_SEL) != 1U) {
+        configure_bbpll();
+    }
+
+    /* At 240 MHz all six LDO slaves remain enabled (no slave power-down bits). */
+    REG_SET_FIELD(RTC_CNTL_DATE_REG, RTC_CNTL_SLAVE_PD, DEFAULT_LDO_SLAVE >> (CPU_FREQ_MHZ / 80U));
+
     s_cpu_freq = CPU_FREQ_MHZ * MHZ;
+
+    REG_SET_FIELD(SYSTEM_CPU_PER_CONF_REG, SYSTEM_PLL_FREQ_SEL, 1U);
+    REG_SET_FIELD(SYSTEM_CPU_PER_CONF_REG, SYSTEM_CPUPERIOD_SEL, 2U);
+    REG_SET_FIELD(SYSTEM_SYSCLK_CONF_REG, SYSTEM_PRE_DIV_CNT, 0U);
+    REG_SET_FIELD(SYSTEM_SYSCLK_CONF_REG, SYSTEM_SOC_CLK_SEL, 1U);
     esp_rom_set_cpu_ticks_per_us(CPU_FREQ_MHZ);
 }
 

--- a/src/target/esp32s3/src/uart.c
+++ b/src/target/esp32s3/src/uart.c
@@ -24,6 +24,7 @@ extern void esp_rom_uart_set_as_console(uint8_t uart_no);
 extern void esp_rom_uart_div_modify(uint8_t uart_no, uint32_t divisor);
 extern void esp_rom_isr_attach(int int_num, void *handler, void *arg);
 extern void esp_rom_isr_unmask(int int_num);
+extern uint32_t esp_rom_get_xtal_freq(void);
 
 void stub_target_rom_uart_attach(void *rxBuffer)
 {
@@ -39,7 +40,7 @@ void stub_target_uart_init(uint8_t uart_num)
 {
     extern bool g_uart_print;
     stub_target_rom_uart_attach(NULL);
-    stub_target_rom_uart_init(uart_num, stub_target_get_apb_freq());
+    stub_target_rom_uart_init(uart_num, esp_rom_get_xtal_freq());
     esp_rom_uart_set_as_console(uart_num);
     g_uart_print = true;
 }
@@ -48,7 +49,7 @@ void stub_target_uart_rominit_set_baudrate(uint8_t uart_num, uint32_t baudrate)
 {
     stub_lib_delay_us(5 * 1000);
 
-    uint32_t clk_div = (stub_target_get_apb_freq() << 4) / baudrate;
+    uint32_t clk_div = (esp_rom_get_xtal_freq() << 4) / baudrate;
     stub_target_uart_wait_idle(uart_num);
     esp_rom_uart_div_modify(uart_num, clk_div);
 


### PR DESCRIPTION
## Summary
- configure the ESP32-S3 BBPLL and switch the stub CPU clock from 40 MHz to 240 MHz
- derive stable digital and RTC DBIAS values from eFuse PVT calibration, with ESP-IDF-compatible defaults and LDO sequencing
- base the ROM UART baud divider on `esp_rom_get_xtal_freq()` instead of `stub_target_get_apb_freq()`

## Why the UART change is needed

The ESP32-S3 UART is clocked from the **XTAL, not from APB**. The ROM's `Uart_Init()` sets `UART_SCLK_SEL` to `3` (XTAL) and ignores its `clock` argument entirely, always deriving the divider from the fixed 40 MHz `UART_CLK_FREQ_ROM`:

```c
WRITE_PERI_REG(UART_CLK_CONF_REG(uart_no), UART_SCLK_EN_M | UART_RX_SCLK_EN_M | UART_TX_SCLK_EN_M);
// Select UART clock source to ext crystal
SET_PERI_REG_BITS(UART_CLK_CONF_REG(uart_no), UART_SCLK_SEL_V, 3, UART_SCLK_SEL_S);
uart_div_modify(uart_no, (UART_CLK_FREQ_ROM << 4) / param->baut_rate);
```

Until now `stub_target_get_apb_freq()` happened to return the XTAL frequency, because `stub_target_clock_init()` was a no-op for the S3 and `SOC_CLK_SEL` stayed at `0` — the baud divider was correct by accident. Once the stub switches to the PLL, that function returns 80 MHz and every baud rate would be off by 2x, so the UART code now reads the XTAL frequency directly.

## Hardware verification (ESP32-S3 rev v0.2, 40 MHz XTAL)

| Register | ROM only | Stub running |
|---|---|---|
| `UART_CLK_CONF_REG(0)` @ `0x60000078` | `0x03700000` | `0x03700000` |
| `SYSTEM_SYSCLK_CONF_REG` @ `0x600c0060` | `0x000a8000` | `0x000a8400` |

`SCLK_SEL` (bits [21:20]) stays `3` = XTAL with `SCLK_DIV_NUM` = 0, unchanged by the clock switch; `SOC_CLK_SEL` goes `0` -> `1`, confirming the PLL switch. `CLK_XTAL_FREQ` (bits [18:12]) reads 40, so `esp_rom_get_xtal_freq()` returns 40000000.

Baud rates exercised end-to-end against the 40 MHz reference:

| Baud | `UART_CLKDIV` | Error | Result |
|---|---|---|---|
| 921600 | `0x0060002b` (43 + 6/16) | +0.06% | pass |
| 1500000 | 26 + 10/16 | +0.16% | pass |
| 2000000 | 20 + 0/16 | 0.00% | pass |
| 3000000 | `0x0050000d` (13 + 5/16) | +0.16% | pass |

3 Mbaud is the limit of the CP2102N bridge used for testing, not of the 40 MHz reference clock.

## Test plan
- [x] Build the ESP32-S3 flasher stub with `ninja -C build-esp32s3`
- [x] Verify the CPU clock against SYSTIMER on ESP32-S3 revision v0.2
- [x] Confirm `UART_SCLK_SEL` = XTAL and the resulting `UART_CLKDIV` on hardware before and after the clock switch
- [x] Upload and run the stub over UART at 921600 baud, and up to 3 Mbaud
- [x] Write and verify 2 MiB uncompressed and 70%-size compressed images over UART, prefilling the flash region before each run