### PR TITLE
fix(flash): increase 4-byte erase and write timeouts

### DIFF
--- a/src/target/common/src/flash_4byte.c
+++ b/src/target/common/src/flash_4byte.c
@@ -20,10 +20,10 @@
 #include <private/flash_commands.h>
 #include <private/rom_flash.h>
 
-// Timeout values for flash operations, inspired by esptool
+// Timeout values for flash operations
 #define DEFAULT_TIMEOUT_US        10000U
-#define ERASE_PER_KB_TIMEOUT_US   30000U
-#define WRITE_PER_KB_TIMEOUT_US   30000U
+#define ERASE_PER_KB_TIMEOUT_US   100000U
+#define WRITE_PER_KB_TIMEOUT_US   40000U
 
 // AES-XTS encryption block sizes for encrypted flash write operations
 // The hardware AES-XTS engine can process multiple 128-bit blocks simultaneously when


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

4-byte-address flash erase/write was waiting only 30 ms per kB. That is too tight for larger, slower NOR parts and can fail with `STUB_LIB_ERR_TIMEOUT` even when the chip is still busy.
This raises the per-kB waits to match a **32 MB flash datasheet**: https://www.mxic.com.tw/Lists/Datasheet/Attachments/8707/MX25UM25645G,%201.8V,%20256Mb,%20v1.1.pdf
| Operation | Before | After |
|-----------|--------|-------|
| Erase     | 30 ms/kB | **100 ms/kB** |
| Write     | 30 ms/kB | **40 ms/kB** |

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

Relates https://github.com/espressif/esp-serial-flasher/issues/173

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

- [x] Build the flasher stub with the new timeouts
- [x] Build the Linux example in esp-serial-flasher
- [x] Flash a hello-world app with that example

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
